### PR TITLE
feat: add slurm cluster autodiscovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 jobs:

--- a/config_templates/config.ini
+++ b/config_templates/config.ini
@@ -40,3 +40,8 @@ ANALYSIS_NAME = analysis
 RUN_DB_PATH = /Group Functions/mdfactory/runs
 ANALYSIS_DB_PATH = /Group Functions/mdfactory/analysis
 ARTIFACT_DB_PATH = /Group Functions/mdfactory/artifacts
+
+[slurm]
+ACCOUNT =
+PARTITION =
+QOS =

--- a/config_templates/config.ini
+++ b/config_templates/config.ini
@@ -42,6 +42,8 @@ ANALYSIS_DB_PATH = /Group Functions/mdfactory/analysis
 ARTIFACT_DB_PATH = /Group Functions/mdfactory/artifacts
 
 [slurm]
+; Optional manual overrides. When empty, values are autodiscovered via sinfo/sacctmgr.
 ACCOUNT =
-PARTITION =
-QOS =
+PARTITION_CPU =
+PARTITION_GPU =
+DEFAULT_QOS =

--- a/mdfactory/analysis/submit.py
+++ b/mdfactory/analysis/submit.py
@@ -34,6 +34,8 @@ class SlurmConfig:
     def from_cluster(
         cls,
         *,
+        account: str | None = None,
+        partition: str | None = None,
         needs_gpu: bool = False,
         time: str = "2h",
         cpus_per_task: int = 4,
@@ -42,15 +44,21 @@ class SlurmConfig:
         constraint: str | None = None,
         job_name_prefix: str = "mdfactory-analysis",
     ) -> "SlurmConfig":
-        """Create SlurmConfig from autodiscovered cluster info.
+        """Create SlurmConfig from config file or autodiscovered cluster info.
+
+        Precedence: explicit parameters > config file > autodiscovery
 
         Uses lazy import of ``mdfactory.performance.cluster`` to avoid
         hard dependency on SLURM commands at import time.
 
         Parameters
         ----------
+        account : str or None
+            SLURM account. If None, uses config or autodiscovery.
+        partition : str or None
+            SLURM partition. If None, uses config or autodiscovers based on needs_gpu.
         needs_gpu : bool
-            If True, select a GPU-enabled partition.
+            If True and partition not specified, autodiscover GPU partition.
         time : str
             Job time limit (default: "2h").
         cpus_per_task : int
@@ -58,7 +66,7 @@ class SlurmConfig:
         mem_gb : int
             Memory per task in GB (default: 8).
         qos : str or None
-            Quality of service. If None, uses first available from cluster.
+            Quality of service. If None, uses config or SLURM default.
         constraint : str or None
             SLURM constraint string.
         job_name_prefix : str
@@ -67,52 +75,69 @@ class SlurmConfig:
         Returns
         -------
         SlurmConfig
-            Configured instance with autodiscovered account and partition.
+            Configured instance.
 
         Raises
         ------
         RuntimeError
-            If SLURM is not available or no suitable partition found.
+            If SLURM is not available or required values cannot be determined.
         """
         from mdfactory.performance.cluster import discover_cluster, select_partition
+        from mdfactory.settings import settings
 
+        # Try autodiscovery (needed for fallback)
         cluster = discover_cluster()
-        if cluster is None:
-            raise RuntimeError(
-                "SLURM autodiscovery failed: not running on a SLURM cluster "
-                "or SLURM commands (sinfo) are not available."
-            )
 
-        # Select appropriate partition
-        partition = select_partition(
-            cluster,
-            needs_gpu=needs_gpu,
-            min_cpus=cpus_per_task,
-            min_mem_gb=mem_gb,
-        )
-        if partition is None:
-            raise RuntimeError(
-                f"No suitable partition found for requirements: "
-                f"needs_gpu={needs_gpu}, min_cpus={cpus_per_task}, min_mem_gb={mem_gb}"
-            )
+        # Determine account: explicit > config > autodiscovery
+        resolved_account = account
+        if resolved_account is None:
+            resolved_account = settings.slurm_account
+        if resolved_account is None:
+            if cluster is None:
+                raise RuntimeError(
+                    "SLURM autodiscovery failed and no account configured. "
+                    "Set [slurm] account in config.ini or pass account= explicitly."
+                )
+            resolved_account = cluster.default_account
+            if resolved_account is None:
+                raise RuntimeError(
+                    "No SLURM account available. "
+                    "Set [slurm] account in config.ini or pass account= explicitly."
+                )
 
-        # Get account (required)
-        account = cluster.default_account
-        if account is None:
-            raise RuntimeError(
-                "SLURM autodiscovery failed: no default account found. "
-                "Please specify --account explicitly."
-            )
+        # Determine partition: explicit > config > autodiscovery
+        resolved_partition = partition
+        if resolved_partition is None:
+            resolved_partition = settings.slurm_partition
 
-        # Use first QOS if available and not explicitly set
+        # Fall back to autodiscovery if no config value
+        if resolved_partition is None:
+            if cluster is None:
+                raise RuntimeError(
+                    "SLURM autodiscovery failed and no partition configured. "
+                    "Set [slurm] partition in config.ini or pass partition= explicitly."
+                )
+            selected = select_partition(
+                cluster,
+                needs_gpu=needs_gpu,
+                min_cpus=cpus_per_task,
+                min_mem_gb=mem_gb,
+            )
+            if selected is None:
+                raise RuntimeError(
+                    f"No suitable partition found for requirements: "
+                    f"needs_gpu={needs_gpu}, cpus={cpus_per_task}, mem={mem_gb}GB"
+                )
+            resolved_partition = selected.name
+
+        # Determine QOS: explicit > config > skip (let SLURM use default)
         resolved_qos = qos
-        if resolved_qos is None and cluster.qos_policies:
-            # Don't auto-select QOS; let SLURM use partition default
-            pass
+        if resolved_qos is None:
+            resolved_qos = settings.slurm_qos
 
         return cls(
-            account=account,
-            partition=partition.name,
+            account=resolved_account,
+            partition=resolved_partition,
             time=time,
             cpus_per_task=cpus_per_task,
             mem_gb=mem_gb,

--- a/mdfactory/analysis/submit.py
+++ b/mdfactory/analysis/submit.py
@@ -30,6 +30,97 @@ class SlurmConfig:
     constraint: str | None = None
     job_name_prefix: str = "mdfactory-analysis"
 
+    @classmethod
+    def from_cluster(
+        cls,
+        *,
+        needs_gpu: bool = False,
+        time: str = "2h",
+        cpus_per_task: int = 4,
+        mem_gb: int = 8,
+        qos: str | None = None,
+        constraint: str | None = None,
+        job_name_prefix: str = "mdfactory-analysis",
+    ) -> "SlurmConfig":
+        """Create SlurmConfig from autodiscovered cluster info.
+
+        Uses lazy import of ``mdfactory.performance.cluster`` to avoid
+        hard dependency on SLURM commands at import time.
+
+        Parameters
+        ----------
+        needs_gpu : bool
+            If True, select a GPU-enabled partition.
+        time : str
+            Job time limit (default: "2h").
+        cpus_per_task : int
+            CPUs per task (default: 4).
+        mem_gb : int
+            Memory per task in GB (default: 8).
+        qos : str or None
+            Quality of service. If None, uses first available from cluster.
+        constraint : str or None
+            SLURM constraint string.
+        job_name_prefix : str
+            Prefix for SLURM job names.
+
+        Returns
+        -------
+        SlurmConfig
+            Configured instance with autodiscovered account and partition.
+
+        Raises
+        ------
+        RuntimeError
+            If SLURM is not available or no suitable partition found.
+        """
+        from mdfactory.performance.cluster import discover_cluster, select_partition
+
+        cluster = discover_cluster()
+        if cluster is None:
+            raise RuntimeError(
+                "SLURM autodiscovery failed: not running on a SLURM cluster "
+                "or SLURM commands (sinfo) are not available."
+            )
+
+        # Select appropriate partition
+        partition = select_partition(
+            cluster,
+            needs_gpu=needs_gpu,
+            min_cpus=cpus_per_task,
+            min_mem_gb=mem_gb,
+        )
+        if partition is None:
+            raise RuntimeError(
+                f"No suitable partition found for requirements: "
+                f"needs_gpu={needs_gpu}, min_cpus={cpus_per_task}, min_mem_gb={mem_gb}"
+            )
+
+        # Get account (required)
+        account = cluster.default_account
+        if account is None:
+            raise RuntimeError(
+                "SLURM autodiscovery failed: no default account found. "
+                "Please specify --account explicitly."
+            )
+
+        # Use first QOS if available and not explicitly set
+        resolved_qos = qos
+        if resolved_qos is None and cluster.qos_policies:
+            # Don't auto-select QOS; let SLURM use partition default
+            pass
+
+        return cls(
+            account=account,
+            partition=partition.name,
+            time=time,
+            cpus_per_task=cpus_per_task,
+            mem_gb=mem_gb,
+            qos=resolved_qos,
+            constraint=constraint,
+            job_name_prefix=job_name_prefix,
+        )
+
 
 def normalize_slurm_time(value: str) -> str:
     """Normalize SLURM time strings to accepted formats."""

--- a/mdfactory/analysis/submit.py
+++ b/mdfactory/analysis/submit.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 import shutil
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable
@@ -16,158 +15,15 @@ import pandas as pd
 from mdfactory.analysis.artifacts import ARTIFACT_REGISTRY
 from mdfactory.analysis.simulation import ANALYSIS_REGISTRY, Simulation
 
-
-@dataclass(frozen=True)
-class SlurmConfig:
-    """Configuration for submitit/SLURM execution."""
-
-    account: str
-    partition: str = "cpu"
-    time: str = "2h"
-    cpus_per_task: int = 4
-    mem_gb: int = 8
-    qos: str | None = None
-    constraint: str | None = None
-    job_name_prefix: str = "mdfactory-analysis"
-
-    @classmethod
-    def from_cluster(
-        cls,
-        *,
-        account: str | None = None,
-        partition: str | None = None,
-        needs_gpu: bool = False,
-        time: str = "2h",
-        cpus_per_task: int = 4,
-        mem_gb: int = 8,
-        qos: str | None = None,
-        constraint: str | None = None,
-        job_name_prefix: str = "mdfactory-analysis",
-    ) -> "SlurmConfig":
-        """Create SlurmConfig from config file or autodiscovered cluster info.
-
-        Precedence: explicit parameters > config file > autodiscovery
-
-        Uses lazy import of ``mdfactory.performance.cluster`` to avoid
-        hard dependency on SLURM commands at import time.
-
-        Parameters
-        ----------
-        account : str or None
-            SLURM account. If None, uses config or autodiscovery.
-        partition : str or None
-            SLURM partition. If None, uses config or autodiscovers based on needs_gpu.
-        needs_gpu : bool
-            If True and partition not specified, autodiscover GPU partition.
-        time : str
-            Job time limit (default: "2h").
-        cpus_per_task : int
-            CPUs per task (default: 4).
-        mem_gb : int
-            Memory per task in GB (default: 8).
-        qos : str or None
-            Quality of service. If None, uses config or SLURM default.
-        constraint : str or None
-            SLURM constraint string.
-        job_name_prefix : str
-            Prefix for SLURM job names.
-
-        Returns
-        -------
-        SlurmConfig
-            Configured instance.
-
-        Raises
-        ------
-        RuntimeError
-            If SLURM is not available or required values cannot be determined.
-        """
-        from mdfactory.performance.cluster import discover_cluster, select_partition
-        from mdfactory.settings import settings
-
-        # Try autodiscovery (needed for fallback)
-        cluster = discover_cluster()
-
-        # Determine account: explicit > config > autodiscovery
-        resolved_account = account
-        if resolved_account is None:
-            resolved_account = settings.slurm_account
-        if resolved_account is None:
-            if cluster is None:
-                raise RuntimeError(
-                    "SLURM autodiscovery failed and no account configured. "
-                    "Set [slurm] account in config.ini or pass account= explicitly."
-                )
-            resolved_account = cluster.default_account
-            if resolved_account is None:
-                raise RuntimeError(
-                    "No SLURM account available. "
-                    "Set [slurm] account in config.ini or pass account= explicitly."
-                )
-
-        # Determine partition: explicit > config > autodiscovery
-        resolved_partition = partition
-        if resolved_partition is None:
-            resolved_partition = settings.slurm_partition
-
-        # Fall back to autodiscovery if no config value
-        if resolved_partition is None:
-            if cluster is None:
-                raise RuntimeError(
-                    "SLURM autodiscovery failed and no partition configured. "
-                    "Set [slurm] partition in config.ini or pass partition= explicitly."
-                )
-            selected = select_partition(
-                cluster,
-                needs_gpu=needs_gpu,
-                min_cpus=cpus_per_task,
-                min_mem_gb=mem_gb,
-            )
-            if selected is None:
-                raise RuntimeError(
-                    f"No suitable partition found for requirements: "
-                    f"needs_gpu={needs_gpu}, cpus={cpus_per_task}, mem={mem_gb}GB"
-                )
-            resolved_partition = selected.name
-
-        # Determine QOS: explicit > config > skip (let SLURM use default)
-        resolved_qos = qos
-        if resolved_qos is None:
-            resolved_qos = settings.slurm_qos
-
-        return cls(
-            account=resolved_account,
-            partition=resolved_partition,
-            time=time,
-            cpus_per_task=cpus_per_task,
-            mem_gb=mem_gb,
-            qos=resolved_qos,
-            constraint=constraint,
-            job_name_prefix=job_name_prefix,
-        )
-
-
-def normalize_slurm_time(value: str) -> str:
-    """Normalize SLURM time strings to accepted formats."""
-    raw = value.strip()
-    if ":" in raw:
-        return raw
-    lowered = raw.lower()
-    if lowered.endswith("d"):
-        days = int(lowered[:-1])
-        return f"{days}-00:00:00"
-    if lowered.endswith("h"):
-        hours = int(lowered[:-1])
-        return f"{hours:02d}:00:00"
-    if lowered.endswith("m"):
-        minutes = int(lowered[:-1])
-        hours, minutes = divmod(minutes, 60)
-        return f"{hours:02d}:{minutes:02d}:00"
-    if lowered.isdigit():
-        minutes = int(lowered)
-        hours, minutes = divmod(minutes, 60)
-        return f"{hours:02d}:{minutes:02d}:00"
-    return raw
+# SlurmConfig and normalize_slurm_time live in the performance package so that
+# every SLURM-facing backend (submitit, Parsl, Nextflow) can share them.
+# Re-exported here for backward compatibility:
+#   from mdfactory.analysis.submit import SlurmConfig        # still works
+#   from mdfactory.analysis.submit import normalize_slurm_time  # still works
+from mdfactory.performance.slurm_config import (  # noqa: F401  (re-export)
+    SlurmConfig,
+    normalize_slurm_time,
+)
 
 
 def resolve_simulation_paths(

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -1187,8 +1187,6 @@ def analysis_run(
     if source is None:
         raise ValueError("Provide SOURCE as a simulation directory or build summary YAML.")
 
-    if slurm and account is None:
-        raise ValueError("--account is required when using --slurm.")
     if analysis_workers is not None and analysis_workers < 1:
         raise ValueError("--analysis-workers must be >= 1.")
 
@@ -1233,16 +1231,49 @@ def analysis_run(
         print(result_df)
         return
 
-    slurm_cfg = SlurmConfig(
-        account=account or "",
-        partition=partition,
-        time=time,
-        cpus_per_task=cpus,
-        mem_gb=mem_gb,
-        qos=qos,
-        constraint=constraint,
-        job_name_prefix=job_name_prefix,
-    )
+    # Use autodiscovery if account not provided
+    if account is None:
+        try:
+            slurm_cfg = SlurmConfig.from_cluster(
+                needs_gpu=False,
+                time=time,
+                cpus_per_task=cpus,
+                mem_gb=mem_gb,
+                qos=qos,
+                constraint=constraint,
+                job_name_prefix=job_name_prefix,
+            )
+            # Override partition if user specified one explicitly
+            if partition != "cpu":  # user changed from default
+                slurm_cfg = SlurmConfig(
+                    account=slurm_cfg.account,
+                    partition=partition,
+                    time=time,
+                    cpus_per_task=cpus,
+                    mem_gb=mem_gb,
+                    qos=qos,
+                    constraint=constraint,
+                    job_name_prefix=job_name_prefix,
+                )
+            logger.info(
+                f"Using autodiscovered SLURM config: account={slurm_cfg.account}, "
+                f"partition={slurm_cfg.partition}"
+            )
+        except RuntimeError as e:
+            raise ValueError(
+                f"SLURM autodiscovery failed: {e}\nPlease specify --account explicitly."
+            ) from e
+    else:
+        slurm_cfg = SlurmConfig(
+            account=account,
+            partition=partition,
+            time=time,
+            cpus_per_task=cpus,
+            mem_gb=mem_gb,
+            qos=qos,
+            constraint=constraint,
+            job_name_prefix=job_name_prefix,
+        )
     if log_dir is None:
         log_dir = determine_log_dir(sim_paths)
     result_df = submit_analyses_slurm(
@@ -1520,19 +1551,50 @@ def analysis_artifacts_run(
         print(summary)
         return
 
+    # Use autodiscovery if account not provided
     if account is None:
-        raise ValueError("--account is required when using --slurm.")
+        try:
+            slurm_cfg = SlurmConfig.from_cluster(
+                needs_gpu=False,
+                time=time,
+                cpus_per_task=cpus,
+                mem_gb=mem_gb,
+                qos=qos,
+                constraint=constraint,
+                job_name_prefix=job_name_prefix,
+            )
+            # Override partition if user specified one explicitly
+            if partition != "cpu":  # user changed from default
+                slurm_cfg = SlurmConfig(
+                    account=slurm_cfg.account,
+                    partition=partition,
+                    time=time,
+                    cpus_per_task=cpus,
+                    mem_gb=mem_gb,
+                    qos=qos,
+                    constraint=constraint,
+                    job_name_prefix=job_name_prefix,
+                )
+            logger.info(
+                f"Using autodiscovered SLURM config: account={slurm_cfg.account}, "
+                f"partition={slurm_cfg.partition}"
+            )
+        except RuntimeError as e:
+            raise ValueError(
+                f"SLURM autodiscovery failed: {e}\nPlease specify --account explicitly."
+            ) from e
+    else:
+        slurm_cfg = SlurmConfig(
+            account=account,
+            partition=partition,
+            time=time,
+            cpus_per_task=cpus,
+            mem_gb=mem_gb,
+            qos=qos,
+            constraint=constraint,
+            job_name_prefix=job_name_prefix,
+        )
 
-    slurm_cfg = SlurmConfig(
-        account=account,
-        partition=partition,
-        time=time,
-        cpus_per_task=cpus,
-        mem_gb=mem_gb,
-        qos=qos,
-        constraint=constraint,
-        job_name_prefix=job_name_prefix,
-    )
     if log_dir is None:
         log_dir = determine_log_dir(sim_paths)
     result_df = submit_artifacts_slurm(
@@ -1748,6 +1810,112 @@ def config_edit():
 
     editor = os.environ.get("EDITOR", "vi")
     subprocess.run([editor, str(config_path)], check=False)
+
+
+@config_app.command(name="cluster")
+def config_cluster(
+    json_output: Annotated[bool, Parameter("--json", help="Output in JSON format.")] = False,
+):
+    """Show discovered SLURM cluster information.
+
+    Queries the local SLURM scheduler and displays available partitions,
+    accounts, and QOS policies. Useful for verifying autodiscovery works
+    and understanding cluster resources before submitting jobs.
+
+    On non-SLURM machines, prints a helpful message instead of failing.
+    """
+    import json as json_module
+
+    from mdfactory.performance.cluster import discover_cluster
+
+    cluster = discover_cluster()
+
+    if cluster is None:
+        if json_output:
+            print(json_module.dumps({"error": "SLURM not available", "cluster": None}))
+        else:
+            print("SLURM cluster not detected.")
+            print()
+            print("This machine does not appear to be a SLURM cluster node,")
+            print("or SLURM commands (sinfo, sacctmgr) are not in PATH.")
+            print()
+            print("To use SLURM submission, run this command on a cluster login node.")
+        return
+
+    if json_output:
+        # Build JSON-serializable structure
+        data = {
+            "default_account": cluster.default_account,
+            "accounts": cluster.accounts,
+            "qos_policies": cluster.qos_policies,
+            "partitions": [
+                {
+                    "name": p.name,
+                    "state": p.state,
+                    "is_default": p.is_default,
+                    "max_time": p.max_time,
+                    "default_time": p.default_time,
+                    "total_nodes": p.total_nodes,
+                    "node_types": [
+                        {
+                            "cpus": nt.cpus,
+                            "memory_mb": nt.memory_mb,
+                            "gpu_specs": [
+                                {"count": count, "type": gtype} for count, gtype in nt.gpu_specs
+                            ],
+                            "features": list(nt.features),
+                            "count": nt.count,
+                        }
+                        for nt in p.node_types
+                    ],
+                }
+                for p in cluster.partitions
+            ],
+        }
+        print(json_module.dumps(data, indent=2))
+        return
+
+    # Human-readable output
+    print("SLURM Cluster Information")
+    print("=" * 50)
+    print()
+
+    # Account info
+    print(f"Default Account: {cluster.default_account or '(none)'}")
+    if cluster.accounts:
+        print(f"Available Accounts: {', '.join(cluster.accounts)}")
+    print()
+
+    # QOS info
+    if cluster.qos_policies:
+        print(f"QOS Policies: {', '.join(cluster.qos_policies)}")
+        print()
+
+    # Partition info
+    print("Partitions:")
+    print("-" * 50)
+    for partition in cluster.partitions:
+        default_marker = " (default)" if partition.is_default else ""
+        state_marker = f" [{partition.state}]" if partition.state != "up" else ""
+        print(f"\n  {partition.name}{default_marker}{state_marker}")
+        print(f"    Nodes: {partition.total_nodes}")
+        print(f"    Max Time: {partition.max_time}")
+        if partition.default_time != partition.max_time:
+            print(f"    Default Time: {partition.default_time}")
+
+        # Summarize node types
+        for nt in partition.node_types:
+            gpu_info = ""
+            if nt.gpu_specs:
+                # Format multiple GPU types like "7x b200, 7x 1g.23gb"
+                gpu_parts = [f"{count}x {gtype}" for count, gtype in nt.gpu_specs]
+                gpu_info = f", {', '.join(gpu_parts)}"
+            mem_gb = nt.memory_mb // 1024
+            features_str = ""
+            if nt.features:
+                features_str = f" [{', '.join(nt.features)}]"
+            count_str = f" ({nt.count} node{'s' if nt.count != 1 else ''})"
+            print(f"      - {nt.cpus} CPUs, {mem_gb} GB{gpu_info}{features_str}{count_str}")
 
 
 def main():

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -1890,7 +1890,7 @@ def config_cluster(
             gpu_info = ""
             if nt.gpu_specs:
                 # Format multiple GPU types like "7x b200, 7x 1g.23gb"
-                gpu_parts = [f"{count}x {gtype}" for count, gtype in nt.gpu_specs]
+                gpu_parts = [f"{count}x {gtype or 'unknown'}" for count, gtype in nt.gpu_specs]
                 gpu_info = f", {', '.join(gpu_parts)}"
             mem_gb = nt.memory_mb // 1024
             features_str = ""

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -1153,7 +1153,7 @@ def analysis_run(
     skip_existing: bool = True,
     slurm: bool = False,
     account: str | None = None,
-    partition: str = "cpu",
+    partition: str | None = None,
     time: str = "2h",
     cpus: int = 4,
     mem_gb: int = 8,
@@ -1236,25 +1236,16 @@ def analysis_run(
         try:
             slurm_cfg = SlurmConfig.from_cluster(
                 needs_gpu=False,
+                min_cpus=cpus,
+                min_mem_gb=mem_gb,
                 time=time,
                 cpus_per_task=cpus,
                 mem_gb=mem_gb,
                 qos=qos,
                 constraint=constraint,
                 job_name_prefix=job_name_prefix,
+                **({"partition": partition} if partition is not None else {}),
             )
-            # Override partition if user specified one explicitly
-            if partition != "cpu":  # user changed from default
-                slurm_cfg = SlurmConfig(
-                    account=slurm_cfg.account,
-                    partition=partition,
-                    time=time,
-                    cpus_per_task=cpus,
-                    mem_gb=mem_gb,
-                    qos=qos,
-                    constraint=constraint,
-                    job_name_prefix=job_name_prefix,
-                )
             logger.info(
                 f"Using autodiscovered SLURM config: account={slurm_cfg.account}, "
                 f"partition={slurm_cfg.partition}"
@@ -1266,7 +1257,7 @@ def analysis_run(
     else:
         slurm_cfg = SlurmConfig(
             account=account,
-            partition=partition,
+            partition=partition or "cpu",
             time=time,
             cpus_per_task=cpus,
             mem_gb=mem_gb,
@@ -1504,7 +1495,7 @@ def analysis_artifacts_run(
     skip_existing: bool = True,
     slurm: bool = False,
     account: str | None = None,
-    partition: str = "cpu",
+    partition: str | None = None,
     time: str = "2h",
     cpus: int = 4,
     mem_gb: int = 8,
@@ -1556,25 +1547,16 @@ def analysis_artifacts_run(
         try:
             slurm_cfg = SlurmConfig.from_cluster(
                 needs_gpu=False,
+                min_cpus=cpus,
+                min_mem_gb=mem_gb,
                 time=time,
                 cpus_per_task=cpus,
                 mem_gb=mem_gb,
                 qos=qos,
                 constraint=constraint,
                 job_name_prefix=job_name_prefix,
+                **({"partition": partition} if partition is not None else {}),
             )
-            # Override partition if user specified one explicitly
-            if partition != "cpu":  # user changed from default
-                slurm_cfg = SlurmConfig(
-                    account=slurm_cfg.account,
-                    partition=partition,
-                    time=time,
-                    cpus_per_task=cpus,
-                    mem_gb=mem_gb,
-                    qos=qos,
-                    constraint=constraint,
-                    job_name_prefix=job_name_prefix,
-                )
             logger.info(
                 f"Using autodiscovered SLURM config: account={slurm_cfg.account}, "
                 f"partition={slurm_cfg.partition}"
@@ -1586,7 +1568,7 @@ def analysis_artifacts_run(
     else:
         slurm_cfg = SlurmConfig(
             account=account,
-            partition=partition,
+            partition=partition or "cpu",
             time=time,
             cpus_per_task=cpus,
             mem_gb=mem_gb,

--- a/mdfactory/performance/__init__.py
+++ b/mdfactory/performance/__init__.py
@@ -1,0 +1,9 @@
+# ABOUTME: HPC performance optimization package for mdfactory.
+# ABOUTME: Cluster autodiscovery, CPU affinity, benchmarking, and GPU MPS management.
+"""HPC performance optimization utilities.
+
+Modules
+-------
+cluster
+    SLURM cluster autodiscovery — query partitions, node types, accounts, and QOS.
+"""

--- a/mdfactory/performance/__init__.py
+++ b/mdfactory/performance/__init__.py
@@ -12,6 +12,7 @@ slurm_config
     ``SlurmConfig`` is the submitit backend configuration.
 """
 
+from mdfactory.performance import cluster
 from mdfactory.performance.slurm_config import BaseSlurmConfig, SlurmConfig
 
-__all__ = ["BaseSlurmConfig", "SlurmConfig"]
+__all__ = ["cluster", "BaseSlurmConfig", "SlurmConfig"]

--- a/mdfactory/performance/__init__.py
+++ b/mdfactory/performance/__init__.py
@@ -6,4 +6,12 @@ Modules
 -------
 cluster
     SLURM cluster autodiscovery — query partitions, node types, accounts, and QOS.
+slurm_config
+    SLURM configuration models shared across all submission backends.
+    ``BaseSlurmConfig`` provides 3-tier autodiscovery for account and partition.
+    ``SlurmConfig`` is the submitit backend configuration.
 """
+
+from mdfactory.performance.slurm_config import BaseSlurmConfig, SlurmConfig
+
+__all__ = ["BaseSlurmConfig", "SlurmConfig"]

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -39,19 +39,20 @@ class NodeType:
         Number of CPU cores per node.
     memory_mb : int
         Memory in megabytes per node.
-    gpus : int
-        Number of GPUs per node (0 if CPU-only).
-    gpu_type : str or None
-        GPU model identifier (e.g., ``"a100"``, ``"h100"``), or None.
+    gpu_specs : tuple of (int, str)
+        GPU specifications as (count, type) tuples. Empty if CPU-only.
+        Multiple entries represent different GPU types on the same node.
     features : tuple of str
         SLURM feature/constraint tags on this node type (immutable).
+    count : int
+        Number of nodes with this exact configuration.
     """
 
     cpus: int
     memory_mb: int
-    gpus: int = 0
-    gpu_type: str | None = None
+    gpu_specs: tuple[tuple[int, str], ...] = field(default_factory=tuple)
     features: tuple[str, ...] = field(default_factory=tuple)
+    count: int = 1
 
 
 @dataclass(frozen=True)
@@ -139,53 +140,61 @@ def _run_command(cmd: list[str], *, timeout: int = 30) -> str | None:
         return None
 
 
-def _parse_gres(gres_str: str) -> tuple[int, str | None]:
-    """Parse SLURM GRES string to extract GPU count and type.
+def _parse_gres(gres_str: str) -> list[tuple[int, str | None]]:
+    """Parse SLURM GRES string to extract GPU count and type for all GPU entries.
 
     Parameters
     ----------
     gres_str : str
         GRES field from sinfo (e.g., ``"gpu:a100:4"``, ``"gpu:2"``, ``"(null)"``).
+        May contain multiple GPU entries separated by commas.
 
     Returns
     -------
-    tuple of (int, str or None)
-        (gpu_count, gpu_type). Returns (0, None) when no GPUs.
+    list of tuple (int, str or None)
+        List of (gpu_count, gpu_type) for each GPU entry. Empty list when no GPUs.
 
     Examples
     --------
     >>> _parse_gres("gpu:a100:4")
-    (4, 'a100')
-    >>> _parse_gres("gpu:2")
-    (2, None)
+    [(4, 'a100')]
+    >>> _parse_gres("gpu:b200:8(S:0-1),gpu:1g.23gb:7(S:1)")
+    [(8, 'b200'), (7, '1g.23gb')]
     >>> _parse_gres("(null)")
-    (0, None)
+    []
     """
     if not gres_str or gres_str == "(null)":
-        return 0, None
+        return []
+
+    gpu_entries = []
 
     # Handle multiple GRES entries separated by commas
     for raw_entry in gres_str.split(","):
         entry = raw_entry.strip()
         if not entry.startswith("gpu"):
             continue
+
+        # Strip socket binding suffix like "(S:0-1)" or "(IDX:0-3)"
+        if "(" in entry:
+            entry = entry.split("(")[0]
+
         parts = entry.split(":")
         if len(parts) == 3:
             # gpu:type:count
             _, gpu_type, count_str = parts
-            return int(count_str), gpu_type
+            gpu_entries.append((int(count_str), gpu_type))
         elif len(parts) == 2:
             # gpu:count (no type specified)
             _, count_str = parts
             # Check if second part is a number or a type
             try:
                 count = int(count_str)
-                return count, None
+                gpu_entries.append((count, None))
             except ValueError:
                 # gpu:type with implicit count of 1
-                return 1, count_str
+                gpu_entries.append((1, count_str))
 
-    return 0, None
+    return gpu_entries
 
 
 def _parse_time_limit(time_str: str) -> str:
@@ -311,34 +320,56 @@ def _parse_sinfo(output: str) -> list[Partition]:
             continue
 
         memory_mb = _parse_memory_mb(mem_str)
-        gpus, gpu_type = _parse_gres(gres_str)
+        gpu_entries = _parse_gres(gres_str)
         features = _parse_features(features_str)
 
         if partition_name not in partition_data:
             partition_data[partition_name] = {
                 "max_time": _parse_time_limit(max_time),
                 "default_time": _parse_time_limit(default_time),
-                "node_types": set(),
+                "node_types": {},  # Maps node_key -> count
                 "node_count": 0,
                 "is_default": is_default,
                 "has_healthy_node": False,
                 "last_unhealthy_state": "down",
             }
 
-        # Use a hashable representation for deduplication (features is already a tuple)
-        node_key = (cpus, memory_mb, gpus, gpu_type, features)
-        partition_data[partition_name]["node_types"].add(node_key)
-        partition_data[partition_name]["node_count"] += 1
-
         # Track if any line marks this as default
         if is_default:
             partition_data[partition_name]["is_default"] = True
 
-        # Track node health: partition is "up" if ANY node is schedulable
-        if state.lower() in ("idle", "mixed", "allocated", "completing", "planned"):
+        # Determine if node is operational (can schedule jobs or report accurate config)
+        # Exclude only truly broken/invalid nodes: down, drained, inval, fail, maint, unknown
+        state_lower = state.lower()
+        is_broken = any(
+            broken in state_lower
+            for broken in ("down", "drained", "inval", "fail", "maint", "unknown")
+        )
+        is_operational = not is_broken
+
+        # Partition is "up" if ANY operational node exists
+        if is_operational:
             partition_data[partition_name]["has_healthy_node"] = True
         else:
             partition_data[partition_name]["last_unhealthy_state"] = state
+
+        # Count all nodes (including allocated, reserved, etc.) for stable totals
+        partition_data[partition_name]["node_count"] += 1
+
+        # Only collect node specs from operational nodes
+        # (broken nodes may report incorrect/stale hardware configs)
+        if is_operational:
+            # Convert GPU entries to a sorted tuple for consistent hashing
+            # Sort by type name for deterministic ordering
+            gpu_specs = tuple(sorted(gpu_entries, key=lambda x: x[1] or ""))
+
+            # Use a hashable representation for deduplication
+            node_key = (cpus, memory_mb, gpu_specs, features)
+
+            # Track count of nodes with this exact configuration
+            if node_key not in partition_data[partition_name]["node_types"]:
+                partition_data[partition_name]["node_types"][node_key] = 0
+            partition_data[partition_name]["node_types"][node_key] += 1
 
     # Build Partition objects
     partitions = []
@@ -354,14 +385,14 @@ def _parse_sinfo(output: str) -> list[Partition]:
             NodeType(
                 cpus=cpus,
                 memory_mb=mem,
-                gpus=gpus,
-                gpu_type=gtype,
+                gpu_specs=gpu_specs,
                 features=feats,
+                count=count,
             )
-            for cpus, mem, gpus, gtype, feats in data["node_types"]
+            for (cpus, mem, gpu_specs, feats), count in data["node_types"].items()
         ]
-        # Sort node types by CPU count for deterministic ordering
-        node_types.sort(key=lambda n: (n.cpus, n.memory_mb, n.gpus))
+        # Sort node types by CPU count, memory, then GPU specs for deterministic ordering
+        node_types.sort(key=lambda n: (n.cpus, n.memory_mb, n.gpu_specs))
 
         partitions.append(
             Partition(
@@ -616,7 +647,9 @@ def select_partition(
                 continue
             if node.memory_mb < min_mem_mb:
                 continue
-            if needs_gpu and node.gpus == 0:
+            # Check if node has any GPUs
+            has_gpu = len(node.gpu_specs) > 0
+            if needs_gpu and not has_gpu:
                 continue
             has_qualifying_node = True
             break

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -484,6 +484,34 @@ def _discover_qos() -> list[str] | None:
     return _parse_qos(output)
 
 
+def _discover_default_account() -> str | None:
+    """Query sacctmgr for the current user's default SLURM account.
+
+    Returns
+    -------
+    str or None
+        The user's default account, or None if unavailable.
+    """
+    user = os.environ.get("USER", os.environ.get("LOGNAME", ""))
+    if not user:
+        return None
+    output = _run_command(
+        [
+            "sacctmgr",
+            "show",
+            "user",
+            user,
+            "format=DefaultAccount",
+            "--noheader",
+            "--parsable2",
+        ]
+    )
+    if output is None:
+        return None
+    account = output.strip().splitlines()[0].strip() if output.strip() else None
+    return account if account else None
+
+
 @functools.lru_cache(maxsize=1)
 def discover_cluster() -> ClusterInfo | None:
     """Query SLURM and return structured cluster information.
@@ -520,7 +548,10 @@ def discover_cluster() -> ClusterInfo | None:
     accounts = _discover_accounts() or []
     qos_policies = _discover_qos() or []
 
-    default_account = accounts[0] if accounts else None
+    # Query the real SLURM default account; fall back to first available
+    default_account = _discover_default_account()
+    if default_account is None and accounts:
+        default_account = accounts[0]
 
     return ClusterInfo(
         partitions=partitions,

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -163,7 +163,10 @@ def _parse_gres(gres_str: str) -> list[tuple[int, str | None]]:
         if len(parts) == 3:
             # gpu:type:count
             _, gpu_type, count_str = parts
-            gpu_entries.append((int(count_str), gpu_type))
+            try:
+                gpu_entries.append((int(count_str), gpu_type))
+            except ValueError:
+                continue  # skip malformed GRES entry
         elif len(parts) == 2:
             # gpu:count (no type specified)
             _, count_str = parts

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -315,11 +315,11 @@ def _parse_sinfo(output: str) -> list[Partition]:
             partition_data[partition_name]["is_default"] = True
 
         # Determine if node is operational (can schedule jobs or report accurate config)
-        # Exclude only truly broken/invalid nodes: down, drained, inval, fail, maint, unknown
+        # Exclude broken/invalid nodes: down, drained, inval, fail, maint, unknown, error
         state_lower = state.lower()
         is_broken = any(
             broken in state_lower
-            for broken in ("down", "drained", "inval", "fail", "maint", "unknown")
+            for broken in ("down", "drained", "inval", "fail", "maint", "unknown", "error")
         )
         is_operational = not is_broken
 

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -22,13 +22,17 @@ Examples
 
 from __future__ import annotations
 
-import functools
 import os
 import shutil
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from mdfactory.utils.utilities import run_command
+
+# Sentinel for selective caching in discover_cluster(): only confirmed sinfo-absent
+# and successful ClusterInfo results are cached; transient failures fall through.
+_CLUSTER_CACHE_SENTINEL = object()
+_cluster_cache: "ClusterInfo | None | object" = _CLUSTER_CACHE_SENTINEL
 
 
 class NodeType(BaseModel):
@@ -535,7 +539,6 @@ def _discover_default_account() -> str | None:
     return account if account else None
 
 
-@functools.lru_cache(maxsize=1)
 def discover_cluster() -> ClusterInfo | None:
     """Query SLURM and return structured cluster information.
 
@@ -543,8 +546,10 @@ def discover_cluster() -> ClusterInfo | None:
     accounts, and QOS policies. Returns None gracefully when SLURM commands
     are not available (e.g., running on a laptop).
 
-    Results are cached for the session (cluster topology doesn't change
-    mid-session). Call ``discover_cluster.cache_clear()`` to force re-query.
+    Successful results and confirmed sinfo-absent are cached for the session
+    (cluster topology doesn't change mid-run). Transient failures (sinfo
+    present but exiting non-zero) are not cached so the next call retries.
+    Call ``discover_cluster.cache_clear()`` to force a full re-query.
 
     Returns
     -------
@@ -558,13 +563,19 @@ def discover_cluster() -> ClusterInfo | None:
     ...     for p in cluster.partitions:
     ...         print(f"{p.name}: {p.total_nodes} nodes")
     """
+    global _cluster_cache
+    if _cluster_cache is not _CLUSTER_CACHE_SENTINEL:
+        return _cluster_cache  # type: ignore[return-value]
+
     # sinfo is the minimum requirement — if it's not available, we're not
-    # on a SLURM cluster
+    # on a SLURM cluster. This is a stable fact; cache it.
     if shutil.which("sinfo") is None:
+        _cluster_cache = None
         return None
 
     partitions = _discover_partitions()
     if partitions is None:
+        # Transient failure (sinfo exited non-zero) — don't cache, allow retry.
         return None
 
     # Accounts and QOS are best-effort (sacctmgr may be restricted)
@@ -576,12 +587,22 @@ def discover_cluster() -> ClusterInfo | None:
     if default_account is None and accounts:
         default_account = accounts[0]
 
-    return ClusterInfo(
+    result = ClusterInfo(
         partitions=partitions,
         accounts=accounts,
         qos_policies=qos_policies,
         default_account=default_account,
     )
+    _cluster_cache = result
+    return result
+
+
+def _clear_cluster_cache() -> None:
+    global _cluster_cache
+    _cluster_cache = _CLUSTER_CACHE_SENTINEL
+
+
+discover_cluster.cache_clear = _clear_cluster_cache  # type: ignore[attr-defined]
 
 
 def select_partition(

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -165,8 +165,8 @@ def _parse_gres(gres_str: str) -> tuple[int, str | None]:
         return 0, None
 
     # Handle multiple GRES entries separated by commas
-    for entry in gres_str.split(","):
-        entry = entry.strip()
+    for raw_entry in gres_str.split(","):
+        entry = raw_entry.strip()
         if not entry.startswith("gpu"):
             continue
         parts = entry.split(":")
@@ -270,8 +270,8 @@ def _parse_sinfo(output: str) -> list[Partition]:
     # Collect data per partition
     partition_data: dict[str, dict] = {}
 
-    for line in output.splitlines():
-        line = line.strip()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
         if not line:
             continue
 
@@ -415,8 +415,8 @@ def _parse_qos(output: str) -> list[str]:
         QOS policy names, sorted.
     """
     qos_names = set()
-    for line in output.splitlines():
-        line = line.strip()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
         if not line:
             continue
         # Format: Name|MaxWall|MaxTRES
@@ -434,9 +434,7 @@ def _discover_partitions() -> list[Partition] | None:
     list of Partition or None
         Parsed partitions, or None if sinfo is unavailable.
     """
-    output = _run_command(
-        ["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %L %T"]
-    )
+    output = _run_command(["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %L %T"])
     if output is None:
         return None
     return _parse_sinfo(output)

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -68,7 +68,8 @@ class Partition:
     max_time : str
         Maximum walltime (SLURM format, e.g., ``"3-00:00:00"``).
     default_time : str
-        Default walltime if none specified.
+        Default walltime assigned when user does not specify one.
+        Populated from sinfo ``%L``; equals ``max_time`` on legacy output.
     node_types : list of NodeType
         Distinct hardware configurations available in this partition.
     total_nodes : int
@@ -248,9 +249,13 @@ def _parse_sinfo(output: str) -> list[Partition]:
     """Parse sinfo output into Partition objects.
 
     Expects output from:
-        sinfo -N --noheader -o "%P %n %c %m %G %f %l %T"
+        sinfo -N --noheader -o "%P %n %c %m %G %f %l %L %T"
 
-    Fields: Partition, NodeName, CPUs, Memory(MB), GRES, Features, TimeLimit, State
+    Fields: Partition, NodeName, CPUs, Memory(MB), GRES, Features,
+            MaxTimeLimit, DefaultTimeLimit, State
+
+    Also supports the legacy 8-field format (without %L) for backward
+    compatibility — in that case ``default_time`` equals ``max_time``.
 
     Parameters
     ----------
@@ -271,17 +276,28 @@ def _parse_sinfo(output: str) -> list[Partition]:
             continue
 
         parts = line.split()
-        if len(parts) < 8:
+        if len(parts) >= 9:
+            # 9-field format: %P %n %c %m %G %f %l %L %T
+            partition_name = parts[0]
+            cpus_str = parts[2]
+            mem_str = parts[3]
+            gres_str = parts[4]
+            features_str = parts[5]
+            max_time = parts[6]
+            default_time = parts[7]
+            state = parts[8]
+        elif len(parts) == 8:
+            # Legacy 8-field format (no %L): default_time = max_time
+            partition_name = parts[0]
+            cpus_str = parts[2]
+            mem_str = parts[3]
+            gres_str = parts[4]
+            features_str = parts[5]
+            max_time = parts[6]
+            default_time = parts[6]
+            state = parts[7]
+        else:
             continue
-
-        partition_name = parts[0]
-        # node_name = parts[1]  # not stored but could be useful for debugging
-        cpus_str = parts[2]
-        mem_str = parts[3]
-        gres_str = parts[4]
-        features_str = parts[5]
-        time_limit = parts[6]
-        state = parts[7]
 
         # Handle default partition marker (trailing asterisk)
         is_default = partition_name.endswith("*")
@@ -298,18 +314,10 @@ def _parse_sinfo(output: str) -> list[Partition]:
         gpus, gpu_type = _parse_gres(gres_str)
         features = _parse_features(features_str)
 
-        node_type = NodeType(
-            cpus=cpus,
-            memory_mb=memory_mb,
-            gpus=gpus,
-            gpu_type=gpu_type,
-            features=features,
-        )
-
         if partition_name not in partition_data:
             partition_data[partition_name] = {
-                "max_time": _parse_time_limit(time_limit),
-                "default_time": _parse_time_limit(time_limit),
+                "max_time": _parse_time_limit(max_time),
+                "default_time": _parse_time_limit(default_time),
                 "node_types": set(),
                 "node_count": 0,
                 "is_default": is_default,
@@ -427,7 +435,7 @@ def _discover_partitions() -> list[Partition] | None:
         Parsed partitions, or None if sinfo is unavailable.
     """
     output = _run_command(
-        ["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %T"]
+        ["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %L %T"]
     )
     if output is None:
         return None

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -26,11 +26,11 @@ import functools
 import os
 import shutil
 import subprocess
-from dataclasses import dataclass, field
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
-@dataclass(frozen=True)
-class NodeType:
+class NodeType(BaseModel):
     """Hardware specification of a node type within a partition.
 
     Parameters
@@ -39,24 +39,26 @@ class NodeType:
         Number of CPU cores per node.
     memory_mb : int
         Memory in megabytes per node.
-    gpu_specs : tuple of (int, str)
+    gpu_specs : tuple of (int, str | None)
         GPU specifications as (count, type) tuples. Empty if CPU-only.
         Multiple entries represent different GPU types on the same node.
+        Type can be None if SLURM reports GPU count without type info.
     features : tuple of str
         SLURM feature/constraint tags on this node type (immutable).
     count : int
         Number of nodes with this exact configuration.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     cpus: int
     memory_mb: int
-    gpu_specs: tuple[tuple[int, str], ...] = field(default_factory=tuple)
-    features: tuple[str, ...] = field(default_factory=tuple)
+    gpu_specs: tuple[tuple[int, str | None], ...] = Field(default_factory=tuple)
+    features: tuple[str, ...] = Field(default_factory=tuple)
     count: int = 1
 
 
-@dataclass(frozen=True)
-class Partition:
+class Partition(BaseModel):
     """A SLURM partition with its node types and limits.
 
     Parameters
@@ -79,17 +81,18 @@ class Partition:
         Whether this is the cluster's default partition.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     name: str
     state: str
     max_time: str
     default_time: str
-    node_types: list[NodeType] = field(default_factory=list)
+    node_types: list[NodeType] = Field(default_factory=list)
     total_nodes: int = 0
     is_default: bool = False
 
 
-@dataclass(frozen=True)
-class ClusterInfo:
+class ClusterInfo(BaseModel):
     """Structured representation of a SLURM cluster's resources.
 
     Parameters
@@ -104,9 +107,11 @@ class ClusterInfo:
         The user's default account, if determinable.
     """
 
-    partitions: list[Partition] = field(default_factory=list)
-    accounts: list[str] = field(default_factory=list)
-    qos_policies: list[str] = field(default_factory=list)
+    model_config = ConfigDict(frozen=True)
+
+    partitions: list[Partition] = Field(default_factory=list)
+    accounts: list[str] = Field(default_factory=list)
+    qos_policies: list[str] = Field(default_factory=list)
     default_account: str | None = None
 
 

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -1,0 +1,595 @@
+# ABOUTME: SLURM cluster autodiscovery — query partitions, node types, accounts, QOS.
+# ABOUTME: Parses sinfo/sacctmgr output into structured dataclasses for resource-aware scheduling.
+"""SLURM cluster autodiscovery.
+
+Query the local SLURM scheduler and return a structured representation of
+available resources (partitions, node types, accounts, QOS policies, GPU types).
+
+Functions
+---------
+discover_cluster
+    Main entry point — returns ``ClusterInfo`` or ``None`` if SLURM is unavailable.
+select_partition
+    Heuristic partition selection given resource requirements.
+
+Examples
+--------
+>>> from mdfactory.performance.cluster import discover_cluster, select_partition
+>>> cluster = discover_cluster()
+>>> if cluster is not None:
+...     gpu_part = select_partition(cluster, needs_gpu=True)
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class NodeType:
+    """Hardware specification of a node type within a partition.
+
+    Parameters
+    ----------
+    cpus : int
+        Number of CPU cores per node.
+    memory_mb : int
+        Memory in megabytes per node.
+    gpus : int
+        Number of GPUs per node (0 if CPU-only).
+    gpu_type : str or None
+        GPU model identifier (e.g., ``"a100"``, ``"h100"``), or None.
+    features : list of str
+        SLURM feature/constraint tags on this node type.
+    """
+
+    cpus: int
+    memory_mb: int
+    gpus: int = 0
+    gpu_type: str | None = None
+    features: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Partition:
+    """A SLURM partition with its node types and limits.
+
+    Parameters
+    ----------
+    name : str
+        Partition name (e.g., ``"gpu"``, ``"cpu"``).
+    state : str
+        Partition state (e.g., ``"up"``, ``"down"``).
+    max_time : str
+        Maximum walltime (SLURM format, e.g., ``"3-00:00:00"``).
+    default_time : str
+        Default walltime if none specified.
+    node_types : list of NodeType
+        Distinct hardware configurations available in this partition.
+    total_nodes : int
+        Total number of nodes in the partition.
+    is_default : bool
+        Whether this is the cluster's default partition.
+    """
+
+    name: str
+    state: str
+    max_time: str
+    default_time: str
+    node_types: list[NodeType] = field(default_factory=list)
+    total_nodes: int = 0
+    is_default: bool = False
+
+
+@dataclass(frozen=True)
+class ClusterInfo:
+    """Structured representation of a SLURM cluster's resources.
+
+    Parameters
+    ----------
+    partitions : list of Partition
+        All discovered partitions.
+    accounts : list of str
+        SLURM accounts available to the current user.
+    qos_policies : list of str
+        Available QOS policy names.
+    default_account : str or None
+        The user's default account, if determinable.
+    """
+
+    partitions: list[Partition] = field(default_factory=list)
+    accounts: list[str] = field(default_factory=list)
+    qos_policies: list[str] = field(default_factory=list)
+    default_account: str | None = None
+
+
+def _run_command(cmd: list[str], *, timeout: int = 30) -> str | None:
+    """Run a shell command and return stdout, or None on failure.
+
+    Parameters
+    ----------
+    cmd : list of str
+        Command and arguments.
+    timeout : int
+        Timeout in seconds.
+
+    Returns
+    -------
+    str or None
+        Stripped stdout on success, None on any failure.
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _parse_gres(gres_str: str) -> tuple[int, str | None]:
+    """Parse SLURM GRES string to extract GPU count and type.
+
+    Parameters
+    ----------
+    gres_str : str
+        GRES field from sinfo (e.g., ``"gpu:a100:4"``, ``"gpu:2"``, ``"(null)"``).
+
+    Returns
+    -------
+    tuple of (int, str or None)
+        (gpu_count, gpu_type). Returns (0, None) when no GPUs.
+
+    Examples
+    --------
+    >>> _parse_gres("gpu:a100:4")
+    (4, 'a100')
+    >>> _parse_gres("gpu:2")
+    (2, None)
+    >>> _parse_gres("(null)")
+    (0, None)
+    """
+    if not gres_str or gres_str == "(null)":
+        return 0, None
+
+    # Handle multiple GRES entries separated by commas
+    for entry in gres_str.split(","):
+        entry = entry.strip()
+        if not entry.startswith("gpu"):
+            continue
+        parts = entry.split(":")
+        if len(parts) == 3:
+            # gpu:type:count
+            _, gpu_type, count_str = parts
+            return int(count_str), gpu_type
+        elif len(parts) == 2:
+            # gpu:count (no type specified)
+            _, count_str = parts
+            # Check if second part is a number or a type
+            try:
+                count = int(count_str)
+                return count, None
+            except ValueError:
+                # gpu:type with implicit count of 1
+                return 1, count_str
+
+    return 0, None
+
+
+def _parse_time_limit(time_str: str) -> str:
+    """Normalize SLURM time limit strings.
+
+    Parameters
+    ----------
+    time_str : str
+        Time limit from sinfo (e.g., ``"3-00:00:00"``, ``"infinite"``, ``"2:00:00"``).
+
+    Returns
+    -------
+    str
+        Cleaned time string.
+    """
+    if not time_str or time_str == "n/a":
+        return "unknown"
+    return time_str.strip()
+
+
+def _parse_memory_mb(mem_str: str) -> int:
+    """Parse memory string from sinfo to megabytes.
+
+    Parameters
+    ----------
+    mem_str : str
+        Memory field from sinfo (numeric, in MB by default).
+
+    Returns
+    -------
+    int
+        Memory in MB. Returns 0 on parse failure.
+    """
+    try:
+        # sinfo %m gives memory in MB as an integer
+        cleaned = mem_str.strip().rstrip("+")
+        return int(cleaned)
+    except (ValueError, AttributeError):
+        return 0
+
+
+def _parse_features(features_str: str) -> list[str]:
+    """Parse SLURM features/constraints string.
+
+    Parameters
+    ----------
+    features_str : str
+        Features field from sinfo (comma-separated or ``"(null)"``).
+
+    Returns
+    -------
+    list of str
+        List of feature strings.
+    """
+    if not features_str or features_str == "(null)":
+        return []
+    return [f.strip() for f in features_str.split(",") if f.strip()]
+
+
+def _parse_sinfo(output: str) -> list[Partition]:
+    """Parse sinfo output into Partition objects.
+
+    Expects output from:
+        sinfo -N --noheader -o "%P %n %c %m %G %f %l %T"
+
+    Fields: Partition, NodeName, CPUs, Memory(MB), GRES, Features, TimeLimit, State
+
+    Parameters
+    ----------
+    output : str
+        Raw sinfo output.
+
+    Returns
+    -------
+    list of Partition
+        Parsed partition list with deduplicated node types.
+    """
+    # Collect data per partition
+    partition_data: dict[str, dict] = {}
+
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split()
+        if len(parts) < 8:
+            continue
+
+        partition_name = parts[0]
+        # node_name = parts[1]  # not stored but could be useful for debugging
+        cpus_str = parts[2]
+        mem_str = parts[3]
+        gres_str = parts[4]
+        features_str = parts[5]
+        time_limit = parts[6]
+        state = parts[7]
+
+        # Handle default partition marker (trailing asterisk)
+        is_default = partition_name.endswith("*")
+        if is_default:
+            partition_name = partition_name.rstrip("*")
+
+        # Parse node specs
+        try:
+            cpus = int(cpus_str)
+        except ValueError:
+            continue
+
+        memory_mb = _parse_memory_mb(mem_str)
+        gpus, gpu_type = _parse_gres(gres_str)
+        features = _parse_features(features_str)
+
+        node_type = NodeType(
+            cpus=cpus,
+            memory_mb=memory_mb,
+            gpus=gpus,
+            gpu_type=gpu_type,
+            features=features,
+        )
+
+        if partition_name not in partition_data:
+            partition_data[partition_name] = {
+                "state": state,
+                "max_time": _parse_time_limit(time_limit),
+                "default_time": _parse_time_limit(time_limit),
+                "node_types": set(),
+                "node_count": 0,
+                "is_default": is_default,
+            }
+
+        # Use a hashable representation for deduplication
+        node_key = (cpus, memory_mb, gpus, gpu_type, tuple(features))
+        partition_data[partition_name]["node_types"].add(node_key)
+        partition_data[partition_name]["node_count"] += 1
+
+        # Track if any line marks this as default
+        if is_default:
+            partition_data[partition_name]["is_default"] = True
+
+        # Use worst state for partition (if any node is down, note it)
+        # Priority: up > drain > down
+        current_state = partition_data[partition_name]["state"]
+        if state.lower() not in ("idle", "mixed", "allocated", "completing"):
+            if current_state.lower() in ("idle", "mixed", "allocated", "completing"):
+                pass  # keep the healthy state as partition state
+            else:
+                partition_data[partition_name]["state"] = state
+
+    # Build Partition objects
+    partitions = []
+    for name, data in partition_data.items():
+        node_types = [
+            NodeType(
+                cpus=cpus,
+                memory_mb=mem,
+                gpus=gpus,
+                gpu_type=gtype,
+                features=list(feats),
+            )
+            for cpus, mem, gpus, gtype, feats in data["node_types"]
+        ]
+        # Sort node types by CPU count for deterministic ordering
+        node_types.sort(key=lambda n: (n.cpus, n.memory_mb, n.gpus))
+
+        partitions.append(
+            Partition(
+                name=name,
+                state=data["state"],
+                max_time=data["max_time"],
+                default_time=data["default_time"],
+                node_types=node_types,
+                total_nodes=data["node_count"],
+                is_default=data["is_default"],
+            )
+        )
+
+    # Sort partitions: default first, then alphabetical
+    partitions.sort(key=lambda p: (not p.is_default, p.name))
+    return partitions
+
+
+def _parse_accounts(output: str) -> list[str]:
+    """Parse sacctmgr account output.
+
+    Parameters
+    ----------
+    output : str
+        Raw sacctmgr output (one account per line, parsable2 format).
+
+    Returns
+    -------
+    list of str
+        Unique account names, sorted.
+    """
+    accounts = set()
+    for line in output.splitlines():
+        account = line.strip()
+        if account:
+            accounts.add(account)
+    return sorted(accounts)
+
+
+def _parse_qos(output: str) -> list[str]:
+    """Parse sacctmgr QOS output.
+
+    Parameters
+    ----------
+    output : str
+        Raw sacctmgr output (pipe-separated: Name|MaxWall|MaxTRES).
+
+    Returns
+    -------
+    list of str
+        QOS policy names, sorted.
+    """
+    qos_names = set()
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # Format: Name|MaxWall|MaxTRES
+        parts = line.split("|")
+        if parts and parts[0].strip():
+            qos_names.add(parts[0].strip())
+    return sorted(qos_names)
+
+
+def _discover_partitions() -> list[Partition] | None:
+    """Query sinfo for partition and node information.
+
+    Returns
+    -------
+    list of Partition or None
+        Parsed partitions, or None if sinfo is unavailable.
+    """
+    output = _run_command(
+        ["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %T"]
+    )
+    if output is None:
+        return None
+    return _parse_sinfo(output)
+
+
+def _discover_accounts() -> list[str] | None:
+    """Query sacctmgr for the current user's accounts.
+
+    Returns
+    -------
+    list of str or None
+        Account names, or None if sacctmgr is unavailable.
+    """
+    user = os.environ.get("USER", os.environ.get("LOGNAME", ""))
+    if not user:
+        return None
+    output = _run_command(
+        [
+            "sacctmgr",
+            "show",
+            "assoc",
+            f"user={user}",
+            "format=Account",
+            "--noheader",
+            "--parsable2",
+        ]
+    )
+    if output is None:
+        return None
+    return _parse_accounts(output)
+
+
+def _discover_qos() -> list[str] | None:
+    """Query sacctmgr for available QOS policies.
+
+    Returns
+    -------
+    list of str or None
+        QOS names, or None if sacctmgr is unavailable.
+    """
+    output = _run_command(
+        [
+            "sacctmgr",
+            "show",
+            "qos",
+            "format=Name,MaxWall,MaxTRES",
+            "--noheader",
+            "--parsable2",
+        ]
+    )
+    if output is None:
+        return None
+    return _parse_qos(output)
+
+
+@functools.lru_cache(maxsize=1)
+def discover_cluster() -> ClusterInfo | None:
+    """Query SLURM and return structured cluster information.
+
+    Calls ``sinfo`` and ``sacctmgr`` to discover partitions, node types,
+    accounts, and QOS policies. Returns None gracefully when SLURM commands
+    are not available (e.g., running on a laptop).
+
+    Results are cached for the session (cluster topology doesn't change
+    mid-session). Call ``discover_cluster.cache_clear()`` to force re-query.
+
+    Returns
+    -------
+    ClusterInfo or None
+        Structured cluster information, or None if SLURM is unavailable.
+
+    Examples
+    --------
+    >>> cluster = discover_cluster()
+    >>> if cluster is not None:
+    ...     for p in cluster.partitions:
+    ...         print(f"{p.name}: {p.total_nodes} nodes")
+    """
+    # sinfo is the minimum requirement — if it's not available, we're not
+    # on a SLURM cluster
+    if shutil.which("sinfo") is None:
+        return None
+
+    partitions = _discover_partitions()
+    if partitions is None:
+        return None
+
+    # Accounts and QOS are best-effort (sacctmgr may be restricted)
+    accounts = _discover_accounts() or []
+    qos_policies = _discover_qos() or []
+
+    default_account = accounts[0] if accounts else None
+
+    return ClusterInfo(
+        partitions=partitions,
+        accounts=accounts,
+        qos_policies=qos_policies,
+        default_account=default_account,
+    )
+
+
+def select_partition(
+    cluster: ClusterInfo,
+    *,
+    needs_gpu: bool = False,
+    min_cpus: int = 1,
+    min_mem_gb: int = 1,
+) -> Partition | None:
+    """Heuristic partition selection given resource requirements.
+
+    Selects the best-matching partition from the cluster based on hardware
+    needs. Prefers partitions that are ``"up"`` and have nodes meeting the
+    specified requirements.
+
+    Parameters
+    ----------
+    cluster : ClusterInfo
+        Cluster information from ``discover_cluster()``.
+    needs_gpu : bool
+        If True, only consider partitions with GPU-equipped nodes.
+    min_cpus : int
+        Minimum CPUs per node required.
+    min_mem_gb : int
+        Minimum memory per node in GB.
+
+    Returns
+    -------
+    Partition or None
+        Best matching partition, or None if no partition meets requirements.
+
+    Examples
+    --------
+    >>> cluster = discover_cluster()
+    >>> gpu_partition = select_partition(cluster, needs_gpu=True, min_cpus=8)
+    """
+    min_mem_mb = min_mem_gb * 1024
+    candidates: list[Partition] = []
+
+    for partition in cluster.partitions:
+        # Skip non-up partitions
+        if partition.state.lower() not in (
+            "up",
+            "idle",
+            "mixed",
+            "allocated",
+            "completing",
+        ):
+            continue
+
+        # Check if any node type meets requirements
+        has_qualifying_node = False
+        for node in partition.node_types:
+            if node.cpus < min_cpus:
+                continue
+            if node.memory_mb < min_mem_mb:
+                continue
+            if needs_gpu and node.gpus == 0:
+                continue
+            has_qualifying_node = True
+            break
+
+        if has_qualifying_node:
+            candidates.append(partition)
+
+    if not candidates:
+        return None
+
+    # Prefer: default partition > most nodes > alphabetical
+    candidates.sort(key=lambda p: (not p.is_default, -p.total_nodes, p.name))
+    return candidates[0]

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -25,9 +25,10 @@ from __future__ import annotations
 import functools
 import os
 import shutil
-import subprocess
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from mdfactory.utils.utilities import run_command
 
 
 class NodeType(BaseModel):
@@ -113,36 +114,6 @@ class ClusterInfo(BaseModel):
     accounts: list[str] = Field(default_factory=list)
     qos_policies: list[str] = Field(default_factory=list)
     default_account: str | None = None
-
-
-def _run_command(cmd: list[str], *, timeout: int = 30) -> str | None:
-    """Run a shell command and return stdout, or None on failure.
-
-    Parameters
-    ----------
-    cmd : list of str
-        Command and arguments.
-    timeout : int
-        Timeout in seconds.
-
-    Returns
-    -------
-    str or None
-        Stripped stdout on success, None on any failure.
-    """
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
-        if result.returncode != 0:
-            return None
-        return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return None
 
 
 def _parse_gres(gres_str: str) -> list[tuple[int, str | None]]:
@@ -470,7 +441,11 @@ def _discover_partitions() -> list[Partition] | None:
     list of Partition or None
         Parsed partitions, or None if sinfo is unavailable.
     """
-    output = _run_command(["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %L %T"])
+    output = run_command(
+        ["sinfo", "-N", "--noheader", "-o", "%P %n %c %m %G %f %l %L %T"],
+        timeout=30,
+        graceful=True,
+    )
     if output is None:
         return None
     return _parse_sinfo(output)
@@ -487,7 +462,7 @@ def _discover_accounts() -> list[str] | None:
     user = os.environ.get("USER", os.environ.get("LOGNAME", ""))
     if not user:
         return None
-    output = _run_command(
+    output = run_command(
         [
             "sacctmgr",
             "show",
@@ -496,7 +471,9 @@ def _discover_accounts() -> list[str] | None:
             "format=Account",
             "--noheader",
             "--parsable2",
-        ]
+        ],
+        timeout=30,
+        graceful=True,
     )
     if output is None:
         return None
@@ -511,7 +488,7 @@ def _discover_qos() -> list[str] | None:
     list of str or None
         QOS names, or None if sacctmgr is unavailable.
     """
-    output = _run_command(
+    output = run_command(
         [
             "sacctmgr",
             "show",
@@ -519,7 +496,9 @@ def _discover_qos() -> list[str] | None:
             "format=Name,MaxWall,MaxTRES",
             "--noheader",
             "--parsable2",
-        ]
+        ],
+        timeout=30,
+        graceful=True,
     )
     if output is None:
         return None
@@ -537,7 +516,7 @@ def _discover_default_account() -> str | None:
     user = os.environ.get("USER", os.environ.get("LOGNAME", ""))
     if not user:
         return None
-    output = _run_command(
+    output = run_command(
         [
             "sacctmgr",
             "show",
@@ -546,7 +525,9 @@ def _discover_default_account() -> str | None:
             "format=DefaultAccount",
             "--noheader",
             "--parsable2",
-        ]
+        ],
+        timeout=30,
+        graceful=True,
     )
     if output is None:
         return None

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -43,15 +43,15 @@ class NodeType:
         Number of GPUs per node (0 if CPU-only).
     gpu_type : str or None
         GPU model identifier (e.g., ``"a100"``, ``"h100"``), or None.
-    features : list of str
-        SLURM feature/constraint tags on this node type.
+    features : tuple of str
+        SLURM feature/constraint tags on this node type (immutable).
     """
 
     cpus: int
     memory_mb: int
     gpus: int = 0
     gpu_type: str | None = None
-    features: list[str] = field(default_factory=list)
+    features: tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -227,7 +227,7 @@ def _parse_memory_mb(mem_str: str) -> int:
         return 0
 
 
-def _parse_features(features_str: str) -> list[str]:
+def _parse_features(features_str: str) -> tuple[str, ...]:
     """Parse SLURM features/constraints string.
 
     Parameters
@@ -237,12 +237,12 @@ def _parse_features(features_str: str) -> list[str]:
 
     Returns
     -------
-    list of str
-        List of feature strings.
+    tuple of str
+        Feature strings (immutable).
     """
     if not features_str or features_str == "(null)":
-        return []
-    return [f.strip() for f in features_str.split(",") if f.strip()]
+        return ()
+    return tuple(f.strip() for f in features_str.split(",") if f.strip())
 
 
 def _parse_sinfo(output: str) -> list[Partition]:
@@ -325,8 +325,8 @@ def _parse_sinfo(output: str) -> list[Partition]:
                 "last_unhealthy_state": "down",
             }
 
-        # Use a hashable representation for deduplication
-        node_key = (cpus, memory_mb, gpus, gpu_type, tuple(features))
+        # Use a hashable representation for deduplication (features is already a tuple)
+        node_key = (cpus, memory_mb, gpus, gpu_type, features)
         partition_data[partition_name]["node_types"].add(node_key)
         partition_data[partition_name]["node_count"] += 1
 
@@ -356,7 +356,7 @@ def _parse_sinfo(output: str) -> list[Partition]:
                 memory_mb=mem,
                 gpus=gpus,
                 gpu_type=gtype,
-                features=list(feats),
+                features=feats,
             )
             for cpus, mem, gpus, gtype, feats in data["node_types"]
         ]

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -63,7 +63,8 @@ class Partition:
     name : str
         Partition name (e.g., ``"gpu"``, ``"cpu"``).
     state : str
-        Partition state (e.g., ``"up"``, ``"down"``).
+        Partition-level state: ``"up"`` if any node is schedulable, otherwise
+        the last observed unhealthy state (e.g., ``"down"``, ``"drained"``).
     max_time : str
         Maximum walltime (SLURM format, e.g., ``"3-00:00:00"``).
     default_time : str
@@ -307,12 +308,13 @@ def _parse_sinfo(output: str) -> list[Partition]:
 
         if partition_name not in partition_data:
             partition_data[partition_name] = {
-                "state": state,
                 "max_time": _parse_time_limit(time_limit),
                 "default_time": _parse_time_limit(time_limit),
                 "node_types": set(),
                 "node_count": 0,
                 "is_default": is_default,
+                "has_healthy_node": False,
+                "last_unhealthy_state": "down",
             }
 
         # Use a hashable representation for deduplication
@@ -324,18 +326,22 @@ def _parse_sinfo(output: str) -> list[Partition]:
         if is_default:
             partition_data[partition_name]["is_default"] = True
 
-        # Use worst state for partition (if any node is down, note it)
-        # Priority: up > drain > down
-        current_state = partition_data[partition_name]["state"]
-        if state.lower() not in ("idle", "mixed", "allocated", "completing"):
-            if current_state.lower() in ("idle", "mixed", "allocated", "completing"):
-                pass  # keep the healthy state as partition state
-            else:
-                partition_data[partition_name]["state"] = state
+        # Track node health: partition is "up" if ANY node is schedulable
+        if state.lower() in ("idle", "mixed", "allocated", "completing", "planned"):
+            partition_data[partition_name]["has_healthy_node"] = True
+        else:
+            partition_data[partition_name]["last_unhealthy_state"] = state
 
     # Build Partition objects
     partitions = []
     for name, data in partition_data.items():
+        # Partition state: "up" if any node is healthy, otherwise report
+        # the last observed unhealthy state
+        if data["has_healthy_node"]:
+            partition_state = "up"
+        else:
+            partition_state = data["last_unhealthy_state"]
+
         node_types = [
             NodeType(
                 cpus=cpus,
@@ -352,7 +358,7 @@ def _parse_sinfo(output: str) -> list[Partition]:
         partitions.append(
             Partition(
                 name=name,
-                state=data["state"],
+                state=partition_state,
                 max_time=data["max_time"],
                 default_time=data["default_time"],
                 node_types=node_types,
@@ -562,14 +568,8 @@ def select_partition(
     candidates: list[Partition] = []
 
     for partition in cluster.partitions:
-        # Skip non-up partitions
-        if partition.state.lower() not in (
-            "up",
-            "idle",
-            "mixed",
-            "allocated",
-            "completing",
-        ):
+        # Skip partitions with no schedulable nodes
+        if partition.state.lower() != "up":
             continue
 
         # Check if any node type meets requirements

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -29,10 +29,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from mdfactory.utils.utilities import run_command
 
-# Sentinel for selective caching in discover_cluster(): only confirmed sinfo-absent
-# and successful ClusterInfo results are cached; transient failures fall through.
+# Single-element list used as a mutable cache cell (avoids 'global', ruff PLW0603).
+# _CLUSTER_CACHE_SENTINEL = not yet queried; None = sinfo absent; ClusterInfo = success.
+# Transient sinfo failures are not cached so the next call retries.
 _CLUSTER_CACHE_SENTINEL = object()
-_cluster_cache: "ClusterInfo | None | object" = _CLUSTER_CACHE_SENTINEL
+_cluster_cache: list = [_CLUSTER_CACHE_SENTINEL]
 
 
 class NodeType(BaseModel):
@@ -563,14 +564,13 @@ def discover_cluster() -> ClusterInfo | None:
     ...     for p in cluster.partitions:
     ...         print(f"{p.name}: {p.total_nodes} nodes")
     """
-    global _cluster_cache
-    if _cluster_cache is not _CLUSTER_CACHE_SENTINEL:
-        return _cluster_cache  # type: ignore[return-value]
+    if _cluster_cache[0] is not _CLUSTER_CACHE_SENTINEL:
+        return _cluster_cache[0]  # type: ignore[return-value]
 
     # sinfo is the minimum requirement — if it's not available, we're not
     # on a SLURM cluster. This is a stable fact; cache it.
     if shutil.which("sinfo") is None:
-        _cluster_cache = None
+        _cluster_cache[0] = None
         return None
 
     partitions = _discover_partitions()
@@ -593,13 +593,12 @@ def discover_cluster() -> ClusterInfo | None:
         qos_policies=qos_policies,
         default_account=default_account,
     )
-    _cluster_cache = result
+    _cluster_cache[0] = result
     return result
 
 
 def _clear_cluster_cache() -> None:
-    global _cluster_cache
-    _cluster_cache = _CLUSTER_CACHE_SENTINEL
+    _cluster_cache[0] = _CLUSTER_CACHE_SENTINEL
 
 
 discover_cluster.cache_clear = _clear_cluster_cache  # type: ignore[attr-defined]

--- a/mdfactory/performance/slurm_config.py
+++ b/mdfactory/performance/slurm_config.py
@@ -29,7 +29,7 @@ normalize_slurm_time
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -88,10 +88,11 @@ def normalize_slurm_time(value: str) -> str:
 class BaseSlurmConfig(BaseModel):
     """SLURM resource specification shared by all submission backends.
 
-    Owns the four cross-cutting SLURM fields and the single authoritative
-    ``from_cluster()`` factory method.  Subclasses add backend-specific
-    fields (e.g. ``cpus_per_task`` for submitit, ``cpus_per_node`` for Parsl)
-    and inherit ``from_cluster()`` without writing any additional code.
+    Base class owning the four cross-cutting SLURM fields and the single
+    authoritative ``from_cluster()`` factory method.  Subclasses add
+    backend-specific fields (e.g. ``cpus_per_task`` for submitit,
+    ``cpus_per_node`` for Parsl) and inherit ``from_cluster()`` without
+    writing any additional code.
 
     Parameters
     ----------
@@ -126,7 +127,7 @@ class BaseSlurmConfig(BaseModel):
         min_cpus: int = 1,
         min_mem_gb: int = 1,
         **extra_fields: Any,
-    ) -> "BaseSlurmConfig":
+    ) -> Self:
         """Create an instance with SLURM fields auto-populated from the cluster.
 
         Three-tier precedence (highest wins):
@@ -294,7 +295,7 @@ class SlurmConfig(BaseSlurmConfig):
         return normalize_slurm_time(v)
 
     @classmethod
-    def from_yaml(cls, path: Path) -> "SlurmConfig":
+    def from_yaml(cls, path: Path | str) -> "SlurmConfig":
         """Load a ``SlurmConfig`` from a YAML file.
 
         Parameters

--- a/mdfactory/performance/slurm_config.py
+++ b/mdfactory/performance/slurm_config.py
@@ -1,0 +1,340 @@
+# ABOUTME: SLURM configuration models shared across all submission backends.
+# ABOUTME: BaseSlurmConfig with 3-tier autodiscovery; SlurmConfig for submitit analysis jobs.
+"""SLURM configuration models for all submission backends.
+
+Provides a shared ``BaseSlurmConfig`` Pydantic model with four cross-cutting
+SLURM fields (``account``, ``partition``, ``qos``, ``constraint``) and a single
+authoritative ``from_cluster()`` factory that implements three-tier precedence:
+
+1. Explicit keyword arguments passed by the caller
+2. ``[slurm]`` section in ``config.ini``
+3. Live ``sinfo`` / ``sacctmgr`` autodiscovery via ``mdfactory.performance.cluster``
+
+Subclasses add backend-specific fields and inherit ``from_cluster()`` for free.
+
+Classes
+-------
+BaseSlurmConfig
+    Abstract base for all SLURM-facing config objects.
+SlurmConfig
+    Configuration for submitit-based analysis submission.
+
+Functions
+---------
+normalize_slurm_time
+    Convert human-friendly time strings (``"2h"``, ``"30m"``) to
+    ``HH:MM:SS`` / ``D-HH:MM:SS`` format accepted by SLURM.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def normalize_slurm_time(value: str) -> str:
+    """Normalize SLURM time strings to ``HH:MM:SS`` or ``D-HH:MM:SS`` format.
+
+    Accepts human-friendly shorthand as well as all canonical SLURM formats.
+
+    Parameters
+    ----------
+    value : str
+        Raw time string, e.g. ``"2h"``, ``"30m"``, ``"90"`` (minutes),
+        ``"1d"``, ``"01:00:00"``, ``"3-00:00:00"``.
+
+    Returns
+    -------
+    str
+        Normalized time string.  Strings that already contain ``:`` are
+        returned unchanged (pass-through for HH:MM:SS / D-HH:MM:SS).
+
+    Examples
+    --------
+    >>> normalize_slurm_time("2h")
+    '02:00:00'
+    >>> normalize_slurm_time("30m")
+    '00:30:00'
+    >>> normalize_slurm_time("90")
+    '01:30:00'
+    >>> normalize_slurm_time("1d")
+    '1-00:00:00'
+    >>> normalize_slurm_time("01:00:00")
+    '01:00:00'
+    """
+    raw = value.strip()
+    if ":" in raw:
+        return raw
+    lowered = raw.lower()
+    if lowered.endswith("d"):
+        days = int(lowered[:-1])
+        return f"{days}-00:00:00"
+    if lowered.endswith("h"):
+        hours = int(lowered[:-1])
+        return f"{hours:02d}:00:00"
+    if lowered.endswith("m"):
+        minutes = int(lowered[:-1])
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours:02d}:{minutes:02d}:00"
+    if lowered.isdigit():
+        minutes = int(lowered)
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours:02d}:{minutes:02d}:00"
+    return raw
+
+
+class BaseSlurmConfig(BaseModel):
+    """SLURM resource specification shared by all submission backends.
+
+    Owns the four cross-cutting SLURM fields and the single authoritative
+    ``from_cluster()`` factory method.  Subclasses add backend-specific
+    fields (e.g. ``cpus_per_task`` for submitit, ``cpus_per_node`` for Parsl)
+    and inherit ``from_cluster()`` without writing any additional code.
+
+    Parameters
+    ----------
+    account : str
+        SLURM account string (``--account``).
+    partition : str
+        SLURM partition name (``--partition``).  Defaults to ``"cpu"``.
+    qos : str or None
+        Quality-of-service policy name (``--qos``).  ``None`` lets SLURM
+        apply its own default.
+    constraint : str or None
+        Node feature constraint string (``--constraint``).
+
+    Notes
+    -----
+    This model is *frozen*: instances are immutable after construction.
+    Use Pydantic's ``model_copy(update={...})`` to derive a modified copy.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    account: str
+    partition: str = "cpu"
+    qos: str | None = None
+    constraint: str | None = None
+
+    @classmethod
+    def from_cluster(
+        cls,
+        *,
+        needs_gpu: bool = False,
+        min_cpus: int = 1,
+        min_mem_gb: int = 1,
+        **extra_fields: Any,
+    ) -> "BaseSlurmConfig":
+        """Create an instance with SLURM fields auto-populated from the cluster.
+
+        Three-tier precedence (highest wins):
+
+        1. Explicit keyword arguments passed by the caller (e.g.
+           ``account="mygroup"`` or ``partition="gpu"``).
+        2. ``[slurm]`` section in ``config.ini`` — read via
+           ``mdfactory.settings.settings``.
+        3. Live ``sinfo`` / ``sacctmgr`` autodiscovery via
+           ``mdfactory.performance.cluster``.
+
+        The lazy import of ``mdfactory.performance.cluster`` keeps this
+        module importable on non-SLURM machines.
+
+        Parameters
+        ----------
+        needs_gpu : bool
+            Select a GPU-capable partition when ``True``.  Used both for
+            partition autodiscovery and for choosing the correct
+            ``PARTITION_GPU`` config key.
+        min_cpus : int
+            Minimum CPUs per node required (passed to ``select_partition()``).
+        min_mem_gb : int
+            Minimum memory per node in GB (passed to ``select_partition()``).
+        **extra_fields
+            Backend-specific fields forwarded to the subclass constructor.
+            For ``SlurmConfig``: ``time``, ``cpus_per_task``, ``mem_gb``,
+            ``job_name_prefix``.
+            Base-class fields (``account``, ``partition``, ``qos``,
+            ``constraint``) may also be passed here to override autodiscovery.
+
+        Returns
+        -------
+        BaseSlurmConfig
+            A fully initialised subclass instance (the concrete type is
+            determined by ``cls``).
+
+        Raises
+        ------
+        RuntimeError
+            If SLURM is unavailable *and* the required ``account`` or
+            ``partition`` value cannot be resolved from config.
+        """
+        from mdfactory.performance.cluster import discover_cluster, select_partition
+        from mdfactory.settings import settings
+
+        cluster = discover_cluster()
+
+        # --- account: explicit kwarg > config.ini > autodiscovery ---
+        resolved_account: str | None = extra_fields.pop("account", None)
+        if resolved_account is None:
+            resolved_account = settings.slurm_account
+        if resolved_account is None:
+            if cluster is None:
+                raise RuntimeError(
+                    "SLURM autodiscovery failed and no account configured. "
+                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
+                )
+            resolved_account = cluster.default_account
+            if resolved_account is None:
+                raise RuntimeError(
+                    "No SLURM account available. "
+                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
+                )
+
+        # --- partition: explicit kwarg > config.ini (cpu/gpu) > autodiscovery ---
+        resolved_partition: str | None = extra_fields.pop("partition", None)
+        if resolved_partition is None:
+            resolved_partition = (
+                settings.slurm_partition_gpu
+                if needs_gpu
+                else settings.slurm_partition_cpu
+            )
+        if resolved_partition is None:
+            if cluster is None:
+                raise RuntimeError(
+                    "SLURM autodiscovery failed and no partition configured. "
+                    "Set [slurm] PARTITION_CPU or PARTITION_GPU in config.ini "
+                    "or pass partition= explicitly."
+                )
+            selected = select_partition(
+                cluster,
+                needs_gpu=needs_gpu,
+                min_cpus=min_cpus,
+                min_mem_gb=min_mem_gb,
+            )
+            if selected is None:
+                raise RuntimeError(
+                    f"No suitable partition found for requirements: "
+                    f"needs_gpu={needs_gpu}, cpus={min_cpus}, mem={min_mem_gb}GB"
+                )
+            resolved_partition = selected.name
+
+        # --- qos: explicit kwarg > config.ini ---
+        resolved_qos: str | None = extra_fields.pop("qos", None)
+        if resolved_qos is None:
+            resolved_qos = settings.slurm_qos
+
+        # --- constraint: explicit kwarg only (no config.ini equivalent) ---
+        resolved_constraint: str | None = extra_fields.pop("constraint", None)
+
+        return cls(
+            account=resolved_account,
+            partition=resolved_partition,
+            qos=resolved_qos,
+            constraint=resolved_constraint,
+            **extra_fields,
+        )
+
+
+class SlurmConfig(BaseSlurmConfig):
+    """SLURM configuration for submitit-based analysis submission.
+
+    Backend: submitit — one SLURM job per analysis task.
+
+    The ``time`` field is normalised on construction via
+    ``normalize_slurm_time()``, so ``"2h"``, ``"120"`` (minutes), and
+    ``"02:00:00"`` are all accepted and stored as ``"02:00:00"``.
+
+    Parameters
+    ----------
+    account : str
+        SLURM account (inherited from ``BaseSlurmConfig``).
+    partition : str
+        SLURM partition (inherited).  Defaults to ``"cpu"``.
+    qos : str or None
+        QOS policy (inherited).
+    constraint : str or None
+        Node constraint (inherited).
+    time : str
+        Job time limit.  Maps to SLURM ``--time``.
+        Accepts human-friendly strings (``"2h"``, ``"30m"``, ``"1d"``) as
+        well as ``MM``, ``HH:MM:SS``, and ``D-HH:MM:SS`` formats.
+    cpus_per_task : int
+        CPUs allocated per task.  Maps to SLURM ``--cpus-per-task``.
+        **Not** the same as ``--cpus-per-node`` used by Parsl executor configs.
+    mem_gb : int
+        Memory per task in gigabytes.  Maps to SLURM ``--mem``.
+    job_name_prefix : str
+        Prefix for SLURM job names submitted via submitit.
+
+    Examples
+    --------
+    Minimal construction (explicit account):
+
+    >>> cfg = SlurmConfig(account="mygroup")
+    >>> cfg.time
+    '02:00:00'
+
+    Autodiscovery on a SLURM cluster:
+
+    >>> cfg = SlurmConfig.from_cluster(time="4h", cpus_per_task=8, mem_gb=16)
+    """
+
+    time: str = Field(default="2h", validate_default=True)
+    cpus_per_task: int = 4
+    """Maps to SLURM ``--cpus-per-task`` (NOT ``--cpus-per-node``)."""
+    mem_gb: int = 8
+    job_name_prefix: str = "mdfactory-analysis"
+
+    @field_validator("time", mode="before")
+    @classmethod
+    def _normalize_time(cls, v: str) -> str:
+        """Normalize time string on construction."""
+        return normalize_slurm_time(v)
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "SlurmConfig":
+        """Load a ``SlurmConfig`` from a YAML file.
+
+        Parameters
+        ----------
+        path : Path
+            Path to a YAML file whose top-level keys match ``SlurmConfig``
+            field names.
+
+        Returns
+        -------
+        SlurmConfig
+            Loaded and validated instance.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the YAML file does not exist.
+        pydantic.ValidationError
+            If the YAML content fails validation.
+
+        Examples
+        --------
+        .. code-block:: yaml
+
+           # slurm.yaml
+           account: mygroup
+           partition: cpu
+           time: 4h
+           cpus_per_task: 8
+           mem_gb: 16
+
+        >>> cfg = SlurmConfig.from_yaml(Path("slurm.yaml"))
+        >>> cfg.time
+        '04:00:00'
+        """
+        import yaml
+
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"SLURM config YAML not found: {path}")
+        with path.open() as fh:
+            data = yaml.safe_load(fh)
+        return cls.model_validate(data or {})

--- a/mdfactory/performance/slurm_config.py
+++ b/mdfactory/performance/slurm_config.py
@@ -197,9 +197,7 @@ class BaseSlurmConfig(BaseModel):
         resolved_partition: str | None = extra_fields.pop("partition", None)
         if resolved_partition is None:
             resolved_partition = (
-                settings.slurm_partition_gpu
-                if needs_gpu
-                else settings.slurm_partition_cpu
+                settings.slurm_partition_gpu if needs_gpu else settings.slurm_partition_cpu
             )
         if resolved_partition is None:
             if cluster is None:

--- a/mdfactory/settings.py
+++ b/mdfactory/settings.py
@@ -72,8 +72,9 @@ class Settings:
             },
             "slurm": {
                 "ACCOUNT": "",
-                "PARTITION": "",
-                "QOS": "",
+                "PARTITION_CPU": "",
+                "PARTITION_GPU": "",
+                "DEFAULT_QOS": "",
             },
         }
 
@@ -103,8 +104,9 @@ class Settings:
         },
         "slurm": {
             "ACCOUNT": "",
-            "PARTITION": "",
-            "QOS": "",
+            "PARTITION_CPU": "",
+            "PARTITION_GPU": "",
+            "DEFAULT_QOS": "",
         },
     }
 
@@ -331,15 +333,32 @@ class Settings:
         return val if val else None
 
     @property
-    def slurm_partition(self) -> str | None:
-        """Return configured SLURM partition, or None if not set."""
-        val = self.config.get("slurm", "PARTITION", fallback="").strip()
+    def slurm_partition_cpu(self) -> str | None:
+        """Return configured CPU partition name, or None if not set.
+
+        Maps to ``[slurm] PARTITION_CPU`` in config.ini.
+        Used by ``BaseSlurmConfig.from_cluster()`` when ``needs_gpu=False``.
+        """
+        val = self.config.get("slurm", "PARTITION_CPU", fallback="").strip()
+        return val if val else None
+
+    @property
+    def slurm_partition_gpu(self) -> str | None:
+        """Return configured GPU partition name, or None if not set.
+
+        Maps to ``[slurm] PARTITION_GPU`` in config.ini.
+        Used by ``BaseSlurmConfig.from_cluster()`` when ``needs_gpu=True``.
+        """
+        val = self.config.get("slurm", "PARTITION_GPU", fallback="").strip()
         return val if val else None
 
     @property
     def slurm_qos(self) -> str | None:
-        """Return configured SLURM QOS, or None if not set."""
-        val = self.config.get("slurm", "QOS", fallback="").strip()
+        """Return configured SLURM default QOS, or None if not set.
+
+        Maps to ``[slurm] DEFAULT_QOS`` in config.ini.
+        """
+        val = self.config.get("slurm", "DEFAULT_QOS", fallback="").strip()
         return val if val else None
 
 

--- a/mdfactory/settings.py
+++ b/mdfactory/settings.py
@@ -70,6 +70,11 @@ class Settings:
                 "ANALYSIS_DB_PATH": "/Group Functions/mdfactory/analysis",
                 "ARTIFACT_DB_PATH": "/Group Functions/mdfactory/artifacts",
             },
+            "slurm": {
+                "ACCOUNT": "",
+                "PARTITION": "",
+                "QOS": "",
+            },
         }
 
     # Keep DEFAULT_CONFIG as class attribute for backward compat in tests
@@ -95,6 +100,11 @@ class Settings:
             "RUN_DB_PATH": "/Group Functions/mdfactory/runs",
             "ANALYSIS_DB_PATH": "/Group Functions/mdfactory/analysis",
             "ARTIFACT_DB_PATH": "/Group Functions/mdfactory/artifacts",
+        },
+        "slurm": {
+            "ACCOUNT": "",
+            "PARTITION": "",
+            "QOS": "",
         },
     }
 
@@ -311,6 +321,26 @@ class Settings:
         path_key = db_mapping.get(db_name, db_name)
         raw_path = self.config["csv"].get(path_key, "")
         return self._resolve_local_path(raw_path)
+
+    # --- SLURM properties ---
+
+    @property
+    def slurm_account(self) -> str | None:
+        """Return configured SLURM account, or None if not set."""
+        val = self.config.get("slurm", "ACCOUNT", fallback="").strip()
+        return val if val else None
+
+    @property
+    def slurm_partition(self) -> str | None:
+        """Return configured SLURM partition, or None if not set."""
+        val = self.config.get("slurm", "PARTITION", fallback="").strip()
+        return val if val else None
+
+    @property
+    def slurm_qos(self) -> str | None:
+        """Return configured SLURM QOS, or None if not set."""
+        val = self.config.get("slurm", "QOS", fallback="").strip()
+        return val if val else None
 
 
 # Module-level singleton

--- a/mdfactory/tests/test_cli_cluster.py
+++ b/mdfactory/tests/test_cli_cluster.py
@@ -1,11 +1,18 @@
 # ABOUTME: Tests for the `mdfactory config cluster` CLI command, verifying
 # ABOUTME: SLURM autodiscovery output in human-readable and JSON formats.
-"""Tests for mdfactory config cluster CLI command."""
+# ABOUTME: Also covers the SLURM config-building glue in analysis_run / analysis_artifacts_run.
+"""Tests for mdfactory config cluster CLI command and analysis SLURM glue."""
 
 import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
 
 from mdfactory import cli
 from mdfactory.performance import cluster as cluster_mod
+from mdfactory.performance.slurm_config import SlurmConfig
 
 
 class TestConfigClusterCommand:
@@ -155,3 +162,159 @@ class TestConfigClusterCommand:
         captured = capsys.readouterr()
         assert "maintenance" in captured.out
         assert "[drained]" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by analysis_run / analysis_artifacts_run glue tests
+# ---------------------------------------------------------------------------
+
+_FAKE_CFG = SlurmConfig(account="auto-account", partition="auto-part")
+_EMPTY_DF = pd.DataFrame()
+
+
+@pytest.fixture()
+def fake_sim_paths(tmp_path: Path) -> list[Path]:
+    """Return a non-empty list of paths without touching the filesystem."""
+    return [tmp_path / "sim1"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: analysis_run SLURM config-building glue
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisRunSlurmGlue:
+    """Tests for the autodiscovery glue inside analysis_run (--slurm mode)."""
+
+    def test_autodiscovery_used_when_no_account(self, monkeypatch, fake_sim_paths):
+        """account=None triggers SlurmConfig.from_cluster(); result is forwarded."""
+        captured = {}
+
+        def fake_submit(sim_paths, analysis_names, *, slurm, **kwargs):
+            captured["slurm"] = slurm
+            return _EMPTY_DF
+
+        with (
+            patch("mdfactory.cli._resolve_sim_paths", return_value=fake_sim_paths),
+            patch("mdfactory.cli.SlurmConfig.from_cluster", return_value=_FAKE_CFG) as mock_fc,
+            patch("mdfactory.cli.submit_analyses_slurm", side_effect=fake_submit),
+            patch("mdfactory.cli.determine_log_dir", return_value=fake_sim_paths[0].parent),
+        ):
+            cli.analysis_run(
+                source=fake_sim_paths[0].parent,
+                slurm=True,
+                account=None,
+            )
+
+        mock_fc.assert_called_once()
+        assert captured["slurm"] is _FAKE_CFG
+
+    def test_autodiscovery_error_reraised_as_value_error(self, monkeypatch, fake_sim_paths):
+        """RuntimeError from from_cluster() is re-raised as ValueError with guidance."""
+        with (
+            patch("mdfactory.cli._resolve_sim_paths", return_value=fake_sim_paths),
+            patch(
+                "mdfactory.cli.SlurmConfig.from_cluster",
+                side_effect=RuntimeError("no account"),
+            ),
+        ):
+            with pytest.raises(ValueError, match="Please specify --account explicitly"):
+                cli.analysis_run(
+                    source=fake_sim_paths[0].parent,
+                    slurm=True,
+                    account=None,
+                )
+
+    def test_explicit_account_skips_autodiscovery(self, monkeypatch, fake_sim_paths):
+        """When account is provided, from_cluster() is never called."""
+        captured = {}
+
+        def fake_submit(sim_paths, analysis_names, *, slurm, **kwargs):
+            captured["slurm"] = slurm
+            return _EMPTY_DF
+
+        with (
+            patch("mdfactory.cli._resolve_sim_paths", return_value=fake_sim_paths),
+            patch("mdfactory.cli.SlurmConfig.from_cluster") as mock_fc,
+            patch("mdfactory.cli.submit_analyses_slurm", side_effect=fake_submit),
+            patch("mdfactory.cli.determine_log_dir", return_value=fake_sim_paths[0].parent),
+        ):
+            cli.analysis_run(
+                source=fake_sim_paths[0].parent,
+                slurm=True,
+                account="explicit-account",
+            )
+
+        mock_fc.assert_not_called()
+        assert captured["slurm"].account == "explicit-account"
+
+
+# ---------------------------------------------------------------------------
+# Tests: analysis_artifacts_run SLURM config-building glue
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisArtifactsRunSlurmGlue:
+    """Tests for the autodiscovery glue inside analysis_artifacts_run (--slurm mode)."""
+
+    def test_autodiscovery_used_when_no_account(self, monkeypatch, fake_sim_paths):
+        """account=None triggers SlurmConfig.from_cluster(); result is forwarded."""
+        captured = {}
+
+        def fake_submit(sim_paths, artifact_names, *, slurm, **kwargs):
+            captured["slurm"] = slurm
+            return _EMPTY_DF
+
+        with (
+            patch("mdfactory.cli._resolve_sim_paths", return_value=fake_sim_paths),
+            patch("mdfactory.cli.SlurmConfig.from_cluster", return_value=_FAKE_CFG) as mock_fc,
+            patch("mdfactory.cli.submit_artifacts_slurm", side_effect=fake_submit),
+            patch("mdfactory.cli.determine_log_dir", return_value=fake_sim_paths[0].parent),
+        ):
+            cli.analysis_artifacts_run(
+                source=fake_sim_paths[0].parent,
+                slurm=True,
+                account=None,
+            )
+
+        mock_fc.assert_called_once()
+        assert captured["slurm"] is _FAKE_CFG
+
+    def test_autodiscovery_error_reraised_as_value_error(self, monkeypatch, fake_sim_paths):
+        """RuntimeError from from_cluster() is re-raised as ValueError with guidance."""
+        with (
+            patch("mdfactory.cli._resolve_sim_paths", return_value=fake_sim_paths),
+            patch(
+                "mdfactory.cli.SlurmConfig.from_cluster",
+                side_effect=RuntimeError("no account"),
+            ),
+        ):
+            with pytest.raises(ValueError, match="Please specify --account explicitly"):
+                cli.analysis_artifacts_run(
+                    source=fake_sim_paths[0].parent,
+                    slurm=True,
+                    account=None,
+                )
+
+    def test_explicit_account_skips_autodiscovery(self, monkeypatch, fake_sim_paths):
+        """When account is provided, from_cluster() is never called."""
+        captured = {}
+
+        def fake_submit(sim_paths, artifact_names, *, slurm, **kwargs):
+            captured["slurm"] = slurm
+            return _EMPTY_DF
+
+        with (
+            patch("mdfactory.cli._resolve_sim_paths", return_value=fake_sim_paths),
+            patch("mdfactory.cli.SlurmConfig.from_cluster") as mock_fc,
+            patch("mdfactory.cli.submit_artifacts_slurm", side_effect=fake_submit),
+            patch("mdfactory.cli.determine_log_dir", return_value=fake_sim_paths[0].parent),
+        ):
+            cli.analysis_artifacts_run(
+                source=fake_sim_paths[0].parent,
+                slurm=True,
+                account="explicit-account",
+            )
+
+        mock_fc.assert_not_called()
+        assert captured["slurm"].account == "explicit-account"

--- a/mdfactory/tests/test_cli_cluster.py
+++ b/mdfactory/tests/test_cli_cluster.py
@@ -1,0 +1,157 @@
+# ABOUTME: Tests for the `mdfactory config cluster` CLI command, verifying
+# ABOUTME: SLURM autodiscovery output in human-readable and JSON formats.
+"""Tests for mdfactory config cluster CLI command."""
+
+import json
+
+from mdfactory import cli
+from mdfactory.performance import cluster as cluster_mod
+
+
+class TestConfigClusterCommand:
+    """Tests for the config cluster CLI command."""
+
+    def test_config_cluster_no_slurm(self, monkeypatch, capsys):
+        """Test graceful message when SLURM is not available."""
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+
+        cli.config_cluster(json_output=False)
+
+        captured = capsys.readouterr()
+        assert "SLURM cluster not detected" in captured.out
+        assert "login node" in captured.out
+
+    def test_config_cluster_no_slurm_json(self, monkeypatch, capsys):
+        """Test JSON output when SLURM is not available."""
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+
+        cli.config_cluster(json_output=True)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["cluster"] is None
+        assert "error" in data
+
+    def test_config_cluster_with_slurm(self, monkeypatch, capsys):
+        """Test human-readable output with SLURM cluster."""
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="7-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpu_specs=(), count=100),
+            ],
+            total_nodes=100,
+            is_default=True,
+        )
+        gpu_partition = cluster_mod.Partition(
+            name="gpu",
+            state="up",
+            max_time="2-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(
+                    cpus=32, memory_mb=128 * 1024, gpu_specs=((4, "a100"),), count=20
+                ),
+            ],
+            total_nodes=20,
+            is_default=False,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition, gpu_partition],
+            accounts=["myaccount", "shared"],
+            qos_policies=["normal", "high"],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        cli.config_cluster(json_output=False)
+
+        captured = capsys.readouterr()
+        assert "SLURM Cluster Information" in captured.out
+        assert "Default Account: myaccount" in captured.out
+        assert "compute" in captured.out
+        assert "(default)" in captured.out
+        assert "gpu" in captured.out
+        assert "a100" in captured.out
+        assert "64 CPUs" in captured.out
+        assert "4x a100" in captured.out
+
+    def test_config_cluster_with_slurm_json(self, monkeypatch, capsys):
+        """Test JSON output with SLURM cluster."""
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="7-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(
+                    cpus=64,
+                    memory_mb=256 * 1024,
+                    gpu_specs=(),
+                    features=("avx512", "intel"),
+                    count=100,
+                ),
+            ],
+            total_nodes=100,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=["normal"],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        cli.config_cluster(json_output=True)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert data["default_account"] == "myaccount"
+        assert data["accounts"] == ["myaccount"]
+        assert data["qos_policies"] == ["normal"]
+        assert len(data["partitions"]) == 1
+
+        part = data["partitions"][0]
+        assert part["name"] == "compute"
+        assert part["is_default"] is True
+        assert part["total_nodes"] == 100
+        assert len(part["node_types"]) == 1
+
+        nt = part["node_types"][0]
+        assert nt["cpus"] == 64
+        assert nt["memory_mb"] == 256 * 1024
+        assert nt["gpu_specs"] == []  # No GPUs
+        assert nt["features"] == ["avx512", "intel"]
+        assert nt["count"] == 100
+
+    def test_config_cluster_down_partition(self, monkeypatch, capsys):
+        """Test display of partition with down state."""
+        mock_partition = cluster_mod.Partition(
+            name="maintenance",
+            state="drained",
+            max_time="1:00:00",
+            default_time="0:30:00",
+            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=32 * 1024, count=5)],
+            total_nodes=5,
+            is_default=False,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        cli.config_cluster(json_output=False)
+
+        captured = capsys.readouterr()
+        assert "maintenance" in captured.out
+        assert "[drained]" in captured.out

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -93,25 +93,37 @@ class TestParseGres:
     """Test GPU GRES string parsing."""
 
     def test_gpu_with_type_and_count(self):
-        assert _parse_gres("gpu:a100:4") == (4, "a100")
+        assert _parse_gres("gpu:a100:4") == [(4, "a100")]
 
     def test_gpu_with_count_only(self):
-        assert _parse_gres("gpu:2") == (2, None)
+        assert _parse_gres("gpu:2") == [(2, None)]
 
     def test_gpu_with_type_only(self):
-        assert _parse_gres("gpu:h100") == (1, "h100")
+        assert _parse_gres("gpu:h100") == [(1, "h100")]
 
     def test_null_gres(self):
-        assert _parse_gres("(null)") == (0, None)
+        assert _parse_gres("(null)") == []
 
     def test_empty_string(self):
-        assert _parse_gres("") == (0, None)
+        assert _parse_gres("") == []
 
     def test_multi_gres_with_gpu(self):
-        assert _parse_gres("mps:shared,gpu:a100:4") == (4, "a100")
+        assert _parse_gres("mps:shared,gpu:a100:4") == [(4, "a100")]
 
     def test_non_gpu_gres(self):
-        assert _parse_gres("mps:shared") == (0, None)
+        assert _parse_gres("mps:shared") == []
+
+    def test_multiple_gpu_types(self):
+        """Test multiple GPU entries (e.g., MIG slices)."""
+        result = _parse_gres("gpu:b200:7,gpu:1g.23gb:7")
+        assert len(result) == 2
+        assert (7, "1g.23gb") in result
+        assert (7, "b200") in result
+
+    def test_socket_binding_stripped(self):
+        """Test that socket binding suffixes are removed."""
+        assert _parse_gres("gpu:l40s:4(S:0-1)") == [(4, "l40s")]
+        assert _parse_gres("gpu:b200:8(S:0-1),gpu:1g.23gb:7(S:1)") == [(8, "b200"), (7, "1g.23gb")]
 
 
 # ---------------------------------------------------------------------------
@@ -155,9 +167,9 @@ class TestParseSinfo:
         nt = cpu_part.node_types[0]
         assert nt.cpus == 128
         assert nt.memory_mb == 512000
-        assert nt.gpus == 0
-        assert nt.gpu_type is None
+        assert nt.gpu_specs == ()  # No GPUs
         assert "epyc9555" in nt.features
+        assert nt.count == 3  # 3 nodes with this config
 
     def test_gpu_partition_multiple_node_types(self):
         partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
@@ -166,13 +178,15 @@ class TestParseSinfo:
         # 2 distinct node types: a100 (64 core) and h100 (96 core)
         assert len(gpu_part.node_types) == 2
 
-        a100_node = next(n for n in gpu_part.node_types if n.gpu_type == "a100")
+        a100_node = next(n for n in gpu_part.node_types if (4, "a100") in n.gpu_specs)
         assert a100_node.cpus == 64
-        assert a100_node.gpus == 4
+        assert a100_node.gpu_specs == ((4, "a100"),)
+        assert a100_node.count == 2  # 2 a100 nodes
 
-        h100_node = next(n for n in gpu_part.node_types if n.gpu_type == "h100")
+        h100_node = next(n for n in gpu_part.node_types if (8, "h100") in n.gpu_specs)
         assert h100_node.cpus == 96
-        assert h100_node.gpus == 8
+        assert h100_node.gpu_specs == ((8, "h100"),)
+        assert h100_node.count == 1  # 1 h100 node
 
     def test_total_node_count(self):
         partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
@@ -201,8 +215,7 @@ class TestParseSinfo:
         partitions = _parse_sinfo(SINFO_OUTPUT_NO_TYPE_GPU)
         assert len(partitions) == 1
         nt = partitions[0].node_types[0]
-        assert nt.gpus == 4
-        assert nt.gpu_type is None
+        assert nt.gpu_specs == ((4, None),)  # 4 GPUs, no type specified
 
     def test_default_time_parsed_separately(self):
         partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
@@ -479,7 +492,7 @@ class TestDataclasses:
     """Test dataclass construction and immutability."""
 
     def test_node_type_frozen(self):
-        nt = NodeType(cpus=64, memory_mb=256000, gpus=4, gpu_type="a100")
+        nt = NodeType(cpus=64, memory_mb=256000, gpu_specs=((4, "a100"),), count=1)
         with pytest.raises(AttributeError):
             nt.cpus = 128  # type: ignore[misc]
 
@@ -495,12 +508,14 @@ class TestDataclasses:
 
     def test_node_type_defaults(self):
         nt = NodeType(cpus=32, memory_mb=64000)
-        assert nt.gpus == 0
-        assert nt.gpu_type is None
+        assert nt.gpu_specs == ()  # No GPUs by default
         assert nt.features == ()
+        assert nt.count == 1  # Default count
 
     def test_node_type_features_immutable(self):
-        nt = NodeType(cpus=64, memory_mb=256000, features=("a100", "nvlink"))
+        nt = NodeType(
+            cpus=64, memory_mb=256000, gpu_specs=((4, "a100"),), features=("a100", "nvlink")
+        )
         assert nt.features == ("a100", "nvlink")
         with pytest.raises(TypeError):
             nt.features[0] = "other"  # type: ignore[index]

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -492,18 +492,24 @@ class TestDataclasses:
     """Test dataclass construction and immutability."""
 
     def test_node_type_frozen(self):
+        from pydantic import ValidationError
+
         nt = NodeType(cpus=64, memory_mb=256000, gpu_specs=((4, "a100"),), count=1)
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValidationError):
             nt.cpus = 128  # type: ignore[misc]
 
     def test_partition_frozen(self):
+        from pydantic import ValidationError
+
         p = Partition(name="test", state="up", max_time="1-00:00:00", default_time="1:00:00")
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValidationError):
             p.name = "other"  # type: ignore[misc]
 
     def test_cluster_info_frozen(self):
+        from pydantic import ValidationError
+
         ci = ClusterInfo()
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValidationError):
             ci.default_account = "hack"  # type: ignore[misc]
 
     def test_node_type_defaults(self):

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -17,7 +16,6 @@ from mdfactory.performance.cluster import (
     _parse_gres,
     _parse_qos,
     _parse_sinfo,
-    _run_command,
     discover_cluster,
     select_partition,
 )
@@ -314,16 +312,18 @@ class TestDiscoverCluster:
         assert result is None
 
     def test_returns_cluster_info_with_sinfo(self):
+        """Test full integration when SLURM commands return data."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        accounts = _parse_accounts(SACCTMGR_ACCOUNTS)
+        qos = _parse_qos(SACCTMGR_QOS)
+
         with (
             patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
+            patch("mdfactory.performance.cluster._discover_partitions", return_value=partitions),
+            patch("mdfactory.performance.cluster._discover_accounts", return_value=accounts),
+            patch("mdfactory.performance.cluster._discover_qos", return_value=qos),
             patch(
-                "mdfactory.performance.cluster._run_command",
-                side_effect=[
-                    SINFO_OUTPUT_MIXED,  # sinfo call
-                    SACCTMGR_ACCOUNTS,  # sacctmgr accounts
-                    SACCTMGR_QOS,  # sacctmgr qos
-                    "myproject",  # sacctmgr default account
-                ],
+                "mdfactory.performance.cluster._discover_default_account", return_value="myproject"
             ),
         ):
             result = discover_cluster()
@@ -337,17 +337,16 @@ class TestDiscoverCluster:
 
     def test_default_account_falls_back_to_first(self):
         """When default account query fails, fall back to first account."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        accounts = _parse_accounts(SACCTMGR_ACCOUNTS)
+        qos = _parse_qos(SACCTMGR_QOS)
+
         with (
             patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
-            patch(
-                "mdfactory.performance.cluster._run_command",
-                side_effect=[
-                    SINFO_OUTPUT_MIXED,  # sinfo call
-                    SACCTMGR_ACCOUNTS,  # sacctmgr accounts
-                    SACCTMGR_QOS,  # sacctmgr qos
-                    None,  # sacctmgr default account fails
-                ],
-            ),
+            patch("mdfactory.performance.cluster._discover_partitions", return_value=partitions),
+            patch("mdfactory.performance.cluster._discover_accounts", return_value=accounts),
+            patch("mdfactory.performance.cluster._discover_qos", return_value=qos),
+            patch("mdfactory.performance.cluster._discover_default_account", return_value=None),
         ):
             result = discover_cluster()
 
@@ -357,17 +356,14 @@ class TestDiscoverCluster:
 
     def test_graceful_without_sacctmgr(self):
         """When sacctmgr fails, still return partitions."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+
         with (
             patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
-            patch(
-                "mdfactory.performance.cluster._run_command",
-                side_effect=[
-                    SINFO_OUTPUT_MIXED,  # sinfo succeeds
-                    None,  # sacctmgr accounts fails
-                    None,  # sacctmgr qos fails
-                    None,  # sacctmgr default account fails
-                ],
-            ),
+            patch("mdfactory.performance.cluster._discover_partitions", return_value=partitions),
+            patch("mdfactory.performance.cluster._discover_accounts", return_value=None),
+            patch("mdfactory.performance.cluster._discover_qos", return_value=None),
+            patch("mdfactory.performance.cluster._discover_default_account", return_value=None),
         ):
             result = discover_cluster()
 
@@ -379,33 +375,29 @@ class TestDiscoverCluster:
 
     def test_caching(self):
         """Second call returns cached result without re-querying."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_SINGLE_PARTITION)
+
         with (
             patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
             patch(
-                "mdfactory.performance.cluster._run_command",
-                side_effect=[
-                    SINFO_OUTPUT_SINGLE_PARTITION,
-                    None,
-                    None,
-                    None,
-                ],
-            ) as mock_cmd,
+                "mdfactory.performance.cluster._discover_partitions", return_value=partitions
+            ) as mock_partitions,
+            patch("mdfactory.performance.cluster._discover_accounts", return_value=None),
+            patch("mdfactory.performance.cluster._discover_qos", return_value=None),
+            patch("mdfactory.performance.cluster._discover_default_account", return_value=None),
         ):
             result1 = discover_cluster()
             result2 = discover_cluster()
 
         assert result1 is result2
-        # _run_command called 4 times for 1 discover (sinfo, accounts, qos, default_account)
-        assert mock_cmd.call_count == 4
+        # _discover_partitions called only once due to caching
+        assert mock_partitions.call_count == 1
 
     def test_returns_none_when_sinfo_fails(self):
         """If sinfo exists but returns error, return None."""
         with (
             patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
-            patch(
-                "mdfactory.performance.cluster._run_command",
-                return_value=None,  # sinfo call fails
-            ),
+            patch("mdfactory.performance.cluster._discover_partitions", return_value=None),
         ):
             result = discover_cluster()
         assert result is None
@@ -532,48 +524,3 @@ class TestDataclasses:
         assert ci.accounts == []
         assert ci.qos_policies == []
         assert ci.default_account is None
-
-
-# ---------------------------------------------------------------------------
-# Tests: _run_command edge cases
-# ---------------------------------------------------------------------------
-
-
-class TestRunCommand:
-    """Test _run_command timeout and error handling."""
-
-    def test_returns_none_on_timeout(self):
-        with patch(
-            "mdfactory.performance.cluster.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd=["sinfo"], timeout=30),
-        ):
-            result = _run_command(["sinfo", "--version"])
-        assert result is None
-
-    def test_returns_none_on_file_not_found(self):
-        with patch(
-            "mdfactory.performance.cluster.subprocess.run",
-            side_effect=FileNotFoundError("No such file"),
-        ):
-            result = _run_command(["nonexistent_binary"])
-        assert result is None
-
-    def test_returns_none_on_nonzero_exit(self):
-        with patch(
-            "mdfactory.performance.cluster.subprocess.run",
-            return_value=subprocess.CompletedProcess(
-                args=["sinfo"], returncode=1, stdout="", stderr="error"
-            ),
-        ):
-            result = _run_command(["sinfo", "--bad-flag"])
-        assert result is None
-
-    def test_returns_stdout_on_success(self):
-        with patch(
-            "mdfactory.performance.cluster.subprocess.run",
-            return_value=subprocess.CompletedProcess(
-                args=["echo"], returncode=0, stdout="hello\n", stderr=""
-            ),
-        ):
-            result = _run_command(["echo", "hello"])
-        assert result == "hello"

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +17,7 @@ from mdfactory.performance.cluster import (
     _parse_gres,
     _parse_qos,
     _parse_sinfo,
+    _run_command,
     discover_cluster,
     select_partition,
 )
@@ -520,3 +522,48 @@ class TestDataclasses:
         assert ci.accounts == []
         assert ci.qos_policies == []
         assert ci.default_account is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _run_command edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommand:
+    """Test _run_command timeout and error handling."""
+
+    def test_returns_none_on_timeout(self):
+        with patch(
+            "mdfactory.performance.cluster.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["sinfo"], timeout=30),
+        ):
+            result = _run_command(["sinfo", "--version"])
+        assert result is None
+
+    def test_returns_none_on_file_not_found(self):
+        with patch(
+            "mdfactory.performance.cluster.subprocess.run",
+            side_effect=FileNotFoundError("No such file"),
+        ):
+            result = _run_command(["nonexistent_binary"])
+        assert result is None
+
+    def test_returns_none_on_nonzero_exit(self):
+        with patch(
+            "mdfactory.performance.cluster.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["sinfo"], returncode=1, stdout="", stderr="error"
+            ),
+        ):
+            result = _run_command(["sinfo", "--bad-flag"])
+        assert result is None
+
+    def test_returns_stdout_on_success(self):
+        with patch(
+            "mdfactory.performance.cluster.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["echo"], returncode=0, stdout="hello\n", stderr=""
+            ),
+        ):
+            result = _run_command(["echo", "hello"])
+        assert result == "hello"

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -14,6 +14,7 @@ from mdfactory.performance.cluster import (
     Partition,
     _parse_accounts,
     _parse_gres,
+    _parse_memory_mb,
     _parse_qos,
     _parse_sinfo,
     discover_cluster,
@@ -256,6 +257,10 @@ class TestParseSinfo:
         # Should still parse valid lines
         assert len(partitions) == 1
 
+    def test_memory_trailing_plus_stripped(self):
+        """SLURM reports '128000+' when memory varies across nodes in a partition."""
+        assert _parse_memory_mb("128000+") == 128000
+
 
 # ---------------------------------------------------------------------------
 # Tests: account / QOS parsing
@@ -473,6 +478,16 @@ class TestSelectPartition:
         cluster = ClusterInfo(partitions=partitions)
         result = select_partition(cluster)
         assert result is None
+
+    def test_node_count_tiebreak(self):
+        """When multiple partitions qualify, prefer the one with more nodes."""
+        # SINFO_OUTPUT_GPU_ONLY: gpu-short (2 nodes) vs gpu-long (1 node), neither default.
+        # sort key (not is_default, -total_nodes, name) should pick gpu-short.
+        partitions = _parse_sinfo(SINFO_OUTPUT_GPU_ONLY)
+        cluster = ClusterInfo(partitions=partitions)
+        result = select_partition(cluster, needs_gpu=True)
+        assert result is not None
+        assert result.name == "gpu-short"
 
 
 # ---------------------------------------------------------------------------

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -25,42 +25,49 @@ from mdfactory.performance.cluster import (
 # Fixtures: realistic sinfo / sacctmgr output
 # ---------------------------------------------------------------------------
 
+# 9-field format: Partition Node CPUs Mem GRES Features MaxTime DefTime State
 SINFO_OUTPUT_MIXED = """\
-cpu* node001 128 512000 (null) epyc9555,avx512 3-00:00:00 idle
-cpu* node002 128 512000 (null) epyc9555,avx512 3-00:00:00 mixed
-cpu* node003 128 512000 (null) epyc9555,avx512 3-00:00:00 allocated
-gpu node010 64 256000 gpu:a100:4 a100,nvlink 1-00:00:00 idle
-gpu node011 64 256000 gpu:a100:4 a100,nvlink 1-00:00:00 idle
-gpu node012 96 512000 gpu:h100:8 h100,nvlink 1-00:00:00 mixed
-bigmem node020 256 2048000 (null) bigmem,epyc 7-00:00:00 idle
+cpu* node001 128 512000 (null) epyc9555,avx512 3-00:00:00 1-00:00:00 idle
+cpu* node002 128 512000 (null) epyc9555,avx512 3-00:00:00 1-00:00:00 mixed
+cpu* node003 128 512000 (null) epyc9555,avx512 3-00:00:00 1-00:00:00 allocated
+gpu node010 64 256000 gpu:a100:4 a100,nvlink 1-00:00:00 4:00:00 idle
+gpu node011 64 256000 gpu:a100:4 a100,nvlink 1-00:00:00 4:00:00 idle
+gpu node012 96 512000 gpu:h100:8 h100,nvlink 1-00:00:00 4:00:00 mixed
+bigmem node020 256 2048000 (null) bigmem,epyc 7-00:00:00 1-00:00:00 idle
 """
 
 SINFO_OUTPUT_SINGLE_PARTITION = """\
-compute node001 64 128000 (null) (null) 2-00:00:00 idle
-compute node002 64 128000 (null) (null) 2-00:00:00 idle
+compute node001 64 128000 (null) (null) 2-00:00:00 1-00:00:00 idle
+compute node002 64 128000 (null) (null) 2-00:00:00 1-00:00:00 idle
 """
 
 SINFO_OUTPUT_GPU_ONLY = """\
-gpu-short node001 32 64000 gpu:v100:2 v100 4:00:00 idle
-gpu-short node002 32 64000 gpu:v100:2 v100 4:00:00 idle
-gpu-long node003 64 128000 gpu:a100:4 a100 2-00:00:00 idle
+gpu-short node001 32 64000 gpu:v100:2 v100 4:00:00 2:00:00 idle
+gpu-short node002 32 64000 gpu:v100:2 v100 4:00:00 2:00:00 idle
+gpu-long node003 64 128000 gpu:a100:4 a100 2-00:00:00 4:00:00 idle
 """
 
 SINFO_OUTPUT_NO_TYPE_GPU = """\
-gpu node001 64 256000 gpu:4 (null) 1-00:00:00 idle
+gpu node001 64 256000 gpu:4 (null) 1-00:00:00 4:00:00 idle
 """
 
 # First node drained, rest healthy → partition should be "up"
 SINFO_OUTPUT_MIXED_HEALTH = """\
-cpu node001 64 128000 (null) (null) 2-00:00:00 drained
-cpu node002 64 128000 (null) (null) 2-00:00:00 idle
-cpu node003 64 128000 (null) (null) 2-00:00:00 idle
+cpu node001 64 128000 (null) (null) 2-00:00:00 1-00:00:00 drained
+cpu node002 64 128000 (null) (null) 2-00:00:00 1-00:00:00 idle
+cpu node003 64 128000 (null) (null) 2-00:00:00 1-00:00:00 idle
 """
 
 # All nodes unhealthy → partition should report unhealthy state
 SINFO_OUTPUT_ALL_DOWN = """\
-cpu node001 64 128000 (null) (null) 2-00:00:00 down
-cpu node002 64 128000 (null) (null) 2-00:00:00 drained
+cpu node001 64 128000 (null) (null) 2-00:00:00 1-00:00:00 down
+cpu node002 64 128000 (null) (null) 2-00:00:00 1-00:00:00 drained
+"""
+
+# Legacy 8-field format (no %L default time) — backward compatibility
+SINFO_OUTPUT_LEGACY_8FIELD = """\
+compute node001 64 128000 (null) (null) 2-00:00:00 idle
+compute node002 64 128000 (null) (null) 2-00:00:00 idle
 """
 
 SACCTMGR_ACCOUNTS = """\
@@ -195,6 +202,24 @@ class TestParseSinfo:
         nt = partitions[0].node_types[0]
         assert nt.gpus == 4
         assert nt.gpu_type is None
+
+    def test_default_time_parsed_separately(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        cpu_part = next(p for p in partitions if p.name == "cpu")
+        assert cpu_part.max_time == "3-00:00:00"
+        assert cpu_part.default_time == "1-00:00:00"
+
+        gpu_part = next(p for p in partitions if p.name == "gpu")
+        assert gpu_part.max_time == "1-00:00:00"
+        assert gpu_part.default_time == "4:00:00"
+
+    def test_legacy_8field_format(self):
+        """Parser handles legacy 8-field sinfo output (no %L)."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_LEGACY_8FIELD)
+        assert len(partitions) == 1
+        assert partitions[0].name == "compute"
+        # default_time falls back to max_time
+        assert partitions[0].default_time == partitions[0].max_time
 
     def test_partition_state_up_when_any_node_healthy(self):
         """Partition with mixed healthy/unhealthy nodes should be 'up'."""

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -1,0 +1,433 @@
+# ABOUTME: Unit tests for mdfactory.performance.cluster (SLURM autodiscovery).
+# ABOUTME: Uses mocked sinfo/sacctmgr output — no SLURM required to run.
+"""Tests for SLURM cluster autodiscovery."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mdfactory.performance.cluster import (
+    ClusterInfo,
+    NodeType,
+    Partition,
+    _parse_accounts,
+    _parse_gres,
+    _parse_qos,
+    _parse_sinfo,
+    discover_cluster,
+    select_partition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic sinfo / sacctmgr output
+# ---------------------------------------------------------------------------
+
+SINFO_OUTPUT_MIXED = """\
+cpu* node001 128 512000 (null) epyc9555,avx512 3-00:00:00 idle
+cpu* node002 128 512000 (null) epyc9555,avx512 3-00:00:00 mixed
+cpu* node003 128 512000 (null) epyc9555,avx512 3-00:00:00 allocated
+gpu node010 64 256000 gpu:a100:4 a100,nvlink 1-00:00:00 idle
+gpu node011 64 256000 gpu:a100:4 a100,nvlink 1-00:00:00 idle
+gpu node012 96 512000 gpu:h100:8 h100,nvlink 1-00:00:00 mixed
+bigmem node020 256 2048000 (null) bigmem,epyc 7-00:00:00 idle
+"""
+
+SINFO_OUTPUT_SINGLE_PARTITION = """\
+compute node001 64 128000 (null) (null) 2-00:00:00 idle
+compute node002 64 128000 (null) (null) 2-00:00:00 idle
+"""
+
+SINFO_OUTPUT_GPU_ONLY = """\
+gpu-short node001 32 64000 gpu:v100:2 v100 4:00:00 idle
+gpu-short node002 32 64000 gpu:v100:2 v100 4:00:00 idle
+gpu-long node003 64 128000 gpu:a100:4 a100 2-00:00:00 idle
+"""
+
+SINFO_OUTPUT_NO_TYPE_GPU = """\
+gpu node001 64 256000 gpu:4 (null) 1-00:00:00 idle
+"""
+
+SACCTMGR_ACCOUNTS = """\
+myproject
+shared-account
+default-account
+"""
+
+SACCTMGR_QOS = """\
+normal||
+high|1-00:00:00|cpu=128,mem=512G
+gpu|12:00:00|cpu=64,gres/gpu=4
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: GRES parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseGres:
+    """Test GPU GRES string parsing."""
+
+    def test_gpu_with_type_and_count(self):
+        assert _parse_gres("gpu:a100:4") == (4, "a100")
+
+    def test_gpu_with_count_only(self):
+        assert _parse_gres("gpu:2") == (2, None)
+
+    def test_gpu_with_type_only(self):
+        assert _parse_gres("gpu:h100") == (1, "h100")
+
+    def test_null_gres(self):
+        assert _parse_gres("(null)") == (0, None)
+
+    def test_empty_string(self):
+        assert _parse_gres("") == (0, None)
+
+    def test_multi_gres_with_gpu(self):
+        assert _parse_gres("mps:shared,gpu:a100:4") == (4, "a100")
+
+    def test_non_gpu_gres(self):
+        assert _parse_gres("mps:shared") == (0, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: sinfo parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseSinfo:
+    """Test sinfo output parsing into Partition objects."""
+
+    def test_mixed_cluster(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+
+        # Should find 3 partitions
+        assert len(partitions) == 3
+        names = [p.name for p in partitions]
+        assert "cpu" in names
+        assert "gpu" in names
+        assert "bigmem" in names
+
+    def test_default_partition_marker(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+
+        cpu_part = next(p for p in partitions if p.name == "cpu")
+        assert cpu_part.is_default is True
+
+        gpu_part = next(p for p in partitions if p.name == "gpu")
+        assert gpu_part.is_default is False
+
+    def test_default_partition_sorted_first(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        assert partitions[0].name == "cpu"
+        assert partitions[0].is_default is True
+
+    def test_cpu_partition_node_types(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        cpu_part = next(p for p in partitions if p.name == "cpu")
+
+        # All 3 nodes have same spec → 1 unique node type
+        assert len(cpu_part.node_types) == 1
+        nt = cpu_part.node_types[0]
+        assert nt.cpus == 128
+        assert nt.memory_mb == 512000
+        assert nt.gpus == 0
+        assert nt.gpu_type is None
+        assert "epyc9555" in nt.features
+
+    def test_gpu_partition_multiple_node_types(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        gpu_part = next(p for p in partitions if p.name == "gpu")
+
+        # 2 distinct node types: a100 (64 core) and h100 (96 core)
+        assert len(gpu_part.node_types) == 2
+
+        a100_node = next(n for n in gpu_part.node_types if n.gpu_type == "a100")
+        assert a100_node.cpus == 64
+        assert a100_node.gpus == 4
+
+        h100_node = next(n for n in gpu_part.node_types if n.gpu_type == "h100")
+        assert h100_node.cpus == 96
+        assert h100_node.gpus == 8
+
+    def test_total_node_count(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+
+        cpu_part = next(p for p in partitions if p.name == "cpu")
+        assert cpu_part.total_nodes == 3
+
+        gpu_part = next(p for p in partitions if p.name == "gpu")
+        assert gpu_part.total_nodes == 3
+
+        bigmem_part = next(p for p in partitions if p.name == "bigmem")
+        assert bigmem_part.total_nodes == 1
+
+    def test_time_limit_parsed(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        cpu_part = next(p for p in partitions if p.name == "cpu")
+        assert cpu_part.max_time == "3-00:00:00"
+
+    def test_single_partition(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_SINGLE_PARTITION)
+        assert len(partitions) == 1
+        assert partitions[0].name == "compute"
+        assert partitions[0].total_nodes == 2
+
+    def test_gpu_without_type(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_NO_TYPE_GPU)
+        assert len(partitions) == 1
+        nt = partitions[0].node_types[0]
+        assert nt.gpus == 4
+        assert nt.gpu_type is None
+
+    def test_empty_output(self):
+        partitions = _parse_sinfo("")
+        assert partitions == []
+
+    def test_malformed_lines_skipped(self):
+        output = "this is not valid sinfo output\n" + SINFO_OUTPUT_SINGLE_PARTITION
+        partitions = _parse_sinfo(output)
+        # Should still parse valid lines
+        assert len(partitions) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: account / QOS parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseAccounts:
+    """Test sacctmgr account output parsing."""
+
+    def test_multiple_accounts(self):
+        accounts = _parse_accounts(SACCTMGR_ACCOUNTS)
+        assert accounts == ["default-account", "myproject", "shared-account"]
+
+    def test_empty_output(self):
+        assert _parse_accounts("") == []
+
+    def test_whitespace_handling(self):
+        assert _parse_accounts("  acc1  \n  acc2  \n") == ["acc1", "acc2"]
+
+    def test_deduplication(self):
+        assert _parse_accounts("acc1\nacc1\nacc2") == ["acc1", "acc2"]
+
+
+class TestParseQos:
+    """Test sacctmgr QOS output parsing."""
+
+    def test_multiple_qos(self):
+        qos = _parse_qos(SACCTMGR_QOS)
+        assert qos == ["gpu", "high", "normal"]
+
+    def test_empty_output(self):
+        assert _parse_qos("") == []
+
+    def test_pipe_separated_format(self):
+        qos = _parse_qos("standard|2-00:00:00|cpu=256\n")
+        assert qos == ["standard"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: discover_cluster integration (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverCluster:
+    """Test discover_cluster with mocked subprocess calls."""
+
+    def setup_method(self):
+        """Clear LRU cache between tests."""
+        discover_cluster.cache_clear()
+
+    def test_returns_none_without_sinfo(self):
+        with patch("mdfactory.performance.cluster.shutil.which", return_value=None):
+            result = discover_cluster()
+        assert result is None
+
+    def test_returns_cluster_info_with_sinfo(self):
+        with (
+            patch(
+                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
+            ),
+            patch(
+                "mdfactory.performance.cluster._run_command",
+                side_effect=[
+                    SINFO_OUTPUT_MIXED,  # sinfo call
+                    SACCTMGR_ACCOUNTS,  # sacctmgr accounts
+                    SACCTMGR_QOS,  # sacctmgr qos
+                ],
+            ),
+        ):
+            result = discover_cluster()
+
+        assert result is not None
+        assert isinstance(result, ClusterInfo)
+        assert len(result.partitions) == 3
+        assert len(result.accounts) == 3
+        assert len(result.qos_policies) == 3
+        assert result.default_account == "default-account"
+
+    def test_graceful_without_sacctmgr(self):
+        """When sacctmgr fails, still return partitions."""
+        with (
+            patch(
+                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
+            ),
+            patch(
+                "mdfactory.performance.cluster._run_command",
+                side_effect=[
+                    SINFO_OUTPUT_MIXED,  # sinfo succeeds
+                    None,  # sacctmgr accounts fails
+                    None,  # sacctmgr qos fails
+                ],
+            ),
+        ):
+            result = discover_cluster()
+
+        assert result is not None
+        assert len(result.partitions) == 3
+        assert result.accounts == []
+        assert result.qos_policies == []
+        assert result.default_account is None
+
+    def test_caching(self):
+        """Second call returns cached result without re-querying."""
+        with (
+            patch(
+                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
+            ),
+            patch(
+                "mdfactory.performance.cluster._run_command",
+                side_effect=[
+                    SINFO_OUTPUT_SINGLE_PARTITION,
+                    None,
+                    None,
+                ],
+            ) as mock_cmd,
+        ):
+            result1 = discover_cluster()
+            result2 = discover_cluster()
+
+        assert result1 is result2
+        # _run_command should only be called once (3 calls total for 1 discover)
+        assert mock_cmd.call_count == 3
+
+    def test_returns_none_when_sinfo_fails(self):
+        """If sinfo exists but returns error, return None."""
+        with (
+            patch(
+                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
+            ),
+            patch(
+                "mdfactory.performance.cluster._run_command",
+                return_value=None,  # sinfo call fails
+            ),
+        ):
+            result = discover_cluster()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: select_partition
+# ---------------------------------------------------------------------------
+
+
+class TestSelectPartition:
+    """Test heuristic partition selection."""
+
+    @pytest.fixture()
+    def cluster(self) -> ClusterInfo:
+        """Build a ClusterInfo from the mixed sinfo output."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
+        return ClusterInfo(
+            partitions=partitions,
+            accounts=["myproject"],
+            qos_policies=["normal"],
+            default_account="myproject",
+        )
+
+    def test_select_default_cpu_partition(self, cluster: ClusterInfo):
+        result = select_partition(cluster)
+        assert result is not None
+        assert result.name == "cpu"
+
+    def test_select_gpu_partition(self, cluster: ClusterInfo):
+        result = select_partition(cluster, needs_gpu=True)
+        assert result is not None
+        assert result.name == "gpu"
+
+    def test_select_with_high_cpu_requirement(self, cluster: ClusterInfo):
+        # Need 200+ CPUs → only bigmem (256) qualifies
+        result = select_partition(cluster, min_cpus=200)
+        assert result is not None
+        assert result.name == "bigmem"
+
+    def test_select_with_high_memory_requirement(self, cluster: ClusterInfo):
+        # Need 1TB+ → only bigmem qualifies
+        result = select_partition(cluster, min_mem_gb=1500)
+        assert result is not None
+        assert result.name == "bigmem"
+
+    def test_returns_none_when_impossible(self, cluster: ClusterInfo):
+        # Need 1000 CPUs — nobody has that
+        result = select_partition(cluster, min_cpus=1000)
+        assert result is None
+
+    def test_returns_none_gpu_when_no_gpu_partition(self):
+        partitions = _parse_sinfo(SINFO_OUTPUT_SINGLE_PARTITION)
+        cluster = ClusterInfo(partitions=partitions)
+        result = select_partition(cluster, needs_gpu=True)
+        assert result is None
+
+    def test_prefers_default_partition(self, cluster: ClusterInfo):
+        # Both cpu and bigmem meet min_cpus=1 — prefer cpu (default)
+        result = select_partition(cluster, min_cpus=1)
+        assert result is not None
+        assert result.name == "cpu"
+
+    def test_gpu_with_min_cpus(self, cluster: ClusterInfo):
+        # Need GPU + 90 CPUs → only h100 node qualifies (96 cpus)
+        result = select_partition(cluster, needs_gpu=True, min_cpus=90)
+        assert result is not None
+        assert result.name == "gpu"
+
+
+# ---------------------------------------------------------------------------
+# Tests: dataclass properties
+# ---------------------------------------------------------------------------
+
+
+class TestDataclasses:
+    """Test dataclass construction and immutability."""
+
+    def test_node_type_frozen(self):
+        nt = NodeType(cpus=64, memory_mb=256000, gpus=4, gpu_type="a100")
+        with pytest.raises(AttributeError):
+            nt.cpus = 128  # type: ignore[misc]
+
+    def test_partition_frozen(self):
+        p = Partition(name="test", state="up", max_time="1-00:00:00", default_time="1:00:00")
+        with pytest.raises(AttributeError):
+            p.name = "other"  # type: ignore[misc]
+
+    def test_cluster_info_frozen(self):
+        ci = ClusterInfo()
+        with pytest.raises(AttributeError):
+            ci.default_account = "hack"  # type: ignore[misc]
+
+    def test_node_type_defaults(self):
+        nt = NodeType(cpus=32, memory_mb=64000)
+        assert nt.gpus == 0
+        assert nt.gpu_type is None
+        assert nt.features == []
+
+    def test_cluster_info_defaults(self):
+        ci = ClusterInfo()
+        assert ci.partitions == []
+        assert ci.accounts == []
+        assert ci.qos_policies == []
+        assert ci.default_account is None

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -285,6 +285,7 @@ class TestDiscoverCluster:
                     SINFO_OUTPUT_MIXED,  # sinfo call
                     SACCTMGR_ACCOUNTS,  # sacctmgr accounts
                     SACCTMGR_QOS,  # sacctmgr qos
+                    "myproject",  # sacctmgr default account
                 ],
             ),
         ):
@@ -295,6 +296,28 @@ class TestDiscoverCluster:
         assert len(result.partitions) == 3
         assert len(result.accounts) == 3
         assert len(result.qos_policies) == 3
+        assert result.default_account == "myproject"
+
+    def test_default_account_falls_back_to_first(self):
+        """When default account query fails, fall back to first account."""
+        with (
+            patch(
+                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
+            ),
+            patch(
+                "mdfactory.performance.cluster._run_command",
+                side_effect=[
+                    SINFO_OUTPUT_MIXED,  # sinfo call
+                    SACCTMGR_ACCOUNTS,  # sacctmgr accounts
+                    SACCTMGR_QOS,  # sacctmgr qos
+                    None,  # sacctmgr default account fails
+                ],
+            ),
+        ):
+            result = discover_cluster()
+
+        assert result is not None
+        # Falls back to first alphabetical account
         assert result.default_account == "default-account"
 
     def test_graceful_without_sacctmgr(self):
@@ -309,6 +332,7 @@ class TestDiscoverCluster:
                     SINFO_OUTPUT_MIXED,  # sinfo succeeds
                     None,  # sacctmgr accounts fails
                     None,  # sacctmgr qos fails
+                    None,  # sacctmgr default account fails
                 ],
             ),
         ):
@@ -332,6 +356,7 @@ class TestDiscoverCluster:
                     SINFO_OUTPUT_SINGLE_PARTITION,
                     None,
                     None,
+                    None,
                 ],
             ) as mock_cmd,
         ):
@@ -339,8 +364,8 @@ class TestDiscoverCluster:
             result2 = discover_cluster()
 
         assert result1 is result2
-        # _run_command should only be called once (3 calls total for 1 discover)
-        assert mock_cmd.call_count == 3
+        # _run_command called 4 times for 1 discover (sinfo, accounts, qos, default_account)
+        assert mock_cmd.call_count == 4
 
     def test_returns_none_when_sinfo_fails(self):
         """If sinfo exists but returns error, return None."""

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -22,7 +22,6 @@ from mdfactory.performance.cluster import (
     select_partition,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures: realistic sinfo / sacctmgr output
 # ---------------------------------------------------------------------------
@@ -303,9 +302,7 @@ class TestDiscoverCluster:
 
     def test_returns_cluster_info_with_sinfo(self):
         with (
-            patch(
-                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
-            ),
+            patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
             patch(
                 "mdfactory.performance.cluster._run_command",
                 side_effect=[
@@ -328,9 +325,7 @@ class TestDiscoverCluster:
     def test_default_account_falls_back_to_first(self):
         """When default account query fails, fall back to first account."""
         with (
-            patch(
-                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
-            ),
+            patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
             patch(
                 "mdfactory.performance.cluster._run_command",
                 side_effect=[
@@ -350,9 +345,7 @@ class TestDiscoverCluster:
     def test_graceful_without_sacctmgr(self):
         """When sacctmgr fails, still return partitions."""
         with (
-            patch(
-                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
-            ),
+            patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
             patch(
                 "mdfactory.performance.cluster._run_command",
                 side_effect=[
@@ -374,9 +367,7 @@ class TestDiscoverCluster:
     def test_caching(self):
         """Second call returns cached result without re-querying."""
         with (
-            patch(
-                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
-            ),
+            patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
             patch(
                 "mdfactory.performance.cluster._run_command",
                 side_effect=[
@@ -397,9 +388,7 @@ class TestDiscoverCluster:
     def test_returns_none_when_sinfo_fails(self):
         """If sinfo exists but returns error, return None."""
         with (
-            patch(
-                "mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"
-            ),
+            patch("mdfactory.performance.cluster.shutil.which", return_value="/usr/bin/sinfo"),
             patch(
                 "mdfactory.performance.cluster._run_command",
                 return_value=None,  # sinfo call fails

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -506,7 +506,13 @@ class TestDataclasses:
         nt = NodeType(cpus=32, memory_mb=64000)
         assert nt.gpus == 0
         assert nt.gpu_type is None
-        assert nt.features == []
+        assert nt.features == ()
+
+    def test_node_type_features_immutable(self):
+        nt = NodeType(cpus=64, memory_mb=256000, features=("a100", "nvlink"))
+        assert nt.features == ("a100", "nvlink")
+        with pytest.raises(TypeError):
+            nt.features[0] = "other"  # type: ignore[index]
 
     def test_cluster_info_defaults(self):
         ci = ClusterInfo()

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -50,6 +50,19 @@ SINFO_OUTPUT_NO_TYPE_GPU = """\
 gpu node001 64 256000 gpu:4 (null) 1-00:00:00 idle
 """
 
+# First node drained, rest healthy → partition should be "up"
+SINFO_OUTPUT_MIXED_HEALTH = """\
+cpu node001 64 128000 (null) (null) 2-00:00:00 drained
+cpu node002 64 128000 (null) (null) 2-00:00:00 idle
+cpu node003 64 128000 (null) (null) 2-00:00:00 idle
+"""
+
+# All nodes unhealthy → partition should report unhealthy state
+SINFO_OUTPUT_ALL_DOWN = """\
+cpu node001 64 128000 (null) (null) 2-00:00:00 down
+cpu node002 64 128000 (null) (null) 2-00:00:00 drained
+"""
+
 SACCTMGR_ACCOUNTS = """\
 myproject
 shared-account
@@ -182,6 +195,19 @@ class TestParseSinfo:
         nt = partitions[0].node_types[0]
         assert nt.gpus == 4
         assert nt.gpu_type is None
+
+    def test_partition_state_up_when_any_node_healthy(self):
+        """Partition with mixed healthy/unhealthy nodes should be 'up'."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_MIXED_HEALTH)
+        assert len(partitions) == 1
+        assert partitions[0].state == "up"
+
+    def test_partition_state_unhealthy_when_all_nodes_down(self):
+        """Partition with no healthy nodes reports unhealthy state."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_ALL_DOWN)
+        assert len(partitions) == 1
+        assert partitions[0].state != "up"
+        assert partitions[0].state in ("down", "drained")
 
     def test_empty_output(self):
         partitions = _parse_sinfo("")
@@ -394,6 +420,13 @@ class TestSelectPartition:
         result = select_partition(cluster, needs_gpu=True, min_cpus=90)
         assert result is not None
         assert result.name == "gpu"
+
+    def test_skips_down_partitions(self):
+        """Partitions where all nodes are down are not selectable."""
+        partitions = _parse_sinfo(SINFO_OUTPUT_ALL_DOWN)
+        cluster = ClusterInfo(partitions=partitions)
+        result = select_partition(cluster)
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/mdfactory/tests/test_slurm_config.py
+++ b/mdfactory/tests/test_slurm_config.py
@@ -1,0 +1,372 @@
+# ABOUTME: Unit tests for BaseSlurmConfig, SlurmConfig, and normalize_slurm_time.
+# ABOUTME: Uses mocked discover_cluster() so tests run on non-SLURM machines.
+"""Unit tests for mdfactory.performance.slurm_config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mdfactory.performance import cluster as cluster_mod
+from mdfactory.performance.slurm_config import (
+    BaseSlurmConfig,
+    SlurmConfig,
+    normalize_slurm_time,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_slurm_time
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSlurmTime:
+    """Edge-case coverage for the time-string normaliser."""
+
+    def test_hours_shorthand(self):
+        assert normalize_slurm_time("2h") == "02:00:00"
+
+    def test_hours_single_digit(self):
+        assert normalize_slurm_time("1h") == "01:00:00"
+
+    def test_hours_large(self):
+        assert normalize_slurm_time("24h") == "24:00:00"
+
+    def test_minutes_shorthand(self):
+        assert normalize_slurm_time("30m") == "00:30:00"
+
+    def test_minutes_overflow(self):
+        assert normalize_slurm_time("90m") == "01:30:00"
+
+    def test_minutes_as_integer(self):
+        assert normalize_slurm_time("90") == "01:30:00"
+        assert normalize_slurm_time("120") == "02:00:00"
+
+    def test_days_shorthand(self):
+        assert normalize_slurm_time("1d") == "1-00:00:00"
+        assert normalize_slurm_time("3d") == "3-00:00:00"
+
+    def test_hms_passthrough(self):
+        assert normalize_slurm_time("01:00:00") == "01:00:00"
+        assert normalize_slurm_time("3-00:00:00") == "3-00:00:00"
+
+    def test_strips_whitespace(self):
+        assert normalize_slurm_time("  2h  ") == "02:00:00"
+
+
+# ---------------------------------------------------------------------------
+# SlurmConfig — Pydantic model behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSlurmConfigModel:
+    """Tests for the SlurmConfig Pydantic model (no SLURM required)."""
+
+    def test_minimal_construction(self):
+        cfg = SlurmConfig(account="mygroup")
+        assert cfg.account == "mygroup"
+        assert cfg.partition == "cpu"
+        assert cfg.time == "02:00:00"  # "2h" normalised on construction
+        assert cfg.cpus_per_task == 4
+        assert cfg.mem_gb == 8
+        assert cfg.job_name_prefix == "mdfactory-analysis"
+        assert cfg.qos is None
+        assert cfg.constraint is None
+
+    def test_time_normalised_on_construction(self):
+        cfg = SlurmConfig(account="grp", time="4h")
+        assert cfg.time == "04:00:00"
+
+    def test_time_hms_passthrough(self):
+        cfg = SlurmConfig(account="grp", time="02:00:00")
+        assert cfg.time == "02:00:00"
+
+    def test_time_minutes_shorthand(self):
+        cfg = SlurmConfig(account="grp", time="30m")
+        assert cfg.time == "00:30:00"
+
+    def test_time_integer_minutes(self):
+        cfg = SlurmConfig(account="grp", time="120")
+        assert cfg.time == "02:00:00"
+
+    def test_frozen(self):
+        cfg = SlurmConfig(account="grp")
+        with pytest.raises(Exception):  # ValidationError or AttributeError
+            cfg.account = "other"  # type: ignore[misc]
+
+    def test_inherits_base_slurm_config(self):
+        assert issubclass(SlurmConfig, BaseSlurmConfig)
+
+    def test_optional_fields(self):
+        cfg = SlurmConfig(
+            account="grp",
+            partition="gpu",
+            qos="high",
+            constraint="a100",
+            time="1d",
+            cpus_per_task=16,
+            mem_gb=64,
+            job_name_prefix="my-job",
+        )
+        assert cfg.partition == "gpu"
+        assert cfg.qos == "high"
+        assert cfg.constraint == "a100"
+        assert cfg.time == "1-00:00:00"
+        assert cfg.cpus_per_task == 16
+        assert cfg.mem_gb == 64
+        assert cfg.job_name_prefix == "my-job"
+
+
+# ---------------------------------------------------------------------------
+# SlurmConfig.from_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestSlurmConfigFromYaml:
+    def test_round_trip(self, tmp_path: Path):
+        data = {
+            "account": "mygroup",
+            "partition": "compute",
+            "time": "4h",
+            "cpus_per_task": 8,
+            "mem_gb": 32,
+        }
+        yaml_file = tmp_path / "slurm.yaml"
+        yaml_file.write_text(yaml.dump(data))
+
+        cfg = SlurmConfig.from_yaml(yaml_file)
+
+        assert cfg.account == "mygroup"
+        assert cfg.partition == "compute"
+        assert cfg.time == "04:00:00"  # normalised
+        assert cfg.cpus_per_task == 8
+        assert cfg.mem_gb == 32
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            SlurmConfig.from_yaml(tmp_path / "nonexistent.yaml")
+
+    def test_defaults_applied(self, tmp_path: Path):
+        yaml_file = tmp_path / "minimal.yaml"
+        yaml_file.write_text("account: grp\n")
+
+        cfg = SlurmConfig.from_yaml(yaml_file)
+        assert cfg.time == "02:00:00"
+        assert cfg.cpus_per_task == 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock cluster objects
+# ---------------------------------------------------------------------------
+
+
+def _make_cpu_partition(name: str = "compute", cpus: int = 32) -> cluster_mod.Partition:
+    return cluster_mod.Partition(
+        name=name,
+        state="up",
+        max_time="3-00:00:00",
+        default_time="1:00:00",
+        node_types=[
+            cluster_mod.NodeType(cpus=cpus, memory_mb=128 * 1024, gpu_specs=(), count=10)
+        ],
+        total_nodes=10,
+        is_default=True,
+    )
+
+
+def _make_gpu_partition(name: str = "gpu") -> cluster_mod.Partition:
+    return cluster_mod.Partition(
+        name=name,
+        state="up",
+        max_time="2-00:00:00",
+        default_time="1:00:00",
+        node_types=[
+            cluster_mod.NodeType(
+                cpus=32,
+                memory_mb=128 * 1024,
+                gpu_specs=((4, "a100"),),
+                count=20,
+            )
+        ],
+        total_nodes=20,
+        is_default=False,
+    )
+
+
+def _make_cluster(
+    partitions: list[cluster_mod.Partition] | None = None,
+    default_account: str | None = "myaccount",
+) -> cluster_mod.ClusterInfo:
+    if partitions is None:
+        partitions = [_make_cpu_partition()]
+    return cluster_mod.ClusterInfo(
+        partitions=partitions,
+        accounts=[default_account] if default_account else [],
+        qos_policies=["normal"],
+        default_account=default_account,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BaseSlurmConfig.from_cluster — 3-tier precedence
+# ---------------------------------------------------------------------------
+
+
+class TestBaseSlurmConfigFromCluster:
+    """Tests run without a real SLURM cluster (discover_cluster mocked)."""
+
+    def test_autodiscovery_populates_account_and_partition(self, monkeypatch):
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        cfg = SlurmConfig.from_cluster()
+        assert cfg.account == "myaccount"
+        assert cfg.partition == "compute"
+
+    def test_no_slurm_raises(self, monkeypatch):
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+        with pytest.raises(RuntimeError, match="SLURM autodiscovery failed and no account"):
+            SlurmConfig.from_cluster()
+
+    def test_no_default_account_raises(self, monkeypatch):
+        cluster = _make_cluster(default_account=None)
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
+        with pytest.raises(RuntimeError, match="No SLURM account available"):
+            SlurmConfig.from_cluster()
+
+    def test_no_suitable_partition_raises(self, monkeypatch):
+        # Tiny partition: 4 CPUs — won't satisfy min_cpus=32
+        cluster = _make_cluster(partitions=[_make_cpu_partition(cpus=4)])
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
+        with pytest.raises(RuntimeError, match="No suitable partition found"):
+            SlurmConfig.from_cluster(min_cpus=32)
+
+    def test_needs_gpu_selects_gpu_partition(self, monkeypatch):
+        cluster = _make_cluster(
+            partitions=[_make_cpu_partition(), _make_gpu_partition()]
+        )
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
+        cfg = SlurmConfig.from_cluster(needs_gpu=True)
+        assert cfg.partition == "gpu"
+
+    # --- tier 2: config.ini overrides autodiscovery ---
+
+    def test_config_account_overrides_autodiscovery(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        monkeypatch.setattr(
+            Settings, "slurm_account", property(lambda self: "config-account")
+        )
+        cfg = SlurmConfig.from_cluster()
+        assert cfg.account == "config-account"
+
+    def test_config_cpu_partition_overrides_autodiscovery(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        monkeypatch.setattr(
+            Settings, "slurm_partition_cpu", property(lambda self: "config-cpu")
+        )
+        cfg = SlurmConfig.from_cluster(needs_gpu=False)
+        assert cfg.partition == "config-cpu"
+
+    def test_config_gpu_partition_overrides_autodiscovery(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        cluster = _make_cluster(
+            partitions=[_make_cpu_partition(), _make_gpu_partition()]
+        )
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
+        monkeypatch.setattr(
+            Settings, "slurm_partition_gpu", property(lambda self: "config-gpu")
+        )
+        cfg = SlurmConfig.from_cluster(needs_gpu=True)
+        assert cfg.partition == "config-gpu"
+
+    def test_config_qos_propagated(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        monkeypatch.setattr(
+            Settings, "slurm_qos", property(lambda self: "high")
+        )
+        cfg = SlurmConfig.from_cluster()
+        assert cfg.qos == "high"
+
+    # --- tier 1: explicit kwargs override everything ---
+
+    def test_explicit_account_overrides_config_and_autodiscovery(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        monkeypatch.setattr(
+            Settings, "slurm_account", property(lambda self: "config-account")
+        )
+        cfg = SlurmConfig.from_cluster(account="explicit-account")
+        assert cfg.account == "explicit-account"
+
+    def test_explicit_partition_overrides_config_and_autodiscovery(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        monkeypatch.setattr(
+            Settings, "slurm_partition_cpu", property(lambda self: "config-partition")
+        )
+        cfg = SlurmConfig.from_cluster(partition="explicit-partition")
+        assert cfg.partition == "explicit-partition"
+
+    def test_explicit_qos_overrides_config(self, monkeypatch):
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        monkeypatch.setattr(
+            Settings, "slurm_qos", property(lambda self: "high")
+        )
+        cfg = SlurmConfig.from_cluster(qos="debug")
+        assert cfg.qos == "debug"
+
+    def test_explicit_constraint_forwarded(self, monkeypatch):
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        cfg = SlurmConfig.from_cluster(constraint="epyc")
+        assert cfg.constraint == "epyc"
+
+    # --- submitit-specific extra fields forwarded ---
+
+    def test_submitit_fields_forwarded(self, monkeypatch):
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        cfg = SlurmConfig.from_cluster(
+            time="4h",
+            cpus_per_task=8,
+            mem_gb=32,
+            job_name_prefix="my-prefix",
+        )
+        assert cfg.time == "04:00:00"
+        assert cfg.cpus_per_task == 8
+        assert cfg.mem_gb == 32
+        assert cfg.job_name_prefix == "my-prefix"
+
+    def test_returns_slurm_config_type(self, monkeypatch):
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
+        result = SlurmConfig.from_cluster()
+        assert isinstance(result, SlurmConfig)
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat import from mdfactory.analysis.submit
+# ---------------------------------------------------------------------------
+
+
+def test_backward_compat_import_slurm_config():
+    """from mdfactory.analysis.submit import SlurmConfig must still work."""
+    from mdfactory.analysis.submit import SlurmConfig as SubmitSlurmConfig
+
+    cfg = SubmitSlurmConfig(account="grp")
+    assert cfg.account == "grp"
+
+
+def test_backward_compat_import_normalize_slurm_time():
+    """from mdfactory.analysis.submit import normalize_slurm_time must still work."""
+    from mdfactory.analysis.submit import normalize_slurm_time as nslt
+
+    assert nslt("2h") == "02:00:00"

--- a/mdfactory/tests/test_slurm_config.py
+++ b/mdfactory/tests/test_slurm_config.py
@@ -238,7 +238,7 @@ def _make_cluster(
 class TestBaseSlurmConfigFromCluster:
     """Tests run without a real SLURM cluster (discover_cluster mocked)."""
 
-    def test_autodiscovery_populates_account_and_partition(self, monkeypatch):
+    def test_autodiscovery_populates_account_and_partition(self, monkeypatch, no_slurm_settings):
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
         cfg = SlurmConfig.from_cluster()
         assert cfg.account == "myaccount"
@@ -262,7 +262,7 @@ class TestBaseSlurmConfigFromCluster:
         with pytest.raises(RuntimeError, match="No suitable partition found"):
             SlurmConfig.from_cluster(min_cpus=32)
 
-    def test_needs_gpu_selects_gpu_partition(self, monkeypatch):
+    def test_needs_gpu_selects_gpu_partition(self, monkeypatch, no_slurm_settings):
         cluster = _make_cluster(
             partitions=[_make_cpu_partition(), _make_gpu_partition()]
         )

--- a/mdfactory/tests/test_slurm_config.py
+++ b/mdfactory/tests/test_slurm_config.py
@@ -16,7 +16,6 @@ from mdfactory.performance.slurm_config import (
     normalize_slurm_time,
 )
 
-
 # ---------------------------------------------------------------------------
 # normalize_slurm_time
 # ---------------------------------------------------------------------------
@@ -189,9 +188,7 @@ def _make_cpu_partition(name: str = "compute", cpus: int = 32) -> cluster_mod.Pa
         state="up",
         max_time="3-00:00:00",
         default_time="1:00:00",
-        node_types=[
-            cluster_mod.NodeType(cpus=cpus, memory_mb=128 * 1024, gpu_specs=(), count=10)
-        ],
+        node_types=[cluster_mod.NodeType(cpus=cpus, memory_mb=128 * 1024, gpu_specs=(), count=10)],
         total_nodes=10,
         is_default=True,
     )
@@ -263,9 +260,7 @@ class TestBaseSlurmConfigFromCluster:
             SlurmConfig.from_cluster(min_cpus=32)
 
     def test_needs_gpu_selects_gpu_partition(self, monkeypatch, no_slurm_settings):
-        cluster = _make_cluster(
-            partitions=[_make_cpu_partition(), _make_gpu_partition()]
-        )
+        cluster = _make_cluster(partitions=[_make_cpu_partition(), _make_gpu_partition()])
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
         cfg = SlurmConfig.from_cluster(needs_gpu=True)
         assert cfg.partition == "gpu"
@@ -276,9 +271,7 @@ class TestBaseSlurmConfigFromCluster:
         from mdfactory.settings import Settings
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
-        monkeypatch.setattr(
-            Settings, "slurm_account", property(lambda self: "config-account")
-        )
+        monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "config-account"))
         cfg = SlurmConfig.from_cluster()
         assert cfg.account == "config-account"
 
@@ -286,22 +279,16 @@ class TestBaseSlurmConfigFromCluster:
         from mdfactory.settings import Settings
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
-        monkeypatch.setattr(
-            Settings, "slurm_partition_cpu", property(lambda self: "config-cpu")
-        )
+        monkeypatch.setattr(Settings, "slurm_partition_cpu", property(lambda self: "config-cpu"))
         cfg = SlurmConfig.from_cluster(needs_gpu=False)
         assert cfg.partition == "config-cpu"
 
     def test_config_gpu_partition_overrides_autodiscovery(self, monkeypatch):
         from mdfactory.settings import Settings
 
-        cluster = _make_cluster(
-            partitions=[_make_cpu_partition(), _make_gpu_partition()]
-        )
+        cluster = _make_cluster(partitions=[_make_cpu_partition(), _make_gpu_partition()])
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
-        monkeypatch.setattr(
-            Settings, "slurm_partition_gpu", property(lambda self: "config-gpu")
-        )
+        monkeypatch.setattr(Settings, "slurm_partition_gpu", property(lambda self: "config-gpu"))
         cfg = SlurmConfig.from_cluster(needs_gpu=True)
         assert cfg.partition == "config-gpu"
 
@@ -309,9 +296,7 @@ class TestBaseSlurmConfigFromCluster:
         from mdfactory.settings import Settings
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
-        monkeypatch.setattr(
-            Settings, "slurm_qos", property(lambda self: "high")
-        )
+        monkeypatch.setattr(Settings, "slurm_qos", property(lambda self: "high"))
         cfg = SlurmConfig.from_cluster()
         assert cfg.qos == "high"
 
@@ -321,9 +306,7 @@ class TestBaseSlurmConfigFromCluster:
         from mdfactory.settings import Settings
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
-        monkeypatch.setattr(
-            Settings, "slurm_account", property(lambda self: "config-account")
-        )
+        monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "config-account"))
         cfg = SlurmConfig.from_cluster(account="explicit-account")
         assert cfg.account == "explicit-account"
 
@@ -341,9 +324,7 @@ class TestBaseSlurmConfigFromCluster:
         from mdfactory.settings import Settings
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: _make_cluster())
-        monkeypatch.setattr(
-            Settings, "slurm_qos", property(lambda self: "high")
-        )
+        monkeypatch.setattr(Settings, "slurm_qos", property(lambda self: "high"))
         cfg = SlurmConfig.from_cluster(qos="debug")
         assert cfg.qos == "debug"
 

--- a/mdfactory/tests/test_slurm_config.py
+++ b/mdfactory/tests/test_slurm_config.py
@@ -158,6 +158,27 @@ class TestSlurmConfigFromYaml:
 
 
 # ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_slurm_settings(monkeypatch):
+    """Return None for all [slurm] settings — simulates an unconfigured machine.
+
+    Without this fixture, tests that expect autodiscovery to be the sole source
+    of truth would behave differently on machines that have ACCOUNT / PARTITION_CPU
+    set in their config.ini.
+    """
+    from mdfactory.settings import Settings
+
+    monkeypatch.setattr(Settings, "slurm_account", property(lambda self: None))
+    monkeypatch.setattr(Settings, "slurm_partition_cpu", property(lambda self: None))
+    monkeypatch.setattr(Settings, "slurm_partition_gpu", property(lambda self: None))
+    monkeypatch.setattr(Settings, "slurm_qos", property(lambda self: None))
+
+
+# ---------------------------------------------------------------------------
 # Helpers to build mock cluster objects
 # ---------------------------------------------------------------------------
 
@@ -223,18 +244,18 @@ class TestBaseSlurmConfigFromCluster:
         assert cfg.account == "myaccount"
         assert cfg.partition == "compute"
 
-    def test_no_slurm_raises(self, monkeypatch):
+    def test_no_slurm_raises(self, monkeypatch, no_slurm_settings):
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
         with pytest.raises(RuntimeError, match="SLURM autodiscovery failed and no account"):
             SlurmConfig.from_cluster()
 
-    def test_no_default_account_raises(self, monkeypatch):
+    def test_no_default_account_raises(self, monkeypatch, no_slurm_settings):
         cluster = _make_cluster(default_account=None)
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)
         with pytest.raises(RuntimeError, match="No SLURM account available"):
             SlurmConfig.from_cluster()
 
-    def test_no_suitable_partition_raises(self, monkeypatch):
+    def test_no_suitable_partition_raises(self, monkeypatch, no_slurm_settings):
         # Tiny partition: 4 CPUs — won't satisfy min_cpus=32
         cluster = _make_cluster(partitions=[_make_cpu_partition(cpus=4)])
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)

--- a/mdfactory/tests/test_slurm_config.py
+++ b/mdfactory/tests/test_slurm_config.py
@@ -259,6 +259,18 @@ class TestBaseSlurmConfigFromCluster:
         with pytest.raises(RuntimeError, match="No suitable partition found"):
             SlurmConfig.from_cluster(min_cpus=32)
 
+    def test_autodiscovery_fails_no_partition_in_config_raises(
+        self, monkeypatch, no_slurm_settings
+    ):
+        """cluster=None with account supplied but no partition in config raises RuntimeError."""
+        from mdfactory.settings import Settings
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+        # Provide account so resolution reaches the partition step
+        monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "myaccount"))
+        with pytest.raises(RuntimeError, match="no partition configured"):
+            SlurmConfig.from_cluster()
+
     def test_needs_gpu_selects_gpu_partition(self, monkeypatch, no_slurm_settings):
         cluster = _make_cluster(partitions=[_make_cpu_partition(), _make_gpu_partition()])
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: cluster)

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -404,7 +404,7 @@ class TestSlurmConfigFromCluster:
             max_time="3-00:00:00",
             default_time="1:00:00",
             node_types=[
-                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=0),
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpu_specs=(), count=10),
             ],
             total_nodes=10,
             is_default=True,
@@ -450,7 +450,7 @@ class TestSlurmConfigFromCluster:
             state="up",
             max_time="1-00:00:00",
             default_time="1:00:00",
-            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=64 * 1024)],
+            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=64 * 1024, count=5)],
             total_nodes=5,
             is_default=True,
         )
@@ -478,7 +478,7 @@ class TestSlurmConfigFromCluster:
             state="up",
             max_time="1:00:00",
             default_time="0:30:00",
-            node_types=[cluster_mod.NodeType(cpus=4, memory_mb=8 * 1024)],
+            node_types=[cluster_mod.NodeType(cpus=4, memory_mb=8 * 1024, count=2)],
             total_nodes=2,
             is_default=True,
         )
@@ -505,7 +505,9 @@ class TestSlurmConfigFromCluster:
             state="up",
             max_time="7-00:00:00",
             default_time="1:00:00",
-            node_types=[cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpus=0)],
+            node_types=[
+                cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpu_specs=(), count=100)
+            ],
             total_nodes=100,
             is_default=True,
         )
@@ -515,7 +517,9 @@ class TestSlurmConfigFromCluster:
             max_time="2-00:00:00",
             default_time="1:00:00",
             node_types=[
-                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100")
+                cluster_mod.NodeType(
+                    cpus=32, memory_mb=128 * 1024, gpu_specs=((4, "a100"),), count=20
+                )
             ],
             total_nodes=20,
             is_default=False,

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -385,3 +385,151 @@ def test_submit_analyses_slurm_forwards_analysis_kwargs(monkeypatch, tmp_path):
 
     assert len(submitted_kwargs) == 1
     assert submitted_kwargs[0]["analysis_kwargs"] == {"start_ns": 50.0, "stride": 2}
+
+
+# --- SlurmConfig.from_cluster tests ---
+
+
+class TestSlurmConfigFromCluster:
+    """Tests for SlurmConfig.from_cluster() autodiscovery method."""
+
+    def test_from_cluster_success(self, monkeypatch):
+        """Test successful autodiscovery creates correct config."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        # Create mock cluster info
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="3-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=0),
+            ],
+            total_nodes=10,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount", "otheraccount"],
+            qos_policies=["normal", "high"],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        config = submit_mod.SlurmConfig.from_cluster(
+            time="4h",
+            cpus_per_task=8,
+            mem_gb=16,
+        )
+
+        assert config.account == "myaccount"
+        assert config.partition == "compute"
+        assert config.time == "4h"
+        assert config.cpus_per_task == 8
+        assert config.mem_gb == 16
+
+    def test_from_cluster_no_slurm_raises(self, monkeypatch):
+        """Test that missing SLURM raises RuntimeError."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="not running on a SLURM cluster"):
+            submit_mod.SlurmConfig.from_cluster()
+
+    def test_from_cluster_no_account_raises(self, monkeypatch):
+        """Test that missing default account raises RuntimeError."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="1-00:00:00",
+            default_time="1:00:00",
+            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=64 * 1024)],
+            total_nodes=5,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=[],
+            qos_policies=[],
+            default_account=None,
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="no default account found"):
+            submit_mod.SlurmConfig.from_cluster()
+
+    def test_from_cluster_no_suitable_partition_raises(self, monkeypatch):
+        """Test that no matching partition raises RuntimeError."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        # Partition with only 4 CPUs - won't match request for 32 CPUs
+        mock_partition = cluster_mod.Partition(
+            name="tiny",
+            state="up",
+            max_time="1:00:00",
+            default_time="0:30:00",
+            node_types=[cluster_mod.NodeType(cpus=4, memory_mb=8 * 1024)],
+            total_nodes=2,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="No suitable partition found"):
+            submit_mod.SlurmConfig.from_cluster(cpus_per_task=32)
+
+    def test_from_cluster_selects_gpu_partition(self, monkeypatch):
+        """Test that needs_gpu=True selects GPU partition."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        cpu_partition = cluster_mod.Partition(
+            name="cpu",
+            state="up",
+            max_time="7-00:00:00",
+            default_time="1:00:00",
+            node_types=[cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpus=0)],
+            total_nodes=100,
+            is_default=True,
+        )
+        gpu_partition = cluster_mod.Partition(
+            name="gpu",
+            state="up",
+            max_time="2-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100")
+            ],
+            total_nodes=20,
+            is_default=False,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[cpu_partition, gpu_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        config = submit_mod.SlurmConfig.from_cluster(needs_gpu=True)
+
+        assert config.partition == "gpu"
+        assert config.account == "myaccount"

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -438,7 +438,9 @@ class TestSlurmConfigFromCluster:
 
         import pytest
 
-        with pytest.raises(RuntimeError, match="not running on a SLURM cluster"):
+        with pytest.raises(
+            RuntimeError, match="SLURM autodiscovery failed and no account configured"
+        ):
             submit_mod.SlurmConfig.from_cluster()
 
     def test_from_cluster_no_account_raises(self, monkeypatch):
@@ -465,7 +467,7 @@ class TestSlurmConfigFromCluster:
 
         import pytest
 
-        with pytest.raises(RuntimeError, match="no default account found"):
+        with pytest.raises(RuntimeError, match="No SLURM account available"):
             submit_mod.SlurmConfig.from_cluster()
 
     def test_from_cluster_no_suitable_partition_raises(self, monkeypatch):
@@ -537,3 +539,100 @@ class TestSlurmConfigFromCluster:
 
         assert config.partition == "gpu"
         assert config.account == "myaccount"
+
+    def test_from_cluster_uses_config_account(self, monkeypatch):
+        """Test that config account takes precedence over autodiscovery."""
+        from mdfactory.performance import cluster as cluster_mod
+        from mdfactory.settings import Settings
+
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="3-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpu_specs=(), count=10),
+            ],
+            total_nodes=10,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["autodiscovered-account"],
+            qos_policies=[],
+            default_account="autodiscovered-account",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+        monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "config-account"))
+
+        config = submit_mod.SlurmConfig.from_cluster()
+
+        # Should use config account, not autodiscovered
+        assert config.account == "config-account"
+
+    def test_from_cluster_uses_config_partition(self, monkeypatch):
+        """Test that config partition takes precedence over autodiscovery."""
+        from mdfactory.performance import cluster as cluster_mod
+        from mdfactory.settings import Settings
+
+        mock_partition = cluster_mod.Partition(
+            name="autodiscovered-partition",
+            state="up",
+            max_time="3-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpu_specs=(), count=10),
+            ],
+            total_nodes=10,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+        monkeypatch.setattr(Settings, "slurm_partition", property(lambda self: "config-partition"))
+
+        config = submit_mod.SlurmConfig.from_cluster(needs_gpu=False)
+
+        # Should use config partition, not autodiscovered
+        assert config.partition == "config-partition"
+
+    def test_from_cluster_explicit_overrides_config(self, monkeypatch):
+        """Test that explicit parameters override config values."""
+        from mdfactory.performance import cluster as cluster_mod
+        from mdfactory.settings import Settings
+
+        mock_partition = cluster_mod.Partition(
+            name="any-partition",
+            state="up",
+            max_time="3-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpu_specs=(), count=10),
+            ],
+            total_nodes=10,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+        monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "config-account"))
+        monkeypatch.setattr(Settings, "slurm_partition", property(lambda self: "config-partition"))
+
+        config = submit_mod.SlurmConfig.from_cluster(
+            account="explicit-account", partition="explicit-partition"
+        )
+
+        # Should use explicit values
+        assert config.account == "explicit-account"
+        assert config.partition == "explicit-partition"

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -597,7 +597,9 @@ class TestSlurmConfigFromCluster:
         )
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
-        monkeypatch.setattr(Settings, "slurm_partition_cpu", property(lambda self: "config-partition"))
+        monkeypatch.setattr(
+            Settings, "slurm_partition_cpu", property(lambda self: "config-partition")
+        )
 
         config = submit_mod.SlurmConfig.from_cluster(needs_gpu=False)
 
@@ -629,7 +631,9 @@ class TestSlurmConfigFromCluster:
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
         monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "config-account"))
-        monkeypatch.setattr(Settings, "slurm_partition_cpu", property(lambda self: "config-partition"))
+        monkeypatch.setattr(
+            Settings, "slurm_partition_cpu", property(lambda self: "config-partition")
+        )
 
         config = submit_mod.SlurmConfig.from_cluster(
             account="explicit-account", partition="explicit-partition"

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -23,6 +23,8 @@ def test_resolve_simulation_paths_from_yaml(tmp_path):
 
 
 def test_normalize_slurm_time():
+    # normalize_slurm_time is re-exported from mdfactory.analysis.submit for
+    # backward compatibility — the canonical version lives in performance.slurm_config.
     assert submit_mod.normalize_slurm_time("2h") == "02:00:00"
     assert submit_mod.normalize_slurm_time("30m") == "00:30:00"
     assert submit_mod.normalize_slurm_time("90") == "01:30:00"
@@ -426,7 +428,7 @@ class TestSlurmConfigFromCluster:
 
         assert config.account == "myaccount"
         assert config.partition == "compute"
-        assert config.time == "4h"
+        assert config.time == "04:00:00"
         assert config.cpus_per_task == 8
         assert config.mem_gb == 16
 
@@ -496,7 +498,7 @@ class TestSlurmConfigFromCluster:
         import pytest
 
         with pytest.raises(RuntimeError, match="No suitable partition found"):
-            submit_mod.SlurmConfig.from_cluster(cpus_per_task=32)
+            submit_mod.SlurmConfig.from_cluster(min_cpus=32)
 
     def test_from_cluster_selects_gpu_partition(self, monkeypatch):
         """Test that needs_gpu=True selects GPU partition."""
@@ -595,7 +597,7 @@ class TestSlurmConfigFromCluster:
         )
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
-        monkeypatch.setattr(Settings, "slurm_partition", property(lambda self: "config-partition"))
+        monkeypatch.setattr(Settings, "slurm_partition_cpu", property(lambda self: "config-partition"))
 
         config = submit_mod.SlurmConfig.from_cluster(needs_gpu=False)
 
@@ -627,7 +629,7 @@ class TestSlurmConfigFromCluster:
 
         monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
         monkeypatch.setattr(Settings, "slurm_account", property(lambda self: "config-account"))
-        monkeypatch.setattr(Settings, "slurm_partition", property(lambda self: "config-partition"))
+        monkeypatch.setattr(Settings, "slurm_partition_cpu", property(lambda self: "config-partition"))
 
         config = submit_mod.SlurmConfig.from_cluster(
             account="explicit-account", partition="explicit-partition"

--- a/mdfactory/tests/test_utilities.py
+++ b/mdfactory/tests/test_utilities.py
@@ -2,14 +2,17 @@
 # ABOUTME: and file locking behavior under concurrent access.
 """Tests for general utility functions including YAML file loading."""
 
+import subprocess
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
 
 from mdfactory.utils.utilities import (
     load_yaml_file,
+    run_command,
 )
 
 from .utils import ProcessWithException
@@ -131,3 +134,76 @@ def test_lock_folder_processes(tmp_path):
         if proc.exception:
             raise Exception(f"{proc.exception[1]}") from proc.exception[0]
     assert not lockfile.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_command
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommand:
+    """Test run_command with various failure modes and options."""
+
+    def test_graceful_returns_none_on_timeout(self):
+        """Test that graceful=True returns None on timeout."""
+        with patch(
+            "mdfactory.utils.utilities.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["test_cmd"], timeout=30),
+        ):
+            result = run_command(["test_cmd"], timeout=30, graceful=True)
+        assert result is None
+
+    def test_graceful_returns_none_on_file_not_found(self):
+        """Test that graceful=True returns None when binary not found."""
+        with patch(
+            "mdfactory.utils.utilities.subprocess.run",
+            side_effect=FileNotFoundError("No such file"),
+        ):
+            result = run_command(["nonexistent_binary"], graceful=True)
+        assert result is None
+
+    def test_graceful_returns_none_on_nonzero_exit(self):
+        """Test that graceful=True returns None on non-zero exit."""
+        with patch(
+            "mdfactory.utils.utilities.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["test"], returncode=1, stdout="", stderr="error"
+            ),
+        ):
+            result = run_command(["test", "--flag"], graceful=True)
+        assert result is None
+
+    def test_graceful_returns_stdout_on_success(self):
+        """Test that graceful=True returns stdout on success."""
+        with patch(
+            "mdfactory.utils.utilities.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["echo"], returncode=0, stdout="hello\n", stderr=""
+            ),
+        ):
+            result = run_command(["echo", "hello"], graceful=True)
+        assert result == "hello"
+
+    def test_check_raises_on_nonzero_exit(self):
+        """Test that check=True raises on non-zero exit."""
+        with patch(
+            "mdfactory.utils.utilities.subprocess.run",
+            side_effect=subprocess.CalledProcessError(
+                returncode=1, cmd=["false"], output="", stderr="error"
+            ),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                run_command(["false"], check=True)
+
+    def test_returns_completed_process_when_no_capture(self):
+        """Test that result is CompletedProcess when not capturing output."""
+        with patch(
+            "mdfactory.utils.utilities.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["echo"], returncode=0, stdout=None, stderr=None
+            ),
+        ) as mock_run:
+            result = run_command(["echo", "test"], capture_output=False)
+            assert isinstance(result, subprocess.CompletedProcess)
+            assert result.returncode == 0
+            mock_run.assert_called_once()

--- a/mdfactory/utils/utilities.py
+++ b/mdfactory/utils/utilities.py
@@ -1,16 +1,117 @@
 # ABOUTME: General-purpose utility functions for mdfactory
 # ABOUTME: Provides working directory management, YAML loading, and file locking
+# ABOUTME: Includes subprocess execution wrapper with graceful failure modes
 """General-purpose utility functions for mdfactory."""
 
 import contextlib
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    timeout: int | None = None,
+    capture_output: bool = True,
+    check: bool = False,
+    text: bool = True,
+    graceful: bool = False,
+    **kwargs,
+) -> subprocess.CompletedProcess | str | None:
+    """Run a shell command with flexible error handling.
+
+    Provides a unified interface for subprocess execution with common
+    patterns: graceful failure for optional commands, strict checking
+    for critical operations, and timeout support.
+
+    Parameters
+    ----------
+    cmd : list of str
+        Command and arguments to execute.
+    timeout : int or None
+        Timeout in seconds. None for no timeout (default).
+    capture_output : bool
+        Capture stdout/stderr. Default True.
+    check : bool
+        Raise CalledProcessError on non-zero exit. Default False.
+        Ignored when graceful=True.
+    text : bool
+        Return output as text (str) rather than bytes. Default True.
+    graceful : bool
+        Return None on any failure (timeout, non-zero exit, OSError)
+        instead of raising. Default False. When True, overrides check=True.
+    **kwargs
+        Additional arguments passed to subprocess.run (e.g., cwd, env,
+        stdout, stderr, stdin).
+
+    Returns
+    -------
+    subprocess.CompletedProcess, str, or None
+        - If graceful=True: Returns stdout string on success, None on any failure.
+        - If capture_output=True and not graceful: Returns stripped stdout string.
+        - Otherwise: Returns CompletedProcess object.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If check=True and command exits with non-zero status.
+    subprocess.TimeoutExpired
+        If timeout is exceeded and graceful=False.
+    FileNotFoundError
+        If command binary not found and graceful=False.
+    OSError
+        On other OS-level failures and graceful=False.
+
+    Examples
+    --------
+    >>> # Graceful failure for optional commands
+    >>> output = run_command(["sinfo", "--version"], timeout=30, graceful=True)
+    >>> if output is None:
+    ...     print("SLURM not available")
+
+    >>> # Strict checking for critical operations
+    >>> run_command(["vmd", "-e", "script.tcl"], check=True)
+
+    >>> # Manual error handling
+    >>> result = run_command(["fdt", "config"], capture_output=False)
+    >>> if result.returncode != 0:
+    ...     print("Validation failed")
+    """
+    if graceful:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=capture_output,
+                text=text,
+                timeout=timeout,
+                check=False,  # Handle manually in graceful mode
+                **kwargs,
+            )
+            if result.returncode != 0:
+                return None
+            return result.stdout.strip() if capture_output and text else result.stdout
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return None
+    else:
+        result = subprocess.run(
+            cmd,
+            capture_output=capture_output,
+            text=text,
+            timeout=timeout,
+            check=check,
+            **kwargs,
+        )
+        # If caller wants just stdout (most common case)
+        if capture_output and text and not check:
+            return result.stdout.strip()
+        return result
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Adds `mdfactory/performance/cluster.py` — queries `sinfo` and `sacctmgr` to discover cluster resources automatically. This is the foundation for all planned HPC features (benchmarking, node packing, GPU sharing).

## What it does

- `discover_cluster()` → returns partitions, node specs (CPUs, memory, GPUs), accounts, and QOS policies as frozen dataclasses
- `select_partition(cluster, needs_gpu=True, min_cpus=64)` → picks the best partition for given requirements
- Returns `None` gracefully on non-SLURM machines
- Results cached per session (topology doesn't change mid-run)

## Files

- `mdfactory/performance/__init__.py` — new package
- `mdfactory/performance/cluster.py` — autodiscovery implementation
- `mdfactory/tests/test_cluster.py` — unit tests with mocked SLURM output

## Test plan

- [x] `pytest mdfactory/tests/test_cluster.py -v` (mocked, no cluster needed)
- [x] Verify `discover_cluster()` returns `None` on laptop
- [x] Verify populated `ClusterInfo` on a real SLURM node