### PR TITLE
fix: comment bilayer md.mdp nsteps

### DIFF
--- a/mdfactory/run_schedules/gromacs/bilayer/md.mdp
+++ b/mdfactory/run_schedules/gromacs/bilayer/md.mdp
@@ -2,7 +2,7 @@
 title                   = MD production run membrane system
 ; Run parameters
 integrator              = md                ; leap-frog integrator
-nsteps                  = 500000000          ; 2 * 50000000 = 100 ns
+nsteps                  = 500000000          ; 2 * 500000000 = 1000 ns
 dt                      = 0.002             ; 2 fs
 ; Output control
 nstxout                 = 0                 ; suppress bulky .trr file by setting to 0


### PR DESCRIPTION
eyond the typo fix, I'm troubleshooting why the bilayer gap isn't closing even after 100 ns of NPT. I noticed steps_equil=0 in the utils and suspect this might be part of the problem. Is this behavior expected for this setup?

```
def compress_equilibrate_bilayer(

    u,

    pdb,

    top,

    pressure=1000.0,

    steps_compression=200_000,

    # steps_equil=500_000,

    # steps_equil=200_000,

    steps_equil=0,

):

    """Compress and equilibrate a lipid bilayer in two phases.



    Phase 1 applies z-coordinate restraints with a membrane barostat at

    elevated pressure (XY-isotropic, Z-fixed) until volume converges.

    Phase 2 removes the restraints and continues equilibration at 1 bar.
    
    ```
    
    
    
     
