### PR TITLE
Fix public documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: docs
         env:
           GITHUB_PAGES: true
-          # NEXT_PUBLIC_BASE_PATH: '__root__'
+          NEXT_PUBLIC_BASE_PATH: '/mdfactory'
           NODE_ENV: production
         run: bun run build
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,13 +6,13 @@ description: High-throughput molecular dynamics simulation library
 MDFactory is an open source, end-to-end simulation manager for high-throughput molecular dynamics with robust data management. It handles the full pipeline from molecular structure generation through parametrization, system building, simulation, and analysis — with built-in database integration for tracking results at scale.
 
 <img
-  src="/diagrams/light/architecture/pipeline-overview.png"
+  src={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/diagrams/light/architecture/pipeline-overview.png`}
   alt="MDFactory pipeline: CSV/YAML input → Structure Generation (RDKit) → Parametrization (OpenFF, CGenFF) → System Build (Mixedbox, Bilayer, LNP) → Simulation (GROMACS, OpenMM) → Analysis, with Database sync to Simulation DB and Analysis DB"
   className="block dark:hidden"
   style={{ width: '100%', maxWidth: '900px', margin: '1.5rem auto' }}
 />
 <img
-  src="/diagrams/dark/architecture/pipeline-overview.png"
+  src={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/diagrams/dark/architecture/pipeline-overview.png`}
   alt="MDFactory pipeline: CSV/YAML input → Structure Generation (RDKit) → Parametrization (OpenFF, CGenFF) → System Build (Mixedbox, Bilayer, LNP) → Simulation (GROMACS, OpenMM) → Analysis, with Database sync to Simulation DB and Analysis DB"
   className="hidden dark:block"
   style={{ width: '100%', maxWidth: '900px', margin: '1.5rem auto' }}


### PR DESCRIPTION
## Summary

Fix GitHub Pages docs site at `emdgroup.github.io/mdfactory/`.

- Set `NEXT_PUBLIC_BASE_PATH: '/mdfactory'` in the docs CI workflow so assets, links, and redirects use the correct subdirectory path
- Prefix diagram image `src` attributes in the docs landing page with the base path so they resolve correctly on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)