### PR TITLE
feat: wire cluster autodiscovery into SlurmConfig and CLI

### DIFF
--- a/mdfactory/analysis/submit.py
+++ b/mdfactory/analysis/submit.py
@@ -30,6 +30,97 @@ class SlurmConfig:
     constraint: str | None = None
     job_name_prefix: str = "mdfactory-analysis"
 
+    @classmethod
+    def from_cluster(
+        cls,
+        *,
+        needs_gpu: bool = False,
+        time: str = "2h",
+        cpus_per_task: int = 4,
+        mem_gb: int = 8,
+        qos: str | None = None,
+        constraint: str | None = None,
+        job_name_prefix: str = "mdfactory-analysis",
+    ) -> "SlurmConfig":
+        """Create SlurmConfig from autodiscovered cluster info.
+
+        Uses lazy import of ``mdfactory.performance.cluster`` to avoid
+        hard dependency on SLURM commands at import time.
+
+        Parameters
+        ----------
+        needs_gpu : bool
+            If True, select a GPU-enabled partition.
+        time : str
+            Job time limit (default: "2h").
+        cpus_per_task : int
+            CPUs per task (default: 4).
+        mem_gb : int
+            Memory per task in GB (default: 8).
+        qos : str or None
+            Quality of service. If None, uses first available from cluster.
+        constraint : str or None
+            SLURM constraint string.
+        job_name_prefix : str
+            Prefix for SLURM job names.
+
+        Returns
+        -------
+        SlurmConfig
+            Configured instance with autodiscovered account and partition.
+
+        Raises
+        ------
+        RuntimeError
+            If SLURM is not available or no suitable partition found.
+        """
+        from mdfactory.performance.cluster import discover_cluster, select_partition
+
+        cluster = discover_cluster()
+        if cluster is None:
+            raise RuntimeError(
+                "SLURM autodiscovery failed: not running on a SLURM cluster "
+                "or SLURM commands (sinfo) are not available."
+            )
+
+        # Select appropriate partition
+        partition = select_partition(
+            cluster,
+            needs_gpu=needs_gpu,
+            min_cpus=cpus_per_task,
+            min_mem_gb=mem_gb,
+        )
+        if partition is None:
+            raise RuntimeError(
+                f"No suitable partition found for requirements: "
+                f"needs_gpu={needs_gpu}, min_cpus={cpus_per_task}, min_mem_gb={mem_gb}"
+            )
+
+        # Get account (required)
+        account = cluster.default_account
+        if account is None:
+            raise RuntimeError(
+                "SLURM autodiscovery failed: no default account found. "
+                "Please specify --account explicitly."
+            )
+
+        # Use first QOS if available and not explicitly set
+        resolved_qos = qos
+        if resolved_qos is None and cluster.qos_policies:
+            # Don't auto-select QOS; let SLURM use partition default
+            pass
+
+        return cls(
+            account=account,
+            partition=partition.name,
+            time=time,
+            cpus_per_task=cpus_per_task,
+            mem_gb=mem_gb,
+            qos=resolved_qos,
+            constraint=constraint,
+            job_name_prefix=job_name_prefix,
+        )
+
 
 def normalize_slurm_time(value: str) -> str:
     """Normalize SLURM time strings to accepted formats."""

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -1860,9 +1860,11 @@ def config_cluster(
                         {
                             "cpus": nt.cpus,
                             "memory_mb": nt.memory_mb,
-                            "gpus": nt.gpus,
-                            "gpu_type": nt.gpu_type,
+                            "gpu_specs": [
+                                {"count": count, "type": gtype} for count, gtype in nt.gpu_specs
+                            ],
                             "features": list(nt.features),
+                            "count": nt.count,
                         }
                         for nt in p.node_types
                     ],
@@ -1904,14 +1906,16 @@ def config_cluster(
         # Summarize node types
         for nt in partition.node_types:
             gpu_info = ""
-            if nt.gpus > 0:
-                gpu_type_str = nt.gpu_type or "GPU"
-                gpu_info = f", {nt.gpus}x {gpu_type_str}"
+            if nt.gpu_specs:
+                # Format multiple GPU types like "7x b200, 7x 1g.23gb"
+                gpu_parts = [f"{count}x {gtype}" for count, gtype in nt.gpu_specs]
+                gpu_info = f", {', '.join(gpu_parts)}"
             mem_gb = nt.memory_mb // 1024
             features_str = ""
             if nt.features:
                 features_str = f" [{', '.join(nt.features)}]"
-            print(f"      - {nt.cpus} CPUs, {mem_gb} GB{gpu_info}{features_str}")
+            count_str = f" ({nt.count} node{'s' if nt.count != 1 else ''})"
+            print(f"      - {nt.cpus} CPUs, {mem_gb} GB{gpu_info}{features_str}{count_str}")
 
 
 def main():

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -1187,8 +1187,6 @@ def analysis_run(
     if source is None:
         raise ValueError("Provide SOURCE as a simulation directory or build summary YAML.")
 
-    if slurm and account is None:
-        raise ValueError("--account is required when using --slurm.")
     if analysis_workers is not None and analysis_workers < 1:
         raise ValueError("--analysis-workers must be >= 1.")
 
@@ -1233,16 +1231,50 @@ def analysis_run(
         print(result_df)
         return
 
-    slurm_cfg = SlurmConfig(
-        account=account or "",
-        partition=partition,
-        time=time,
-        cpus_per_task=cpus,
-        mem_gb=mem_gb,
-        qos=qos,
-        constraint=constraint,
-        job_name_prefix=job_name_prefix,
-    )
+    # Use autodiscovery if account not provided
+    if account is None:
+        try:
+            slurm_cfg = SlurmConfig.from_cluster(
+                needs_gpu=False,
+                time=time,
+                cpus_per_task=cpus,
+                mem_gb=mem_gb,
+                qos=qos,
+                constraint=constraint,
+                job_name_prefix=job_name_prefix,
+            )
+            # Override partition if user specified one explicitly
+            if partition != "cpu":  # user changed from default
+                slurm_cfg = SlurmConfig(
+                    account=slurm_cfg.account,
+                    partition=partition,
+                    time=time,
+                    cpus_per_task=cpus,
+                    mem_gb=mem_gb,
+                    qos=qos,
+                    constraint=constraint,
+                    job_name_prefix=job_name_prefix,
+                )
+            logger.info(
+                f"Using autodiscovered SLURM config: account={slurm_cfg.account}, "
+                f"partition={slurm_cfg.partition}"
+            )
+        except RuntimeError as e:
+            raise ValueError(
+                f"SLURM autodiscovery failed: {e}\n"
+                "Please specify --account explicitly."
+            ) from e
+    else:
+        slurm_cfg = SlurmConfig(
+            account=account,
+            partition=partition,
+            time=time,
+            cpus_per_task=cpus,
+            mem_gb=mem_gb,
+            qos=qos,
+            constraint=constraint,
+            job_name_prefix=job_name_prefix,
+        )
     if log_dir is None:
         log_dir = determine_log_dir(sim_paths)
     result_df = submit_analyses_slurm(
@@ -1520,19 +1552,51 @@ def analysis_artifacts_run(
         print(summary)
         return
 
+    # Use autodiscovery if account not provided
     if account is None:
-        raise ValueError("--account is required when using --slurm.")
+        try:
+            slurm_cfg = SlurmConfig.from_cluster(
+                needs_gpu=False,
+                time=time,
+                cpus_per_task=cpus,
+                mem_gb=mem_gb,
+                qos=qos,
+                constraint=constraint,
+                job_name_prefix=job_name_prefix,
+            )
+            # Override partition if user specified one explicitly
+            if partition != "cpu":  # user changed from default
+                slurm_cfg = SlurmConfig(
+                    account=slurm_cfg.account,
+                    partition=partition,
+                    time=time,
+                    cpus_per_task=cpus,
+                    mem_gb=mem_gb,
+                    qos=qos,
+                    constraint=constraint,
+                    job_name_prefix=job_name_prefix,
+                )
+            logger.info(
+                f"Using autodiscovered SLURM config: account={slurm_cfg.account}, "
+                f"partition={slurm_cfg.partition}"
+            )
+        except RuntimeError as e:
+            raise ValueError(
+                f"SLURM autodiscovery failed: {e}\n"
+                "Please specify --account explicitly."
+            ) from e
+    else:
+        slurm_cfg = SlurmConfig(
+            account=account,
+            partition=partition,
+            time=time,
+            cpus_per_task=cpus,
+            mem_gb=mem_gb,
+            qos=qos,
+            constraint=constraint,
+            job_name_prefix=job_name_prefix,
+        )
 
-    slurm_cfg = SlurmConfig(
-        account=account,
-        partition=partition,
-        time=time,
-        cpus_per_task=cpus,
-        mem_gb=mem_gb,
-        qos=qos,
-        constraint=constraint,
-        job_name_prefix=job_name_prefix,
-    )
     if log_dir is None:
         log_dir = determine_log_dir(sim_paths)
     result_df = submit_artifacts_slurm(
@@ -1748,6 +1812,108 @@ def config_edit():
 
     editor = os.environ.get("EDITOR", "vi")
     subprocess.run([editor, str(config_path)], check=False)
+
+
+@config_app.command(name="cluster")
+def config_cluster(
+    json_output: Annotated[bool, Parameter("--json", help="Output in JSON format.")] = False,
+):
+    """Show discovered SLURM cluster information.
+
+    Queries the local SLURM scheduler and displays available partitions,
+    accounts, and QOS policies. Useful for verifying autodiscovery works
+    and understanding cluster resources before submitting jobs.
+
+    On non-SLURM machines, prints a helpful message instead of failing.
+    """
+    import json as json_module
+
+    from mdfactory.performance.cluster import discover_cluster
+
+    cluster = discover_cluster()
+
+    if cluster is None:
+        if json_output:
+            print(json_module.dumps({"error": "SLURM not available", "cluster": None}))
+        else:
+            print("SLURM cluster not detected.")
+            print()
+            print("This machine does not appear to be a SLURM cluster node,")
+            print("or SLURM commands (sinfo, sacctmgr) are not in PATH.")
+            print()
+            print("To use SLURM submission, run this command on a cluster login node.")
+        return
+
+    if json_output:
+        # Build JSON-serializable structure
+        data = {
+            "default_account": cluster.default_account,
+            "accounts": cluster.accounts,
+            "qos_policies": cluster.qos_policies,
+            "partitions": [
+                {
+                    "name": p.name,
+                    "state": p.state,
+                    "is_default": p.is_default,
+                    "max_time": p.max_time,
+                    "default_time": p.default_time,
+                    "total_nodes": p.total_nodes,
+                    "node_types": [
+                        {
+                            "cpus": nt.cpus,
+                            "memory_mb": nt.memory_mb,
+                            "gpus": nt.gpus,
+                            "gpu_type": nt.gpu_type,
+                            "features": list(nt.features),
+                        }
+                        for nt in p.node_types
+                    ],
+                }
+                for p in cluster.partitions
+            ],
+        }
+        print(json_module.dumps(data, indent=2))
+        return
+
+    # Human-readable output
+    print("SLURM Cluster Information")
+    print("=" * 50)
+    print()
+
+    # Account info
+    print(f"Default Account: {cluster.default_account or '(none)'}")
+    if cluster.accounts:
+        print(f"Available Accounts: {', '.join(cluster.accounts)}")
+    print()
+
+    # QOS info
+    if cluster.qos_policies:
+        print(f"QOS Policies: {', '.join(cluster.qos_policies)}")
+        print()
+
+    # Partition info
+    print("Partitions:")
+    print("-" * 50)
+    for partition in cluster.partitions:
+        default_marker = " (default)" if partition.is_default else ""
+        state_marker = f" [{partition.state}]" if partition.state != "up" else ""
+        print(f"\n  {partition.name}{default_marker}{state_marker}")
+        print(f"    Nodes: {partition.total_nodes}")
+        print(f"    Max Time: {partition.max_time}")
+        if partition.default_time != partition.max_time:
+            print(f"    Default Time: {partition.default_time}")
+
+        # Summarize node types
+        for nt in partition.node_types:
+            gpu_info = ""
+            if nt.gpus > 0:
+                gpu_type_str = nt.gpu_type or "GPU"
+                gpu_info = f", {nt.gpus}x {gpu_type_str}"
+            mem_gb = nt.memory_mb // 1024
+            features_str = ""
+            if nt.features:
+                features_str = f" [{', '.join(nt.features)}]"
+            print(f"      - {nt.cpus} CPUs, {mem_gb} GB{gpu_info}{features_str}")
 
 
 def main():

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -1261,8 +1261,7 @@ def analysis_run(
             )
         except RuntimeError as e:
             raise ValueError(
-                f"SLURM autodiscovery failed: {e}\n"
-                "Please specify --account explicitly."
+                f"SLURM autodiscovery failed: {e}\nPlease specify --account explicitly."
             ) from e
     else:
         slurm_cfg = SlurmConfig(
@@ -1582,8 +1581,7 @@ def analysis_artifacts_run(
             )
         except RuntimeError as e:
             raise ValueError(
-                f"SLURM autodiscovery failed: {e}\n"
-                "Please specify --account explicitly."
+                f"SLURM autodiscovery failed: {e}\nPlease specify --account explicitly."
             ) from e
     else:
         slurm_cfg = SlurmConfig(

--- a/mdfactory/performance/cluster.py
+++ b/mdfactory/performance/cluster.py
@@ -39,19 +39,20 @@ class NodeType:
         Number of CPU cores per node.
     memory_mb : int
         Memory in megabytes per node.
-    gpus : int
-        Number of GPUs per node (0 if CPU-only).
-    gpu_type : str or None
-        GPU model identifier (e.g., ``"a100"``, ``"h100"``), or None.
+    gpu_specs : tuple of (int, str)
+        GPU specifications as (count, type) tuples. Empty if CPU-only.
+        Multiple entries represent different GPU types on the same node.
     features : tuple of str
         SLURM feature/constraint tags on this node type (immutable).
+    count : int
+        Number of nodes with this exact configuration.
     """
 
     cpus: int
     memory_mb: int
-    gpus: int = 0
-    gpu_type: str | None = None
+    gpu_specs: tuple[tuple[int, str], ...] = field(default_factory=tuple)
     features: tuple[str, ...] = field(default_factory=tuple)
+    count: int = 1
 
 
 @dataclass(frozen=True)
@@ -139,53 +140,61 @@ def _run_command(cmd: list[str], *, timeout: int = 30) -> str | None:
         return None
 
 
-def _parse_gres(gres_str: str) -> tuple[int, str | None]:
-    """Parse SLURM GRES string to extract GPU count and type.
+def _parse_gres(gres_str: str) -> list[tuple[int, str | None]]:
+    """Parse SLURM GRES string to extract GPU count and type for all GPU entries.
 
     Parameters
     ----------
     gres_str : str
         GRES field from sinfo (e.g., ``"gpu:a100:4"``, ``"gpu:2"``, ``"(null)"``).
+        May contain multiple GPU entries separated by commas.
 
     Returns
     -------
-    tuple of (int, str or None)
-        (gpu_count, gpu_type). Returns (0, None) when no GPUs.
+    list of tuple (int, str or None)
+        List of (gpu_count, gpu_type) for each GPU entry. Empty list when no GPUs.
 
     Examples
     --------
     >>> _parse_gres("gpu:a100:4")
-    (4, 'a100')
-    >>> _parse_gres("gpu:2")
-    (2, None)
+    [(4, 'a100')]
+    >>> _parse_gres("gpu:b200:8(S:0-1),gpu:1g.23gb:7(S:1)")
+    [(8, 'b200'), (7, '1g.23gb')]
     >>> _parse_gres("(null)")
-    (0, None)
+    []
     """
     if not gres_str or gres_str == "(null)":
-        return 0, None
+        return []
+
+    gpu_entries = []
 
     # Handle multiple GRES entries separated by commas
     for raw_entry in gres_str.split(","):
         entry = raw_entry.strip()
         if not entry.startswith("gpu"):
             continue
+
+        # Strip socket binding suffix like "(S:0-1)" or "(IDX:0-3)"
+        if "(" in entry:
+            entry = entry.split("(")[0]
+
         parts = entry.split(":")
         if len(parts) == 3:
             # gpu:type:count
             _, gpu_type, count_str = parts
-            return int(count_str), gpu_type
+            gpu_entries.append((int(count_str), gpu_type))
         elif len(parts) == 2:
             # gpu:count (no type specified)
             _, count_str = parts
             # Check if second part is a number or a type
             try:
                 count = int(count_str)
-                return count, None
+                gpu_entries.append((count, None))
             except ValueError:
                 # gpu:type with implicit count of 1
-                return 1, count_str
+                gpu_entries.append((1, count_str))
 
-    return 0, None
+    return gpu_entries
 
 
 def _parse_time_limit(time_str: str) -> str:
@@ -311,34 +320,56 @@ def _parse_sinfo(output: str) -> list[Partition]:
             continue
 
         memory_mb = _parse_memory_mb(mem_str)
-        gpus, gpu_type = _parse_gres(gres_str)
+        gpu_entries = _parse_gres(gres_str)
         features = _parse_features(features_str)
 
         if partition_name not in partition_data:
             partition_data[partition_name] = {
                 "max_time": _parse_time_limit(max_time),
                 "default_time": _parse_time_limit(default_time),
-                "node_types": set(),
+                "node_types": {},  # Maps node_key -> count
                 "node_count": 0,
                 "is_default": is_default,
                 "has_healthy_node": False,
                 "last_unhealthy_state": "down",
             }
 
-        # Use a hashable representation for deduplication (features is already a tuple)
-        node_key = (cpus, memory_mb, gpus, gpu_type, features)
-        partition_data[partition_name]["node_types"].add(node_key)
-        partition_data[partition_name]["node_count"] += 1
-
         # Track if any line marks this as default
         if is_default:
             partition_data[partition_name]["is_default"] = True
 
-        # Track node health: partition is "up" if ANY node is schedulable
-        if state.lower() in ("idle", "mixed", "allocated", "completing", "planned"):
+        # Determine if node is operational (can schedule jobs or report accurate config)
+        # Exclude only truly broken/invalid nodes: down, drained, inval, fail, maint, unknown
+        state_lower = state.lower()
+        is_broken = any(
+            broken in state_lower
+            for broken in ("down", "drained", "inval", "fail", "maint", "unknown")
+        )
+        is_operational = not is_broken
+
+        # Partition is "up" if ANY operational node exists
+        if is_operational:
             partition_data[partition_name]["has_healthy_node"] = True
         else:
             partition_data[partition_name]["last_unhealthy_state"] = state
+
+        # Count all nodes (including allocated, reserved, etc.) for stable totals
+        partition_data[partition_name]["node_count"] += 1
+
+        # Only collect node specs from operational nodes
+        # (broken nodes may report incorrect/stale hardware configs)
+        if is_operational:
+            # Convert GPU entries to a sorted tuple for consistent hashing
+            # Sort by type name for deterministic ordering
+            gpu_specs = tuple(sorted(gpu_entries, key=lambda x: x[1] or ""))
+
+            # Use a hashable representation for deduplication
+            node_key = (cpus, memory_mb, gpu_specs, features)
+
+            # Track count of nodes with this exact configuration
+            if node_key not in partition_data[partition_name]["node_types"]:
+                partition_data[partition_name]["node_types"][node_key] = 0
+            partition_data[partition_name]["node_types"][node_key] += 1
 
     # Build Partition objects
     partitions = []
@@ -354,14 +385,14 @@ def _parse_sinfo(output: str) -> list[Partition]:
             NodeType(
                 cpus=cpus,
                 memory_mb=mem,
-                gpus=gpus,
-                gpu_type=gtype,
+                gpu_specs=gpu_specs,
                 features=feats,
+                count=count,
             )
-            for cpus, mem, gpus, gtype, feats in data["node_types"]
+            for (cpus, mem, gpu_specs, feats), count in data["node_types"].items()
         ]
-        # Sort node types by CPU count for deterministic ordering
-        node_types.sort(key=lambda n: (n.cpus, n.memory_mb, n.gpus))
+        # Sort node types by CPU count, memory, then GPU specs for deterministic ordering
+        node_types.sort(key=lambda n: (n.cpus, n.memory_mb, n.gpu_specs))
 
         partitions.append(
             Partition(
@@ -616,7 +647,9 @@ def select_partition(
                 continue
             if node.memory_mb < min_mem_mb:
                 continue
-            if needs_gpu and node.gpus == 0:
+            # Check if node has any GPUs
+            has_gpu = len(node.gpu_specs) > 0
+            if needs_gpu and not has_gpu:
                 continue
             has_qualifying_node = True
             break

--- a/mdfactory/tests/test_cli_cluster.py
+++ b/mdfactory/tests/test_cli_cluster.py
@@ -1,0 +1,155 @@
+# ABOUTME: Tests for the `mdfactory config cluster` CLI command, verifying
+# ABOUTME: SLURM autodiscovery output in human-readable and JSON formats.
+"""Tests for mdfactory config cluster CLI command."""
+
+import json
+
+from mdfactory import cli
+from mdfactory.performance import cluster as cluster_mod
+
+
+class TestConfigClusterCommand:
+    """Tests for the config cluster CLI command."""
+
+    def test_config_cluster_no_slurm(self, monkeypatch, capsys):
+        """Test graceful message when SLURM is not available."""
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+
+        cli.config_cluster(json_output=False)
+
+        captured = capsys.readouterr()
+        assert "SLURM cluster not detected" in captured.out
+        assert "login node" in captured.out
+
+    def test_config_cluster_no_slurm_json(self, monkeypatch, capsys):
+        """Test JSON output when SLURM is not available."""
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+
+        cli.config_cluster(json_output=True)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["cluster"] is None
+        assert "error" in data
+
+    def test_config_cluster_with_slurm(self, monkeypatch, capsys):
+        """Test human-readable output with SLURM cluster."""
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="7-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpus=0),
+            ],
+            total_nodes=100,
+            is_default=True,
+        )
+        gpu_partition = cluster_mod.Partition(
+            name="gpu",
+            state="up",
+            max_time="2-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(
+                    cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100"
+                ),
+            ],
+            total_nodes=20,
+            is_default=False,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition, gpu_partition],
+            accounts=["myaccount", "shared"],
+            qos_policies=["normal", "high"],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        cli.config_cluster(json_output=False)
+
+        captured = capsys.readouterr()
+        assert "SLURM Cluster Information" in captured.out
+        assert "Default Account: myaccount" in captured.out
+        assert "compute" in captured.out
+        assert "(default)" in captured.out
+        assert "gpu" in captured.out
+        assert "a100" in captured.out
+        assert "64 CPUs" in captured.out
+        assert "4x a100" in captured.out
+
+    def test_config_cluster_with_slurm_json(self, monkeypatch, capsys):
+        """Test JSON output with SLURM cluster."""
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="7-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(
+                    cpus=64,
+                    memory_mb=256 * 1024,
+                    gpus=0,
+                    features=("avx512", "intel"),
+                ),
+            ],
+            total_nodes=100,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=["normal"],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        cli.config_cluster(json_output=True)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert data["default_account"] == "myaccount"
+        assert data["accounts"] == ["myaccount"]
+        assert data["qos_policies"] == ["normal"]
+        assert len(data["partitions"]) == 1
+
+        part = data["partitions"][0]
+        assert part["name"] == "compute"
+        assert part["is_default"] is True
+        assert part["total_nodes"] == 100
+        assert len(part["node_types"]) == 1
+
+        nt = part["node_types"][0]
+        assert nt["cpus"] == 64
+        assert nt["memory_mb"] == 256 * 1024
+        assert nt["gpus"] == 0
+        assert nt["features"] == ["avx512", "intel"]
+
+    def test_config_cluster_down_partition(self, monkeypatch, capsys):
+        """Test display of partition with down state."""
+        mock_partition = cluster_mod.Partition(
+            name="maintenance",
+            state="drained",
+            max_time="1:00:00",
+            default_time="0:30:00",
+            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=32 * 1024)],
+            total_nodes=5,
+            is_default=False,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        cli.config_cluster(json_output=False)
+
+        captured = capsys.readouterr()
+        assert "maintenance" in captured.out
+        assert "[drained]" in captured.out

--- a/mdfactory/tests/test_cli_cluster.py
+++ b/mdfactory/tests/test_cli_cluster.py
@@ -51,9 +51,7 @@ class TestConfigClusterCommand:
             max_time="2-00:00:00",
             default_time="1:00:00",
             node_types=[
-                cluster_mod.NodeType(
-                    cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100"
-                ),
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100"),
             ],
             total_nodes=20,
             is_default=False,

--- a/mdfactory/tests/test_cli_cluster.py
+++ b/mdfactory/tests/test_cli_cluster.py
@@ -40,7 +40,7 @@ class TestConfigClusterCommand:
             max_time="7-00:00:00",
             default_time="1:00:00",
             node_types=[
-                cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpus=0),
+                cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpu_specs=(), count=100),
             ],
             total_nodes=100,
             is_default=True,
@@ -51,7 +51,9 @@ class TestConfigClusterCommand:
             max_time="2-00:00:00",
             default_time="1:00:00",
             node_types=[
-                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100"),
+                cluster_mod.NodeType(
+                    cpus=32, memory_mb=128 * 1024, gpu_specs=((4, "a100"),), count=20
+                ),
             ],
             total_nodes=20,
             is_default=False,
@@ -88,8 +90,9 @@ class TestConfigClusterCommand:
                 cluster_mod.NodeType(
                     cpus=64,
                     memory_mb=256 * 1024,
-                    gpus=0,
+                    gpu_specs=(),
                     features=("avx512", "intel"),
+                    count=100,
                 ),
             ],
             total_nodes=100,
@@ -123,8 +126,9 @@ class TestConfigClusterCommand:
         nt = part["node_types"][0]
         assert nt["cpus"] == 64
         assert nt["memory_mb"] == 256 * 1024
-        assert nt["gpus"] == 0
+        assert nt["gpu_specs"] == []  # No GPUs
         assert nt["features"] == ["avx512", "intel"]
+        assert nt["count"] == 100
 
     def test_config_cluster_down_partition(self, monkeypatch, capsys):
         """Test display of partition with down state."""
@@ -133,7 +137,7 @@ class TestConfigClusterCommand:
             state="drained",
             max_time="1:00:00",
             default_time="0:30:00",
-            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=32 * 1024)],
+            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=32 * 1024, count=5)],
             total_nodes=5,
             is_default=False,
         )

--- a/mdfactory/tests/test_cluster.py
+++ b/mdfactory/tests/test_cluster.py
@@ -93,25 +93,37 @@ class TestParseGres:
     """Test GPU GRES string parsing."""
 
     def test_gpu_with_type_and_count(self):
-        assert _parse_gres("gpu:a100:4") == (4, "a100")
+        assert _parse_gres("gpu:a100:4") == [(4, "a100")]
 
     def test_gpu_with_count_only(self):
-        assert _parse_gres("gpu:2") == (2, None)
+        assert _parse_gres("gpu:2") == [(2, None)]
 
     def test_gpu_with_type_only(self):
-        assert _parse_gres("gpu:h100") == (1, "h100")
+        assert _parse_gres("gpu:h100") == [(1, "h100")]
 
     def test_null_gres(self):
-        assert _parse_gres("(null)") == (0, None)
+        assert _parse_gres("(null)") == []
 
     def test_empty_string(self):
-        assert _parse_gres("") == (0, None)
+        assert _parse_gres("") == []
 
     def test_multi_gres_with_gpu(self):
-        assert _parse_gres("mps:shared,gpu:a100:4") == (4, "a100")
+        assert _parse_gres("mps:shared,gpu:a100:4") == [(4, "a100")]
 
     def test_non_gpu_gres(self):
-        assert _parse_gres("mps:shared") == (0, None)
+        assert _parse_gres("mps:shared") == []
+
+    def test_multiple_gpu_types(self):
+        """Test multiple GPU entries (e.g., MIG slices)."""
+        result = _parse_gres("gpu:b200:7,gpu:1g.23gb:7")
+        assert len(result) == 2
+        assert (7, "1g.23gb") in result
+        assert (7, "b200") in result
+
+    def test_socket_binding_stripped(self):
+        """Test that socket binding suffixes are removed."""
+        assert _parse_gres("gpu:l40s:4(S:0-1)") == [(4, "l40s")]
+        assert _parse_gres("gpu:b200:8(S:0-1),gpu:1g.23gb:7(S:1)") == [(8, "b200"), (7, "1g.23gb")]
 
 
 # ---------------------------------------------------------------------------
@@ -155,9 +167,9 @@ class TestParseSinfo:
         nt = cpu_part.node_types[0]
         assert nt.cpus == 128
         assert nt.memory_mb == 512000
-        assert nt.gpus == 0
-        assert nt.gpu_type is None
+        assert nt.gpu_specs == ()  # No GPUs
         assert "epyc9555" in nt.features
+        assert nt.count == 3  # 3 nodes with this config
 
     def test_gpu_partition_multiple_node_types(self):
         partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
@@ -166,13 +178,15 @@ class TestParseSinfo:
         # 2 distinct node types: a100 (64 core) and h100 (96 core)
         assert len(gpu_part.node_types) == 2
 
-        a100_node = next(n for n in gpu_part.node_types if n.gpu_type == "a100")
+        a100_node = next(n for n in gpu_part.node_types if (4, "a100") in n.gpu_specs)
         assert a100_node.cpus == 64
-        assert a100_node.gpus == 4
+        assert a100_node.gpu_specs == ((4, "a100"),)
+        assert a100_node.count == 2  # 2 a100 nodes
 
-        h100_node = next(n for n in gpu_part.node_types if n.gpu_type == "h100")
+        h100_node = next(n for n in gpu_part.node_types if (8, "h100") in n.gpu_specs)
         assert h100_node.cpus == 96
-        assert h100_node.gpus == 8
+        assert h100_node.gpu_specs == ((8, "h100"),)
+        assert h100_node.count == 1  # 1 h100 node
 
     def test_total_node_count(self):
         partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
@@ -201,8 +215,7 @@ class TestParseSinfo:
         partitions = _parse_sinfo(SINFO_OUTPUT_NO_TYPE_GPU)
         assert len(partitions) == 1
         nt = partitions[0].node_types[0]
-        assert nt.gpus == 4
-        assert nt.gpu_type is None
+        assert nt.gpu_specs == ((4, None),)  # 4 GPUs, no type specified
 
     def test_default_time_parsed_separately(self):
         partitions = _parse_sinfo(SINFO_OUTPUT_MIXED)
@@ -479,7 +492,7 @@ class TestDataclasses:
     """Test dataclass construction and immutability."""
 
     def test_node_type_frozen(self):
-        nt = NodeType(cpus=64, memory_mb=256000, gpus=4, gpu_type="a100")
+        nt = NodeType(cpus=64, memory_mb=256000, gpu_specs=((4, "a100"),), count=1)
         with pytest.raises(AttributeError):
             nt.cpus = 128  # type: ignore[misc]
 
@@ -495,12 +508,14 @@ class TestDataclasses:
 
     def test_node_type_defaults(self):
         nt = NodeType(cpus=32, memory_mb=64000)
-        assert nt.gpus == 0
-        assert nt.gpu_type is None
+        assert nt.gpu_specs == ()  # No GPUs by default
         assert nt.features == ()
+        assert nt.count == 1  # Default count
 
     def test_node_type_features_immutable(self):
-        nt = NodeType(cpus=64, memory_mb=256000, features=("a100", "nvlink"))
+        nt = NodeType(
+            cpus=64, memory_mb=256000, gpu_specs=((4, "a100"),), features=("a100", "nvlink")
+        )
         assert nt.features == ("a100", "nvlink")
         with pytest.raises(TypeError):
             nt.features[0] = "other"  # type: ignore[index]

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -385,3 +385,153 @@ def test_submit_analyses_slurm_forwards_analysis_kwargs(monkeypatch, tmp_path):
 
     assert len(submitted_kwargs) == 1
     assert submitted_kwargs[0]["analysis_kwargs"] == {"start_ns": 50.0, "stride": 2}
+
+
+# --- SlurmConfig.from_cluster tests ---
+
+
+class TestSlurmConfigFromCluster:
+    """Tests for SlurmConfig.from_cluster() autodiscovery method."""
+
+    def test_from_cluster_success(self, monkeypatch):
+        """Test successful autodiscovery creates correct config."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        # Create mock cluster info
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="3-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=0),
+            ],
+            total_nodes=10,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount", "otheraccount"],
+            qos_policies=["normal", "high"],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        config = submit_mod.SlurmConfig.from_cluster(
+            time="4h",
+            cpus_per_task=8,
+            mem_gb=16,
+        )
+
+        assert config.account == "myaccount"
+        assert config.partition == "compute"
+        assert config.time == "4h"
+        assert config.cpus_per_task == 8
+        assert config.mem_gb == 16
+
+    def test_from_cluster_no_slurm_raises(self, monkeypatch):
+        """Test that missing SLURM raises RuntimeError."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: None)
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="not running on a SLURM cluster"):
+            submit_mod.SlurmConfig.from_cluster()
+
+    def test_from_cluster_no_account_raises(self, monkeypatch):
+        """Test that missing default account raises RuntimeError."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        mock_partition = cluster_mod.Partition(
+            name="compute",
+            state="up",
+            max_time="1-00:00:00",
+            default_time="1:00:00",
+            node_types=[cluster_mod.NodeType(cpus=16, memory_mb=64 * 1024)],
+            total_nodes=5,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=[],
+            qos_policies=[],
+            default_account=None,
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="no default account found"):
+            submit_mod.SlurmConfig.from_cluster()
+
+    def test_from_cluster_no_suitable_partition_raises(self, monkeypatch):
+        """Test that no matching partition raises RuntimeError."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        # Partition with only 4 CPUs - won't match request for 32 CPUs
+        mock_partition = cluster_mod.Partition(
+            name="tiny",
+            state="up",
+            max_time="1:00:00",
+            default_time="0:30:00",
+            node_types=[cluster_mod.NodeType(cpus=4, memory_mb=8 * 1024)],
+            total_nodes=2,
+            is_default=True,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[mock_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="No suitable partition found"):
+            submit_mod.SlurmConfig.from_cluster(min_cpus=32)
+
+    def test_from_cluster_selects_gpu_partition(self, monkeypatch):
+        """Test that needs_gpu=True selects GPU partition."""
+        from mdfactory.performance import cluster as cluster_mod
+
+        cpu_partition = cluster_mod.Partition(
+            name="cpu",
+            state="up",
+            max_time="7-00:00:00",
+            default_time="1:00:00",
+            node_types=[cluster_mod.NodeType(cpus=64, memory_mb=256 * 1024, gpus=0)],
+            total_nodes=100,
+            is_default=True,
+        )
+        gpu_partition = cluster_mod.Partition(
+            name="gpu",
+            state="up",
+            max_time="2-00:00:00",
+            default_time="1:00:00",
+            node_types=[
+                cluster_mod.NodeType(
+                    cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100"
+                )
+            ],
+            total_nodes=20,
+            is_default=False,
+        )
+        mock_cluster = cluster_mod.ClusterInfo(
+            partitions=[cpu_partition, gpu_partition],
+            accounts=["myaccount"],
+            qos_policies=[],
+            default_account="myaccount",
+        )
+
+        monkeypatch.setattr(cluster_mod, "discover_cluster", lambda: mock_cluster)
+
+        config = submit_mod.SlurmConfig.from_cluster(needs_gpu=True)
+
+        assert config.partition == "gpu"
+        assert config.account == "myaccount"

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -515,9 +515,7 @@ class TestSlurmConfigFromCluster:
             max_time="2-00:00:00",
             default_time="1:00:00",
             node_types=[
-                cluster_mod.NodeType(
-                    cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100"
-                )
+                cluster_mod.NodeType(cpus=32, memory_mb=128 * 1024, gpus=4, gpu_type="a100")
             ],
             total_nodes=20,
             is_default=False,

--- a/mdfactory/tests/test_submit.py
+++ b/mdfactory/tests/test_submit.py
@@ -494,7 +494,7 @@ class TestSlurmConfigFromCluster:
         import pytest
 
         with pytest.raises(RuntimeError, match="No suitable partition found"):
-            submit_mod.SlurmConfig.from_cluster(min_cpus=32)
+            submit_mod.SlurmConfig.from_cluster(cpus_per_task=32)
 
     def test_from_cluster_selects_gpu_partition(self, monkeypatch):
         """Test that needs_gpu=True selects GPU partition."""


### PR DESCRIPTION
Connects the autodiscovery module to existing infrastructure so users benefit from it without changing their workflow.

- Add `SlurmConfig.from_cluster()` classmethod that auto-populates account/partition from discovered cluster info
- Add `mdfactory config cluster` CLI command to display discovered SLURM resources
- Add `mdfactory config cluster --json` for machine-readable output
- Update `analysis run --slurm` and `analysis artifacts run --slurm` to use autodiscovery when `--account` not provided

## Files Changed

| File | Change |
|------|--------|
| `mdfactory/analysis/submit.py` | Add `SlurmConfig.from_cluster()` classmethod |
| `mdfactory/cli.py` | Add `config cluster` command, autodiscovery fallback in SLURM commands |
| `mdfactory/tests/test_submit.py` | Tests for `from_cluster()` |
| `mdfactory/tests/test_cli_cluster.py` | Tests for `config cluster` command |

## Test plan

- [x] `pytest mdfactory/tests/test_submit.py -v` — all pass
- [x] `pytest mdfactory/tests/test_cli_cluster.py -v` — all pass
- [x] Manual: `mdfactory config cluster` on SLURM node shows cluster info
- [x] Manual: `mdfactory config cluster` on laptop shows graceful message