### PR TITLE
docs: add HPC customization notice where simulate.config is referenced

### DIFF
--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -99,6 +99,10 @@ nextflow run workflows/simulate.nf \
   --config_yaml output_systems/sample_input.yaml
 ```
 
+<Callout type="warn" title="Cluster-specific configuration">
+The shipped `simulate.config` contains SLURM settings tuned for a specific cluster. Edit this file to match your HPC environment before running. See [Running on HPC Clusters](/docs/user-guide/running-on-hpc) for details.
+</Callout>
+
 </Step>
 </Steps>
 

--- a/docs/content/docs/user-guide/tutorial-mixedbox-campaign.mdx
+++ b/docs/content/docs/user-guide/tutorial-mixedbox-campaign.mdx
@@ -146,6 +146,10 @@ nextflow run workflows/simulate.nf \
   --config_yaml tutorial_campaign/mixedbox_chain_length_series_20.yaml
 ```
 
+<Callout type="warn" title="Cluster-specific configuration">
+The shipped `simulate.config` contains SLURM settings tuned for a specific cluster. Edit this file to match your HPC environment before running. See [Running on HPC Clusters](/docs/user-guide/running-on-hpc) for details.
+</Callout>
+
 This executes the fixed sequence implemented in `workflows/simulate.nf`:
 
 1. minimization

--- a/docs/content/docs/user-guide/workflows.mdx
+++ b/docs/content/docs/user-guide/workflows.mdx
@@ -50,6 +50,10 @@ nextflow run workflows/simulate.nf \
   --config_yaml results/systems.yaml
 ```
 
+<Callout type="warn" title="Cluster-specific configuration">
+The shipped `simulate.config` contains SLURM settings (queue name, module loads, GPU/CPU/memory requests) tuned for a specific cluster. Edit this file to match your HPC environment before running. See [Running on HPC Clusters](/docs/user-guide/running-on-hpc) for guidance.
+</Callout>
+
 `simulate.nf` executes this fixed sequence for each hash listed in the summary YAML:
 
 1. Minimization using `em.mdp`


### PR DESCRIPTION
## Summary

- Added `<Callout type="warn">` to three doc pages that reference `simulate.config` without warning that its SLURM settings are cluster-specific
- Each callout directs users to edit the config and links to the existing [Running on HPC Clusters](/docs/user-guide/running-on-hpc) guide

**Pages updated:**
- `quick-start.mdx`
- `user-guide/workflows.mdx`
- `user-guide/tutorial-mixedbox-campaign.mdx`

Closes #4

## Test plan
- [ ] Run `cd docs && npm run dev` and verify the callout renders on all three pages
- [ ] Confirm the "Running on HPC Clusters" link works from each callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)