### PR TITLE
feat: add Parsl-based parallel build orchestration

### DIFF
--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -173,6 +173,13 @@ def _build_from_csv(
             logger.error(f"  Row {k}: {v}")
         sys.exit(1)
 
+    if dry_run:
+        from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
+
+        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        build_systems_dry_run(models, executor_config, output_dir=output)
+        return
+
     # Create per-hash directories and write YAML files
     for model in models:
         build_dir = output / model.hash
@@ -181,13 +188,6 @@ def _build_from_csv(
         if not yml_path.exists():
             with open(yml_path, "w") as f:
                 yaml.safe_dump(model.model_dump(), f)
-
-    if dry_run:
-        from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
-
-        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
-        build_systems_dry_run(models, executor_config, output_dir=output)
-        return
 
     if config is not None:
         # Parallel builds via Parsl
@@ -217,7 +217,11 @@ def _build_from_yaml(
     with open(input) as f:
         data = yaml.safe_load(f)
 
-    if isinstance(data, dict) and "system_directory" in data:
+    if not isinstance(data, dict):
+        logger.error(f"Invalid YAML input file (empty or not a mapping): {input}")
+        sys.exit(1)
+
+    if "system_directory" in data:
         # Summary YAML -- dispatch builds for prepared systems
         _build_from_summary_yaml(data, output, config=config, dry_run=dry_run)
     else:
@@ -263,6 +267,13 @@ def _build_from_summary_yaml(
 
     if not dirs:
         logger.error("Summary YAML contains no system_directory entries.")
+        sys.exit(1)
+
+    if len(dirs) != len(hashes):
+        logger.error(
+            f"Summary YAML is malformed: system_directory has {len(dirs)} entries "
+            f"but hash has {len(hashes)}."
+        )
         sys.exit(1)
 
     from mdfactory.models.input import BuildInput

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -173,24 +173,48 @@ def _build_from_csv(
             logger.error(f"  Row {k}: {v}")
         sys.exit(1)
 
-    if config is not None or dry_run:
-        # Parallel builds via Parsl (or dry-run preview)
+    if dry_run:
         from mdfactory.orchestration import ExecutorConfig, build_systems
 
         executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
-        results = build_systems(models, executor_config, output_dir=output, dry_run=dry_run)
-        if not dry_run:
-            _report_build_results(results)
-    else:
-        # Sequential local builds — create per-hash directories
-        for model in models:
-            build_dir = output / model.hash
-            build_dir.mkdir(parents=True, exist_ok=True)
-            yml_path = build_dir / f"{model.hash}.yaml"
-            if not yml_path.exists():
-                with open(yml_path, "w") as f:
-                    yaml.safe_dump(model.model_dump(), f)
+        build_systems(models, executor_config, output_dir=output, dry_run=True)
+        return
 
+    # Create per-hash directories, write per-system YAMLs, and generate summary
+    dirs = []
+    for model in models:
+        build_dir = output / model.hash
+        build_dir.mkdir(parents=True, exist_ok=True)
+        yml_path = build_dir / f"{model.hash}.yaml"
+        if not yml_path.exists():
+            with open(yml_path, "w") as f:
+                yaml.safe_dump(model.model_dump(), f)
+        dirs.append(str(build_dir.resolve()))
+
+    # Write summary YAML (same format as prepare-build)
+    summary_path = output / f"{input.stem}.yaml"
+    summary = {
+        "n_systems": len(models),
+        "input": str(input),
+        "output": str(output),
+        "hash": [m.hash for m in models],
+        "simulation_type": [m.simulation_type for m in models],
+        "system_directory": dirs,
+        "date": datetime.now(),
+    }
+    with open(summary_path, "w") as f:
+        yaml.safe_dump(summary, f)
+    logger.info(f"Summary YAML written to {summary_path}")
+
+    if config is not None:
+        # Parallel builds via Parsl
+        from mdfactory.orchestration import ExecutorConfig, build_systems
+
+        executor_config = ExecutorConfig.from_yaml(config)
+        results = build_systems(models, executor_config, output_dir=output)
+        _report_build_results(results)
+    else:
+        # Sequential local builds
         logger.info(f"Building {len(models)} system(s) sequentially.")
         for model in models:
             build_dir = output / model.hash

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 import pandas as pd
 import questionary
@@ -34,6 +34,9 @@ from .utils.data_manager import check_run_exists
 from .utils.push import push_systems
 from .utils.utilities import working_directory
 from .workflows import run_build_from_dict, run_build_from_file
+
+if TYPE_CHECKING:
+    from .orchestration import ExecutorConfig
 
 app = App(name="MDFactory", version=__version__)
 
@@ -82,26 +85,7 @@ def prepare_build(input: Path, output: Path = Path(".")):
 
     logger.info("Created DataFrame for systems:\n{}", df)
 
-    dirs = []
-    for _, row in df.iterrows():
-        out = output / Path(row.hash)
-        out.mkdir(parents=True, exist_ok=False)
-        yml_path = out / f"{row.hash}.yaml"
-        dirs.append(str(out.resolve()))
-        with open(yml_path, "w") as fb:
-            yaml.safe_dump(row.model.model_dump(), fb)
-
-    summary = {
-        "n_systems": df.shape[0],
-        "input": str(input),
-        "output": str(output),
-        "hash": df.hash.values.tolist(),
-        "simulation_type": [x.simulation_type for x in df.model.values],
-        "system_directory": dirs,
-        "date": datetime.now(),
-    }
-    with open(yml_build_path, "w") as fb:
-        yaml.safe_dump(summary, fb)
+    _prepare_system_directories(models, input, output, exist_ok=False)
 
 
 def df_models_from_input_csv(input):
@@ -112,20 +96,73 @@ def df_models_from_input_csv(input):
     return df, models, errors
 
 
-def _resolve_slurm_flag(slurm: str | None) -> Path | None:
-    """Resolve the ``--slurm`` CLI flag to an executor config YAML path.
+def _prepare_system_directories(
+    models: list,
+    input_path: Path,
+    output: Path,
+    *,
+    exist_ok: bool = True,
+) -> tuple[list[str], Path]:
+    """Create per-hash build directories, write system YAMLs, and generate summary.
+
+    Parameters
+    ----------
+    models : list
+        List of BuildInput models.
+    input_path : Path
+        Original input file path (used for summary YAML naming).
+    output : Path
+        Base output directory.
+    exist_ok : bool
+        Whether to allow existing directories.
+
+    Returns
+    -------
+    tuple[list[str], Path]
+        List of system directory paths, and path to the summary YAML.
+
+    """
+    dirs = []
+    for model in models:
+        build_dir = output / model.hash
+        build_dir.mkdir(parents=True, exist_ok=exist_ok)
+        yml_path = build_dir / f"{model.hash}.yaml"
+        if not yml_path.exists():
+            with open(yml_path, "w") as f:
+                yaml.safe_dump(model.model_dump(), f)
+        dirs.append(str(build_dir.resolve()))
+
+    summary_path = output / f"{input_path.stem}.yaml"
+    summary = {
+        "n_systems": len(models),
+        "input": str(input_path),
+        "output": str(output),
+        "hash": [m.hash for m in models],
+        "simulation_type": [m.simulation_type for m in models],
+        "system_directory": dirs,
+        "date": datetime.now(),
+    }
+    with open(summary_path, "w") as f:
+        yaml.safe_dump(summary, f)
+    return dirs, summary_path
+
+
+def _resolve_slurm_flag(slurm: str | None) -> "ExecutorConfig | Path | None":
+    """Resolve the ``--slurm`` CLI flag to an executor config or YAML path.
 
     Parameters
     ----------
     slurm : str or None
         Raw value from the ``--slurm`` flag.  ``"tui"`` launches the
-        interactive wizard (which writes a temporary YAML).  Any other
-        non-None value is treated as a file path.
+        interactive wizard (which returns a config object directly).
+        Any other non-None value is treated as a file path.
 
     Returns
     -------
-    Path or None
-        Path to executor config YAML, or None if no SLURM config requested.
+    ExecutorConfig, Path, or None
+        An ExecutorConfig when using TUI mode, a Path to executor config
+        YAML, or None if no SLURM config requested.
+
     """
     if slurm is None:
         return None
@@ -134,29 +171,42 @@ def _resolve_slurm_flag(slurm: str | None) -> Path | None:
         from mdfactory.orchestration.tui import UserCancelledError, configure_slurm_interactive
 
         try:
-            config = configure_slurm_interactive()
+            return configure_slurm_interactive()
         except UserCancelledError:
             logger.info("SLURM configuration cancelled.")
             sys.exit(0)
-
-        # Write to a temporary YAML so the existing from_yaml flow works
-        import tempfile
-
-        import yaml as _yaml
-
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", prefix="mdfactory_slurm_", delete=False
-        )
-        _yaml.dump(config.model_dump(exclude_none=True), tmp, default_flow_style=False)
-        tmp.close()
-        logger.info(f"Using SLURM config from interactive wizard ({tmp.name})")
-        return Path(tmp.name)
 
     path = Path(slurm)
     if not path.exists():
         logger.error(f"SLURM config file not found: {path}")
         sys.exit(1)
     return path
+
+
+def _load_executor_config(config: "ExecutorConfig | Path | None") -> "ExecutorConfig":
+    """Load executor config from path or return directly if already loaded.
+
+    Parameters
+    ----------
+    config : ExecutorConfig, Path, or None
+        An already-loaded config object, a path to a YAML file, or None
+        for default local execution.
+
+    Returns
+    -------
+    ExecutorConfig
+        The resolved executor configuration.
+
+    """
+    if config is None:
+        from mdfactory.orchestration import ExecutorConfig
+
+        return ExecutorConfig()
+    if isinstance(config, Path):
+        from mdfactory.orchestration import ExecutorConfig
+
+        return ExecutorConfig.from_yaml(config)
+    return config  # already an ExecutorConfig instance
 
 
 @app.command(name="build", group="Build")
@@ -200,7 +250,7 @@ def build_system(
 
     # Resolve --slurm flag: "tui" launches the interactive wizard,
     # anything else is treated as a path to a YAML config file.
-    config: Path | None = _resolve_slurm_flag(slurm)
+    config: "ExecutorConfig | Path | None" = _resolve_slurm_flag(slurm)
 
     suffix = input.suffix.lower()
 
@@ -217,7 +267,7 @@ def _build_from_csv(
     input: Path,
     output: Path,
     *,
-    config: Path | None = None,
+    config: "ExecutorConfig | Path | None" = None,
     dry_run: bool = False,
 ):
     """Handle CSV input for the build command."""
@@ -229,43 +279,21 @@ def _build_from_csv(
         sys.exit(1)
 
     if dry_run:
-        from mdfactory.orchestration import ExecutorConfig, build_systems
+        from mdfactory.orchestration import build_systems
 
-        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        executor_config = _load_executor_config(config)
         build_systems(models, executor_config, output_dir=output, dry_run=True)
         return
 
     # Create per-hash directories, write per-system YAMLs, and generate summary
-    dirs = []
-    for model in models:
-        build_dir = output / model.hash
-        build_dir.mkdir(parents=True, exist_ok=True)
-        yml_path = build_dir / f"{model.hash}.yaml"
-        if not yml_path.exists():
-            with open(yml_path, "w") as f:
-                yaml.safe_dump(model.model_dump(), f)
-        dirs.append(str(build_dir.resolve()))
-
-    # Write summary YAML (same format as prepare-build)
-    summary_path = output / f"{input.stem}.yaml"
-    summary = {
-        "n_systems": len(models),
-        "input": str(input),
-        "output": str(output),
-        "hash": [m.hash for m in models],
-        "simulation_type": [m.simulation_type for m in models],
-        "system_directory": dirs,
-        "date": datetime.now(),
-    }
-    with open(summary_path, "w") as f:
-        yaml.safe_dump(summary, f)
+    dirs, summary_path = _prepare_system_directories(models, input, output, exist_ok=True)
     logger.info(f"Summary YAML written to {summary_path}")
 
     if config is not None:
         # Parallel builds via Parsl
-        from mdfactory.orchestration import ExecutorConfig, build_systems
+        from mdfactory.orchestration import build_systems
 
-        executor_config = ExecutorConfig.from_yaml(config)
+        executor_config = _load_executor_config(config)
         results = build_systems(models, executor_config, output_dir=output)
         _report_build_results(results)
     else:
@@ -282,7 +310,7 @@ def _build_from_yaml(
     input: Path,
     output: Path,
     *,
-    config: Path | None = None,
+    config: "ExecutorConfig | Path | None" = None,
     dry_run: bool = False,
 ):
     """Handle YAML input for the build command."""
@@ -303,9 +331,9 @@ def _build_from_yaml(
         model = BuildInput(**data)
 
         if config is not None or dry_run:
-            from mdfactory.orchestration import ExecutorConfig, build_systems
+            from mdfactory.orchestration import build_systems
 
-            executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+            executor_config = _load_executor_config(config)
             results = build_systems([model], executor_config, output_dir=output, dry_run=dry_run)
             if not dry_run:
                 _report_build_results(results)
@@ -320,7 +348,7 @@ def _build_from_summary_yaml(
     data: dict,
     output: Path,
     *,
-    config: Path | None = None,
+    config: "ExecutorConfig | Path | None" = None,
     dry_run: bool = False,
 ):
     """Handle summary YAML (from prepare-build) for the build command."""
@@ -351,9 +379,9 @@ def _build_from_summary_yaml(
         models.append(BuildInput(**model_data))
 
     if config is not None or dry_run:
-        from mdfactory.orchestration import ExecutorConfig, build_systems
+        from mdfactory.orchestration import build_systems
 
-        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        executor_config = _load_executor_config(config)
         results = build_systems(models, executor_config, output_dir=output, dry_run=dry_run)
         if not dry_run:
             _report_build_results(results)

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -173,31 +173,24 @@ def _build_from_csv(
             logger.error(f"  Row {k}: {v}")
         sys.exit(1)
 
-    if dry_run:
-        from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
-
-        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
-        build_systems_dry_run(models, executor_config, output_dir=output)
-        return
-
-    # Create per-hash directories and write YAML files
-    for model in models:
-        build_dir = output / model.hash
-        build_dir.mkdir(parents=True, exist_ok=True)
-        yml_path = build_dir / f"{model.hash}.yaml"
-        if not yml_path.exists():
-            with open(yml_path, "w") as f:
-                yaml.safe_dump(model.model_dump(), f)
-
-    if config is not None:
-        # Parallel builds via Parsl
+    if config is not None or dry_run:
+        # Parallel builds via Parsl (or dry-run preview)
         from mdfactory.orchestration import ExecutorConfig, build_systems
 
-        executor_config = ExecutorConfig.from_yaml(config)
-        results = build_systems(models, executor_config, output_dir=output)
-        _report_build_results(results)
+        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        results = build_systems(models, executor_config, output_dir=output, dry_run=dry_run)
+        if not dry_run:
+            _report_build_results(results)
     else:
-        # Sequential local builds
+        # Sequential local builds — create per-hash directories
+        for model in models:
+            build_dir = output / model.hash
+            build_dir.mkdir(parents=True, exist_ok=True)
+            yml_path = build_dir / f"{model.hash}.yaml"
+            if not yml_path.exists():
+                with open(yml_path, "w") as f:
+                    yaml.safe_dump(model.model_dump(), f)
+
         logger.info(f"Building {len(models)} system(s) sequentially.")
         for model in models:
             build_dir = output / model.hash
@@ -226,28 +219,18 @@ def _build_from_yaml(
         _build_from_summary_yaml(data, output, config=config, dry_run=dry_run)
     else:
         # Single build YAML
-        if dry_run:
-            from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
+        from mdfactory.models.input import BuildInput
 
-            executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
-            from mdfactory.models.input import BuildInput
+        model = BuildInput(**data)
 
-            model = BuildInput(**data)
-            build_systems_dry_run([model], executor_config, output_dir=output)
-            return
-
-        if config is not None:
-            from mdfactory.models.input import BuildInput
+        if config is not None or dry_run:
             from mdfactory.orchestration import ExecutorConfig, build_systems
 
-            executor_config = ExecutorConfig.from_yaml(config)
-            model = BuildInput(**data)
-            results = build_systems([model], executor_config, output_dir=output)
-            _report_build_results(results)
+            executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+            results = build_systems([model], executor_config, output_dir=output, dry_run=dry_run)
+            if not dry_run:
+                _report_build_results(results)
         else:
-            from mdfactory.models.input import BuildInput
-
-            model = BuildInput(**data)
             build_dir = output / model.hash
             logger.info(f"Building {model.hash} ({model.simulation_type}) -> {build_dir}")
             with working_directory(build_dir, create=True):
@@ -288,19 +271,13 @@ def _build_from_summary_yaml(
             model_data = yaml.safe_load(f)
         models.append(BuildInput(**model_data))
 
-    if dry_run:
-        from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
-
-        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
-        build_systems_dry_run(models, executor_config, output_dir=output)
-        return
-
-    if config is not None:
+    if config is not None or dry_run:
         from mdfactory.orchestration import ExecutorConfig, build_systems
 
-        executor_config = ExecutorConfig.from_yaml(config)
-        results = build_systems(models, executor_config, output_dir=output)
-        _report_build_results(results)
+        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        results = build_systems(models, executor_config, output_dir=output, dry_run=dry_run)
+        if not dry_run:
+            _report_build_results(results)
     else:
         # Sequential local builds
         logger.info(f"Building {len(models)} prepared system(s) sequentially.")

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -241,8 +241,12 @@ def _build_from_yaml(
             results = build_systems([model], executor_config, output_dir=output)
             _report_build_results(results)
         else:
-            logger.info(f"Building system from YAML file {input} and output directory: {output}.")
-            with working_directory(output, create=True):
+            from mdfactory.models.input import BuildInput
+
+            model = BuildInput(**data)
+            build_dir = output / model.hash
+            logger.info(f"Building {model.hash} ({model.simulation_type}) -> {build_dir}")
+            with working_directory(build_dir, create=True):
                 run_build_from_file(input)
 
 

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -33,7 +33,7 @@ from .prepare import df_to_build_input_models
 from .utils.data_manager import check_run_exists
 from .utils.push import push_systems
 from .utils.utilities import working_directory
-from .workflows import run_build_from_file
+from .workflows import run_build_from_dict, run_build_from_file
 
 app = App(name="MDFactory", version=__version__)
 
@@ -113,21 +113,196 @@ def df_models_from_input_csv(input):
 
 
 @app.command(name="build", group="Build")
-def build_system(input: Path, output: Path = Path(".")):
-    """Build MD system from YAML input file.
+def build_system(
+    input: Path,
+    output: Path = Path("."),
+    config: Annotated[
+        Path | None, Parameter(help="Executor config YAML for parallel Parsl builds.")
+    ] = None,
+    dry_run: Annotated[
+        bool, Parameter(help="Print what would be built without executing.")
+    ] = False,
+):
+    """Build MD system(s) from YAML, CSV, or summary input.
+
+    Supports three input modes:
+
+    - Single YAML: builds one system locally (original behavior)
+    - CSV file: builds systems from each row (parallel with --config, sequential without)
+    - Summary YAML: dispatches builds for previously prepared systems
 
     Parameters
     ----------
     input : Path
-        Path to the YAML file specifying the `BuildInput`
+        Path to input file (YAML for single build, CSV for batch, summary YAML for prepared).
     output : Path, optional
-        Output directory, by default Path(".")
+        Output directory, by default Path(".").
+    config : Path, optional
+        Path to executor configuration YAML for parallel Parsl builds.
+    dry_run : bool, optional
+        Print what would be built without executing.
 
     """
     input = input.resolve()
-    logger.info(f"Building system from YAML file {input} and output directory: {output}.")
-    with working_directory(output, create=True):
-        run_build_from_file(input)
+    output = output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+
+    suffix = input.suffix.lower()
+
+    if suffix == ".csv":
+        _build_from_csv(input, output, config=config, dry_run=dry_run)
+    elif suffix in (".yaml", ".yml"):
+        _build_from_yaml(input, output, config=config, dry_run=dry_run)
+    else:
+        logger.error(f"Unsupported input file format: {suffix}. Use .csv, .yaml, or .yml.")
+        sys.exit(1)
+
+
+def _build_from_csv(
+    input: Path,
+    output: Path,
+    *,
+    config: Path | None = None,
+    dry_run: bool = False,
+):
+    """Handle CSV input for the build command."""
+    df, models, errors = df_models_from_input_csv(input)
+    if errors:
+        logger.error("Errors building models from CSV:")
+        for k, v in errors.items():
+            logger.error(f"  Row {k}: {v}")
+        sys.exit(1)
+
+    # Create per-hash directories and write YAML files
+    for model in models:
+        build_dir = output / model.hash
+        build_dir.mkdir(parents=True, exist_ok=True)
+        yml_path = build_dir / f"{model.hash}.yaml"
+        if not yml_path.exists():
+            with open(yml_path, "w") as f:
+                yaml.safe_dump(model.model_dump(), f)
+
+    if dry_run:
+        from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
+
+        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        build_systems_dry_run(models, executor_config, output_dir=output)
+        return
+
+    if config is not None:
+        # Parallel builds via Parsl
+        from mdfactory.orchestration import ExecutorConfig, build_systems
+
+        executor_config = ExecutorConfig.from_yaml(config)
+        results = build_systems(models, executor_config, output_dir=output)
+        _report_build_results(results)
+    else:
+        # Sequential local builds
+        logger.info(f"Building {len(models)} system(s) sequentially.")
+        for model in models:
+            build_dir = output / model.hash
+            logger.info(f"Building {model.hash} ({model.simulation_type})...")
+            with working_directory(build_dir, create=True):
+                run_build_from_dict(model)
+
+
+def _build_from_yaml(
+    input: Path,
+    output: Path,
+    *,
+    config: Path | None = None,
+    dry_run: bool = False,
+):
+    """Handle YAML input for the build command."""
+    with open(input) as f:
+        data = yaml.safe_load(f)
+
+    if isinstance(data, dict) and "system_directory" in data:
+        # Summary YAML -- dispatch builds for prepared systems
+        _build_from_summary_yaml(data, output, config=config, dry_run=dry_run)
+    else:
+        # Single build YAML
+        if dry_run:
+            from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
+
+            executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+            from mdfactory.models.input import BuildInput
+
+            model = BuildInput(**data)
+            build_systems_dry_run([model], executor_config, output_dir=output)
+            return
+
+        if config is not None:
+            from mdfactory.models.input import BuildInput
+            from mdfactory.orchestration import ExecutorConfig, build_systems
+
+            executor_config = ExecutorConfig.from_yaml(config)
+            model = BuildInput(**data)
+            results = build_systems([model], executor_config, output_dir=output)
+            _report_build_results(results)
+        else:
+            logger.info(f"Building system from YAML file {input} and output directory: {output}.")
+            with working_directory(output, create=True):
+                run_build_from_file(input)
+
+
+def _build_from_summary_yaml(
+    data: dict,
+    output: Path,
+    *,
+    config: Path | None = None,
+    dry_run: bool = False,
+):
+    """Handle summary YAML (from prepare-build) for the build command."""
+    dirs = data.get("system_directory", [])
+    hashes = data.get("hash", [])
+
+    if not dirs:
+        logger.error("Summary YAML contains no system_directory entries.")
+        sys.exit(1)
+
+    from mdfactory.models.input import BuildInput
+
+    models = []
+    for sim_dir, sim_hash in zip(dirs, hashes):
+        yml_path = Path(sim_dir) / f"{sim_hash}.yaml"
+        if not yml_path.exists():
+            logger.error(f"Build YAML not found: {yml_path}")
+            sys.exit(1)
+        with open(yml_path) as f:
+            model_data = yaml.safe_load(f)
+        models.append(BuildInput(**model_data))
+
+    if dry_run:
+        from mdfactory.orchestration import ExecutorConfig, build_systems_dry_run
+
+        executor_config = ExecutorConfig.from_yaml(config) if config else ExecutorConfig()
+        build_systems_dry_run(models, executor_config, output_dir=output)
+        return
+
+    if config is not None:
+        from mdfactory.orchestration import ExecutorConfig, build_systems
+
+        executor_config = ExecutorConfig.from_yaml(config)
+        results = build_systems(models, executor_config, output_dir=output)
+        _report_build_results(results)
+    else:
+        # Sequential local builds
+        logger.info(f"Building {len(models)} prepared system(s) sequentially.")
+        for model, sim_dir in zip(models, dirs):
+            logger.info(f"Building {model.hash} ({model.simulation_type})...")
+            with working_directory(Path(sim_dir), create=True):
+                run_build_from_dict(model)
+
+
+def _report_build_results(results: list[dict]):
+    """Report build results to the user."""
+    succeeded = sum(1 for r in results if r.get("status") == "success")
+    failed = sum(1 for r in results if r.get("status") == "failed")
+    logger.info(f"Build complete: {succeeded} succeeded, {failed} failed.")
+    for r in results:
+        if r.get("status") == "failed":
+            logger.error(f"  {r.get('hash', 'unknown')}: {r.get('error', 'unknown error')}")
 
 
 @app.command(name="clean")

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -112,12 +112,62 @@ def df_models_from_input_csv(input):
     return df, models, errors
 
 
+def _resolve_slurm_flag(slurm: str | None) -> Path | None:
+    """Resolve the ``--slurm`` CLI flag to an executor config YAML path.
+
+    Parameters
+    ----------
+    slurm : str or None
+        Raw value from the ``--slurm`` flag.  ``"tui"`` launches the
+        interactive wizard (which writes a temporary YAML).  Any other
+        non-None value is treated as a file path.
+
+    Returns
+    -------
+    Path or None
+        Path to executor config YAML, or None if no SLURM config requested.
+    """
+    if slurm is None:
+        return None
+
+    if slurm.strip().lower() == "tui":
+        from mdfactory.orchestration.tui import UserCancelledError, configure_slurm_interactive
+
+        try:
+            config = configure_slurm_interactive()
+        except UserCancelledError:
+            logger.info("SLURM configuration cancelled.")
+            sys.exit(0)
+
+        # Write to a temporary YAML so the existing from_yaml flow works
+        import tempfile
+
+        import yaml as _yaml
+
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", prefix="mdfactory_slurm_", delete=False
+        )
+        _yaml.dump(config.model_dump(exclude_none=True), tmp, default_flow_style=False)
+        tmp.close()
+        logger.info(f"Using SLURM config from interactive wizard ({tmp.name})")
+        return Path(tmp.name)
+
+    path = Path(slurm)
+    if not path.exists():
+        logger.error(f"SLURM config file not found: {path}")
+        sys.exit(1)
+    return path
+
+
 @app.command(name="build", group="Build")
 def build_system(
     input: Path,
     output: Path = Path("."),
-    config: Annotated[
-        Path | None, Parameter(help="Executor config YAML for parallel Parsl builds.")
+    slurm: Annotated[
+        str | None,
+        Parameter(
+            help=("SLURM executor config: path to YAML file, or 'tui' for interactive setup.")
+        ),
     ] = None,
     dry_run: Annotated[
         bool, Parameter(help="Print what would be built without executing.")
@@ -128,7 +178,7 @@ def build_system(
     Supports three input modes:
 
     - Single YAML: builds one system locally (original behavior)
-    - CSV file: builds systems from each row (parallel with --config, sequential without)
+    - CSV file: builds systems from each row (parallel with --slurm, sequential without)
     - Summary YAML: dispatches builds for previously prepared systems
 
     Parameters
@@ -137,8 +187,9 @@ def build_system(
         Path to input file (YAML for single build, CSV for batch, summary YAML for prepared).
     output : Path, optional
         Output directory, by default Path(".").
-    config : Path, optional
-        Path to executor configuration YAML for parallel Parsl builds.
+    slurm : str, optional
+        Path to SLURM executor config YAML, or ``"tui"`` to launch the
+        interactive configuration wizard.
     dry_run : bool, optional
         Print what would be built without executing.
 
@@ -146,6 +197,10 @@ def build_system(
     input = input.resolve()
     output = output.resolve()
     output.mkdir(parents=True, exist_ok=True)
+
+    # Resolve --slurm flag: "tui" launches the interactive wizard,
+    # anything else is treated as a path to a YAML config file.
+    config: Path | None = _resolve_slurm_flag(slurm)
 
     suffix = input.suffix.lower()
 
@@ -1983,6 +2038,25 @@ def config_edit():
 
     editor = os.environ.get("EDITOR", "vi")
     subprocess.run([editor, str(config_path)], check=False)
+
+
+@config_app.command(name="slurm")
+def config_slurm():
+    """Interactive wizard to configure a SLURM executor and save to YAML.
+
+    Queries the local SLURM scheduler for available accounts, partitions,
+    and hardware, then walks through resource selection interactively.
+    The result is saved to a YAML file that can be reused with
+    ``mdfactory build --slurm <file>``.
+
+    On non-SLURM machines, falls back to manual text entry.
+    """
+    from mdfactory.orchestration.tui import UserCancelledError, configure_and_save_slurm
+
+    try:
+        configure_and_save_slurm()
+    except UserCancelledError:
+        logger.info("SLURM configuration cancelled.")
 
 
 @config_app.command(name="cluster")

--- a/mdfactory/orchestration/__init__.py
+++ b/mdfactory/orchestration/__init__.py
@@ -4,9 +4,12 @@
 
 from .build import build_systems
 from .config import ExecutorConfig, SlurmExecutorConfig
+from .tui import configure_and_save_slurm, configure_slurm_interactive
 
 __all__ = [
     "ExecutorConfig",
     "SlurmExecutorConfig",
     "build_systems",
+    "configure_and_save_slurm",
+    "configure_slurm_interactive",
 ]

--- a/mdfactory/orchestration/__init__.py
+++ b/mdfactory/orchestration/__init__.py
@@ -2,12 +2,11 @@
 # ABOUTME: Exports executor configs and build dispatch functions
 """Parsl-based parallel build orchestration for mdfactory."""
 
-from .build import build_systems, build_systems_dry_run
+from .build import build_systems
 from .config import ExecutorConfig, SlurmExecutorConfig
 
 __all__ = [
     "ExecutorConfig",
     "SlurmExecutorConfig",
     "build_systems",
-    "build_systems_dry_run",
 ]

--- a/mdfactory/orchestration/__init__.py
+++ b/mdfactory/orchestration/__init__.py
@@ -1,0 +1,13 @@
+# ABOUTME: Public API for Parsl-based parallel build orchestration
+# ABOUTME: Exports executor configs and build dispatch functions
+"""Parsl-based parallel build orchestration for mdfactory."""
+
+from .build import build_systems, build_systems_dry_run
+from .config import ExecutorConfig, SlurmExecutorConfig
+
+__all__ = [
+    "ExecutorConfig",
+    "SlurmExecutorConfig",
+    "build_systems",
+    "build_systems_dry_run",
+]

--- a/mdfactory/orchestration/apps.py
+++ b/mdfactory/orchestration/apps.py
@@ -1,0 +1,58 @@
+# ABOUTME: Parsl application definitions for build orchestration
+# ABOUTME: Wraps run_build_from_dict as a @python_app with runtime decoration
+"""Parsl application definitions for build orchestration."""
+
+from parsl import python_app
+
+
+def _build_system_impl(build_input_dict: dict) -> dict:
+    """Run a single system build inside a Parsl worker.
+
+    All heavy imports (OpenMM, MDAnalysis, OpenFF) happen inside the
+    worker process — only the plain dict crosses the serialization boundary.
+
+    Parameters
+    ----------
+    build_input_dict : dict
+        Serialized BuildInput as a plain dictionary. May contain a special
+        ``_build_dir`` key specifying the output directory.
+
+    Returns
+    -------
+    dict
+        Result dictionary with hash, status, and directory.
+
+    """
+    import os
+    from pathlib import Path
+
+    from mdfactory.models.input import BuildInput
+    from mdfactory.workflows import run_build_from_dict
+
+    # Extract and remove internal keys before validation
+    input_copy = {k: v for k, v in build_input_dict.items() if not k.startswith("_")}
+    model = BuildInput(**input_copy)
+    build_dir = Path(build_input_dict.get("_build_dir", model.hash))
+    build_dir.mkdir(parents=True, exist_ok=True)
+    original_dir = os.getcwd()
+    try:
+        os.chdir(build_dir)
+        run_build_from_dict(model)
+    finally:
+        os.chdir(original_dir)
+    return {"hash": model.hash, "status": "success", "directory": str(build_dir.resolve())}
+
+
+def get_build_app():
+    """Create and return the Parsl python_app for building systems.
+
+    The ``@python_app`` decorator is applied here (not at module level)
+    because it requires an active Parsl DataFlowKernel.
+
+    Returns
+    -------
+    callable
+        A Parsl ``@python_app`` wrapping the build implementation.
+
+    """
+    return python_app(_build_system_impl)

--- a/mdfactory/orchestration/apps.py
+++ b/mdfactory/orchestration/apps.py
@@ -2,8 +2,6 @@
 # ABOUTME: Wraps run_build_from_dict as a @python_app with runtime decoration
 """Parsl application definitions for build orchestration."""
 
-from parsl import python_app
-
 
 def _build_system_impl(build_input_dict: dict) -> dict:
     """Run a single system build inside a Parsl worker.
@@ -54,5 +52,17 @@ def get_build_app():
     callable
         A Parsl ``@python_app`` wrapping the build implementation.
 
+    Raises
+    ------
+    ImportError
+        If parsl is not installed.
+
     """
+    try:
+        from parsl import python_app  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "parsl is required for build orchestration. "
+            "Install with `pip install 'mdfactory[parsl]'`."
+        ) from exc
     return python_app(_build_system_impl)

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -24,8 +24,9 @@ def build_systems(
     *,
     output_dir: Path | None = None,
     wait: bool = True,
+    dry_run: bool = False,
 ) -> list:
-    """Submit parallel builds via Parsl.
+    """Submit parallel builds via Parsl (or preview with dry_run).
 
     Parameters
     ----------
@@ -39,13 +40,54 @@ def build_systems(
         Whether to wait for all futures to complete. Default True.
         If False, returns raw AppFutures and the caller is responsible
         for calling ``parsl.clear()`` after all futures complete.
+    dry_run : bool, optional
+        If True, log what would be built and return descriptions without
+        loading Parsl or submitting any work. Default False.
 
     Returns
     -------
     list
-        If wait=True, list of result dicts. If wait=False, list of AppFutures.
+        If dry_run=True, list of description dicts.
+        If wait=True, list of result dicts.
+        If wait=False, list of AppFutures.
 
     """
+    output_dir = Path(output_dir) if output_dir else Path.cwd()
+
+    # Resolve all inputs upfront
+    resolved: list[tuple[BuildInput, dict]] = []
+    for inp in build_inputs:
+        if isinstance(inp, BuildInput):
+            model = inp
+            input_dict = inp.model_dump()
+        elif isinstance(inp, dict):
+            model = BuildInput(**inp)
+            input_dict = inp.copy()
+        else:
+            raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
+        input_dict["_build_dir"] = str(output_dir / model.hash)
+        resolved.append((model, input_dict))
+
+    # Dry-run: log plan and return without loading Parsl
+    if dry_run:
+        descriptions = []
+        for model, _ in resolved:
+            desc = {
+                "hash": model.hash,
+                "simulation_type": model.simulation_type,
+                "parametrization": model.parametrization,
+                "engine": model.engine,
+                "output_directory": str(output_dir / model.hash),
+            }
+            descriptions.append(desc)
+            logger.info(
+                f"[dry-run] {model.hash} | {model.simulation_type} | "
+                f"{model.parametrization} | {model.engine} -> {output_dir / model.hash}"
+            )
+        logger.info(f"[dry-run] {len(descriptions)} system(s) would be built")
+        logger.info(f"[dry-run] Provider: {config.provider}")
+        return descriptions
+
     try:
         import parsl  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -53,8 +95,6 @@ def build_systems(
             "parsl is required for build orchestration. "
             "Install with `pip install 'mdfactory[parsl]'`."
         ) from exc
-
-    output_dir = Path(output_dir) if output_dir else Path.cwd()
 
     # Build parsl config and load
     parsl_config = config.to_parsl_config()
@@ -64,21 +104,11 @@ def build_systems(
     try:
         build_app = get_build_app()
 
-        # Prepare inputs and submit
+        # Submit all builds
         futures = []
         input_hashes = []
-        for inp in build_inputs:
-            if isinstance(inp, BuildInput):
-                input_dict = inp.model_dump()
-                input_dict["_build_dir"] = str(output_dir / inp.hash)
-                input_hashes.append(inp.hash)
-            elif isinstance(inp, dict):
-                model = BuildInput(**inp)
-                input_dict = inp.copy()
-                input_dict["_build_dir"] = str(output_dir / model.hash)
-                input_hashes.append(model.hash)
-            else:
-                raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
+        for model, input_dict in resolved:
+            input_hashes.append(model.hash)
             futures.append(build_app(input_dict))
 
         logger.info(f"Submitted {len(futures)} build(s) to Parsl")
@@ -323,55 +353,3 @@ def _wait_with_progress(
         raise
 
     return [r for r in results if r is not None]
-
-
-def build_systems_dry_run(
-    build_inputs: list,
-    config: "ExecutorConfig",
-    *,
-    output_dir: Path | None = None,
-) -> list[dict]:
-    """Print what would be built without submitting to Parsl.
-
-    Parameters
-    ----------
-    build_inputs : list
-        List of BuildInput models or dicts.
-    config : ExecutorConfig
-        Executor configuration (used for display, Parsl not loaded).
-    output_dir : Path, optional
-        Base output directory for builds. Defaults to current directory.
-
-    Returns
-    -------
-    list[dict]
-        List of dicts describing each planned build.
-
-    """
-    output_dir = Path(output_dir) if output_dir else Path.cwd()
-
-    descriptions = []
-    for inp in build_inputs:
-        if isinstance(inp, BuildInput):
-            model = inp
-        elif isinstance(inp, dict):
-            model = BuildInput(**inp)
-        else:
-            raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
-
-        desc = {
-            "hash": model.hash,
-            "simulation_type": model.simulation_type,
-            "parametrization": model.parametrization,
-            "engine": model.engine,
-            "output_directory": str(output_dir / model.hash),
-        }
-        descriptions.append(desc)
-        logger.info(
-            f"[dry-run] {model.hash} | {model.simulation_type} | "
-            f"{model.parametrization} | {model.engine} -> {output_dir / model.hash}"
-        )
-
-    logger.info(f"[dry-run] {len(descriptions)} system(s) would be built")
-    logger.info(f"[dry-run] Provider: {config.provider}")
-    return descriptions

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,10 +12,24 @@ from loguru import logger
 from mdfactory.models.input import BuildInput
 
 from .apps import get_build_app
-from .config import _import_parsl
+from .session import (
+    _get_slurm_job_ids,
+    _scancel_jobs,
+    _shutdown_parsl,
+    parsl_session,
+)
 
 if TYPE_CHECKING:
     from .config import ExecutorConfig
+
+# Re-exported for backward compatibility — the canonical home is ``session``.
+__all__ = [
+    "build_systems",
+    "parsl_session",
+    "_shutdown_parsl",
+    "_get_slurm_job_ids",
+    "_scancel_jobs",
+]
 
 
 def build_systems(
@@ -89,25 +102,9 @@ def build_systems(
         logger.info(f"[dry-run] Provider: {config.provider}")
         return descriptions
 
-    parsl = _import_parsl()
-
-    # Guard against already-active DataFlowKernel
-    try:
-        parsl.dfk()
-    except Exception:
-        pass  # No active DFK, good
-    else:
-        raise RuntimeError(
-            "A Parsl DataFlowKernel is already active. "
-            "Call parsl.clear() before starting a new build session."
-        )
-
-    # Build parsl config and load
-    parsl_config = config.to_parsl_config()
-    parsl.load(parsl_config)
-
-    cleanup_needed = True
-    try:
+    # parsl_session owns the full DFK lifecycle: guard, load, and shutdown
+    # (including scancel of lingering SLURM jobs) on exit.
+    with parsl_session(config) as session:
         build_app = get_build_app()
 
         # Submit all builds
@@ -121,82 +118,18 @@ def build_systems(
 
         if not wait:
             logger.warning("Returning raw futures — caller must call parsl.clear() when done.")
-            cleanup_needed = False
+            session.detach()
             return futures
 
         # Poll futures with live status reporting
-        results = _wait_with_progress(futures, hashes=input_hashes)
-        return results
-    finally:
-        if cleanup_needed:
-            _shutdown_parsl()
-
-
-def _shutdown_parsl():
-    """Shut down Parsl and cancel any remaining SLURM jobs."""
-    try:
-        import parsl  # type: ignore[import-not-found]
-    except ImportError:
-        return
-
-    job_ids = []
-    try:
-        dfk = parsl.dfk()
-        job_ids = _get_slurm_job_ids(dfk)
-    except Exception as exc:
-        logger.debug(f"Could not query Parsl DFK for SLURM jobs: {exc}")
-
-    try:
-        parsl.clear()
-    except Exception as exc:
-        logger.warning(f"Parsl shutdown failed — DFK may still be loaded: {exc}")
-
-    # Always attempt scancel if we found job IDs
-    if job_ids:
-        _scancel_jobs(job_ids)
-
-
-def _get_slurm_job_ids(dfk) -> list[str]:
-    """Extract active SLURM job IDs from the Parsl DataFlowKernel."""
-    job_ids = []
-    try:
-        for executor in dfk.executors.values():
-            if hasattr(executor, "provider") and hasattr(executor.provider, "resources"):
-                for _block_id, resource in executor.provider.resources.items():
-                    job_id = resource.get("remote_job_id") or resource.get("job_id")
-                    if job_id:
-                        job_ids.append(str(job_id))
-    except Exception as exc:
-        logger.debug(f"Could not enumerate SLURM jobs for explicit scancel: {exc}")
-    return job_ids
-
-
-def _scancel_jobs(job_ids: list[str]):
-    """Run scancel on the given SLURM job IDs."""
-    if not job_ids:
-        return
-    try:
-        cmd = ["scancel"] + job_ids
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
-        if result.returncode == 0:
-            logger.info(f"Cancelled SLURM jobs: {', '.join(job_ids)}")
-        else:
-            logger.debug(f"scancel stderr: {result.stderr.strip()}")
-    except FileNotFoundError:
-        logger.debug("scancel not found (not on SLURM cluster)")
-    except subprocess.TimeoutExpired:
-        logger.warning(
-            f"scancel timed out after 10 s — SLURM jobs {', '.join(job_ids)} may still "
-            f"be running. Run `scancel {' '.join(job_ids)}` manually."
-        )
-    except Exception as exc:
-        logger.debug(f"scancel failed: {exc}")
+        return _wait_with_progress(futures, hashes=input_hashes, label="Parsl Builds")
 
 
 def _wait_with_progress(
     futures: list,
     *,
     hashes: list[str] | None = None,
+    label: str = "Parsl Builds",
     poll_interval: float = 2.0,
 ) -> list[dict]:
     """Wait for futures with a live terminal progress display.
@@ -210,6 +143,9 @@ def _wait_with_progress(
         List of Parsl AppFutures.
     hashes : list[str], optional
         Known hashes for each build (displayed in activity log).
+    label : str
+        Heading shown next to the progress bar. Defaults to ``"Parsl Builds"``;
+        pass e.g. ``"Simulations"`` to reuse this display for other workflows.
     poll_interval : float
         Seconds between status polls.
 
@@ -240,7 +176,7 @@ def _wait_with_progress(
 
     # Progress bar
     progress = Progress(
-        TextColumn("⚒ [bold]Parsl Builds[/]"),
+        TextColumn(f"⚒ [bold]{label}[/]"),
         BarColumn(bar_width=40),
         MofNCompleteColumn(),
         TextColumn("·"),

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -1,0 +1,265 @@
+# ABOUTME: Build orchestration dispatch via Parsl
+# ABOUTME: Submits parallel builds and provides dry-run preview
+"""Build orchestration via Parsl."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import parsl
+from loguru import logger
+
+from mdfactory.models.input import BuildInput
+
+from .apps import get_build_app
+
+if TYPE_CHECKING:
+    from .config import ExecutorConfig
+
+
+def build_systems(
+    build_inputs: list,
+    config: "ExecutorConfig",
+    *,
+    output_dir: Path | None = None,
+    wait: bool = True,
+) -> list:
+    """Submit parallel builds via Parsl.
+
+    Parameters
+    ----------
+    build_inputs : list
+        List of BuildInput models or dicts.
+    config : ExecutorConfig
+        Executor configuration for Parsl.
+    output_dir : Path, optional
+        Base output directory for builds. Defaults to current directory.
+    wait : bool, optional
+        Whether to wait for all futures to complete. Default True.
+
+    Returns
+    -------
+    list
+        If wait=True, list of result dicts. If wait=False, list of AppFutures.
+
+    """
+    output_dir = Path(output_dir) if output_dir else Path.cwd()
+
+    # Build parsl config and load
+    parsl_config = config.to_parsl_config()
+    parsl.load(parsl_config)
+
+    build_app = get_build_app()
+
+    # Prepare inputs and submit
+    futures = []
+    input_hashes = []
+    for inp in build_inputs:
+        if isinstance(inp, BuildInput):
+            input_dict = inp.model_dump()
+            input_dict["_build_dir"] = str(output_dir / inp.hash)
+            input_hashes.append(inp.hash)
+        elif isinstance(inp, dict):
+            model = BuildInput(**inp)
+            input_dict = inp.copy()
+            input_dict["_build_dir"] = str(output_dir / model.hash)
+            input_hashes.append(model.hash)
+        else:
+            raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
+        futures.append(build_app(input_dict))
+
+    logger.info(f"Submitted {len(futures)} build(s) to Parsl")
+
+    if not wait:
+        return futures
+
+    # Poll futures with live status reporting
+    results = _wait_with_progress(futures, hashes=input_hashes)
+    parsl.clear()
+    return results
+
+
+def _wait_with_progress(
+    futures: list,
+    *,
+    hashes: list[str] | None = None,
+    poll_interval: float = 2.0,
+) -> list[dict]:
+    """Wait for futures with a live terminal progress display.
+
+    Shows a progress bar with summary counts and a scrolling activity log
+    of recent completions/failures. Scales to any number of builds.
+
+    Parameters
+    ----------
+    futures : list
+        List of Parsl AppFutures.
+    hashes : list[str], optional
+        Known hashes for each build (displayed in activity log).
+    poll_interval : float
+        Seconds between status polls.
+
+    Returns
+    -------
+    list[dict]
+        Result dicts for each future.
+
+    """
+    import time
+
+    from rich.console import Console, Group
+    from rich.live import Live
+    from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
+    from rich.text import Text
+
+    total = len(futures)
+    results: list[dict | None] = [None] * total
+    display_hashes = hashes or [f"build-{i}" for i in range(total)]
+    console = Console()
+
+    # Track counts
+    succeeded = 0
+    failed = 0
+    # Activity log (last N events)
+    max_activity = 8
+    activity: list[Text] = []
+
+    # Progress bar
+    progress = Progress(
+        TextColumn("🔨 [bold]Parsl Builds[/]"),
+        BarColumn(bar_width=40),
+        MofNCompleteColumn(),
+        TextColumn("·"),
+        TextColumn("[green]{task.fields[succeeded]} ✓[/]"),
+        TextColumn("[red]{task.fields[failed]} ✗[/]"),
+        TextColumn("[yellow]{task.fields[running]} ●[/]"),
+        console=console,
+        transient=False,
+    )
+    task_id = progress.add_task("builds", total=total, succeeded=0, failed=0, running=0)
+
+    def _render():
+        done_count = succeeded + failed
+        running = sum(1 for i, f in enumerate(futures) if results[i] is None and _is_running(f))
+        progress.update(
+            task_id,
+            completed=done_count,
+            succeeded=succeeded,
+            failed=failed,
+            running=running,
+        )
+        # Combine progress bar + activity log
+        parts = [progress]
+        if activity:
+            parts.append(Text(""))  # blank line
+            for line in activity[-max_activity:]:
+                parts.append(line)
+        return Group(*parts)
+
+    def _is_running(future) -> bool:
+        try:
+            status = future.task_status()
+            return status in ("launched", "running", "running_ended")
+        except Exception:
+            return False
+
+    try:
+        with Live(_render(), console=console, refresh_per_second=2) as live:
+            while True:
+                done_count = 0
+                for i, future in enumerate(futures):
+                    if results[i] is not None:
+                        done_count += 1
+                        continue
+                    if future.done():
+                        try:
+                            result = future.result()
+                            results[i] = result
+                            succeeded += 1
+                            line = Text()
+                            line.append("  ✓ ", style="bold green")
+                            line.append(display_hashes[i][:12], style="cyan")
+                            line.append("  done", style="dim")
+                            activity.append(line)
+                        except Exception as exc:
+                            results[i] = {
+                                "hash": display_hashes[i],
+                                "status": "failed",
+                                "error": str(exc),
+                            }
+                            failed += 1
+                            line = Text()
+                            line.append("  ✗ ", style="bold red")
+                            line.append(display_hashes[i][:12], style="cyan")
+                            line.append(f"  {str(exc)[:50]}", style="red")
+                            activity.append(line)
+                        done_count += 1
+
+                live.update(_render())
+
+                if done_count == total:
+                    break
+
+                time.sleep(poll_interval)
+
+    except KeyboardInterrupt:
+        console.print(
+            "\n[bold yellow]Interrupted — shutting down Parsl (cancelling SLURM jobs)...[/]"
+        )
+        parsl.clear()
+        raise
+
+    return [r for r in results if r is not None]
+
+
+def build_systems_dry_run(
+    build_inputs: list,
+    config: "ExecutorConfig",
+    *,
+    output_dir: Path | None = None,
+) -> list[dict]:
+    """Print what would be built without submitting to Parsl.
+
+    Parameters
+    ----------
+    build_inputs : list
+        List of BuildInput models or dicts.
+    config : ExecutorConfig
+        Executor configuration (used for display, Parsl not loaded).
+    output_dir : Path, optional
+        Base output directory for builds. Defaults to current directory.
+
+    Returns
+    -------
+    list[dict]
+        List of dicts describing each planned build.
+
+    """
+    output_dir = Path(output_dir) if output_dir else Path.cwd()
+
+    descriptions = []
+    for inp in build_inputs:
+        if isinstance(inp, BuildInput):
+            model = inp
+        elif isinstance(inp, dict):
+            model = BuildInput(**inp)
+        else:
+            raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
+
+        desc = {
+            "hash": model.hash,
+            "simulation_type": model.simulation_type,
+            "parametrization": model.parametrization,
+            "engine": model.engine,
+            "output_directory": str(output_dir / model.hash),
+        }
+        descriptions.append(desc)
+        logger.info(
+            f"[dry-run] {model.hash} | {model.simulation_type} | "
+            f"{model.parametrization} | {model.engine} -> {output_dir / model.hash}"
+        )
+
+    logger.info(f"[dry-run] {len(descriptions)} system(s) would be built")
+    logger.info(f"[dry-run] Provider: {config.provider}")
+    return descriptions

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -148,6 +148,11 @@ def _scancel_jobs(job_ids: list[str]):
             logger.debug(f"scancel stderr: {result.stderr.strip()}")
     except FileNotFoundError:
         logger.debug("scancel not found (not on SLURM cluster)")
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            f"scancel timed out after 10 s — SLURM jobs {', '.join(job_ids)} may still "
+            f"be running. Run `scancel {' '.join(job_ids)}` manually."
+        )
     except Exception as exc:
         logger.debug(f"scancel failed: {exc}")
 
@@ -314,7 +319,7 @@ def _wait_with_progress(
 
     except KeyboardInterrupt:
         console.print("\n[bold yellow]Interrupted — cancelling SLURM jobs...[/]")
-        _shutdown_parsl()
+        # Don't call _shutdown_parsl() here — build_systems' finally block owns cleanup
         raise
 
     return [r for r in results if r is not None]

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -125,6 +125,68 @@ def build_systems(
         return _wait_with_progress(futures, hashes=input_hashes, label="Parsl Builds")
 
 
+def _describe_failure(exc: BaseException) -> tuple[str, str]:
+    """Extract ``(failure_type, error_detail)`` from a future's exception.
+
+    Parsl surfaces worker errors differently across versions: modern Parsl
+    re-raises the *original* exception (via ``RemoteExceptionWrapper.reraise()``),
+    while older versions wrapped it and exposed the underlying error on
+    ``.e_value``. Unwrap defensively so callers always see the *underlying*
+    error type — letting future retry logic distinguish, e.g., a GROMACS crash
+    (``CalledProcessError``) from an infrastructure failure (OOM / preemption).
+
+    Parameters
+    ----------
+    exc : BaseException
+        The exception raised by ``future.result()``.
+
+    Returns
+    -------
+    tuple[str, str]
+        ``(failure_type, error_detail)`` — the underlying exception's class
+        name and its string representation.
+
+    """
+    underlying = getattr(exc, "e_value", None) or exc
+    return type(underlying).__name__, str(underlying)
+
+
+def _collect_results(results: list, hashes: list[str]) -> list[dict]:
+    """Return all captured results, raising if any slot is still uncaptured.
+
+    The polling loop only exits once every future has been recorded, so a
+    ``None`` slot here signals an internal bug rather than a normal outcome.
+    Failing explicitly is safer than silently returning a shorter list than
+    the caller submitted (which would corrupt any ``len()``-based bookkeeping).
+
+    Parameters
+    ----------
+    results : list
+        Per-future result slots; ``None`` marks an uncaptured future.
+    hashes : list[str]
+        Display hashes aligned with ``results``, used for the error message.
+
+    Returns
+    -------
+    list[dict]
+        The complete list of result dicts.
+
+    Raises
+    ------
+    RuntimeError
+        If one or more result slots were never captured.
+
+    """
+    missing = [hashes[i] for i, r in enumerate(results) if r is None]
+    if missing:
+        raise RuntimeError(
+            f"{len(missing)} build result(s) were never captured "
+            f"({', '.join(h[:12] for h in missing)}); the polling loop exited "
+            "prematurely. This is an internal error."
+        )
+    return list(results)
+
+
 def _wait_with_progress(
     futures: list,
     *,
@@ -268,17 +330,19 @@ def _wait_with_progress(
                             line.append("  done", style="dim")
                             activity.append(line)
                         except Exception as exc:
-                            error_msg = str(exc)
+                            failure_type, error_detail = _describe_failure(exc)
                             results[i] = {
                                 "hash": display_hashes[i],
                                 "status": "failed",
-                                "error": error_msg,
+                                "error": error_detail,
+                                "failure_type": failure_type,
+                                "error_detail": error_detail,
                             }
                             failed += 1
                             line = Text()
                             line.append("  ✗ ", style="bold red")
                             line.append(display_hashes[i][:12], style="cyan")
-                            line.append(f"  {error_msg}", style="red")
+                            line.append(f"  {error_detail}", style="red")
                             activity.append(line)
                         done_count += 1
 
@@ -294,4 +358,4 @@ def _wait_with_progress(
         # Don't call _shutdown_parsl() here — build_systems' finally block owns cleanup
         raise
 
-    return [r for r in results if r is not None]
+    return _collect_results(results, display_hashes)

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -240,7 +240,7 @@ def _wait_with_progress(
 
     # Progress bar
     progress = Progress(
-        TextColumn("🔨 [bold]Parsl Builds[/]"),
+        TextColumn("⚒ [bold]Parsl Builds[/]"),
         BarColumn(bar_width=40),
         MofNCompleteColumn(),
         TextColumn("·"),
@@ -299,7 +299,7 @@ def _wait_with_progress(
         parts = [progress]
         block_info = _get_block_status()
         if block_info:
-            parts.append(Text.from_markup(f"  🖥  SLURM: {block_info}"))
+            parts.append(Text.from_markup(f"  ▸ SLURM: {block_info}"))
         if activity:
             parts.append(Text(""))  # blank line
             for line in activity[-max_activity:]:

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -13,6 +13,7 @@ from loguru import logger
 from mdfactory.models.input import BuildInput
 
 from .apps import get_build_app
+from .config import _import_parsl
 
 if TYPE_CHECKING:
     from .config import ExecutorConfig
@@ -88,13 +89,18 @@ def build_systems(
         logger.info(f"[dry-run] Provider: {config.provider}")
         return descriptions
 
+    parsl = _import_parsl()
+
+    # Guard against already-active DataFlowKernel
     try:
-        import parsl  # type: ignore[import-not-found]
-    except ImportError as exc:
-        raise ImportError(
-            "parsl is required for build orchestration. "
-            "Install with `pip install 'mdfactory[parsl]'`."
-        ) from exc
+        parsl.dfk()
+    except Exception:
+        pass  # No active DFK, good
+    else:
+        raise RuntimeError(
+            "A Parsl DataFlowKernel is already active. "
+            "Call parsl.clear() before starting a new build session."
+        )
 
     # Build parsl config and load
     parsl_config = config.to_parsl_config()

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -231,7 +231,7 @@ def _wait_with_progress(
         parts = [progress]
         block_info = _get_block_status()
         if block_info:
-            parts.append(Text.from_markup(f"  SLURM jobs: {block_info}"))
+            parts.append(Text.from_markup(f"  🖥  SLURM: {block_info}"))
         if activity:
             parts.append(Text(""))  # blank line
             for line in activity[-max_activity:]:

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -8,7 +8,6 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import parsl
 from loguru import logger
 
 from mdfactory.models.input import BuildInput
@@ -38,6 +37,8 @@ def build_systems(
         Base output directory for builds. Defaults to current directory.
     wait : bool, optional
         Whether to wait for all futures to complete. Default True.
+        If False, returns raw AppFutures and the caller is responsible
+        for calling ``parsl.clear()`` after all futures complete.
 
     Returns
     -------
@@ -45,54 +46,78 @@ def build_systems(
         If wait=True, list of result dicts. If wait=False, list of AppFutures.
 
     """
+    try:
+        import parsl  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "parsl is required for build orchestration. "
+            "Install with `pip install 'mdfactory[parsl]'`."
+        ) from exc
+
     output_dir = Path(output_dir) if output_dir else Path.cwd()
 
     # Build parsl config and load
     parsl_config = config.to_parsl_config()
     parsl.load(parsl_config)
 
-    build_app = get_build_app()
+    cleanup_needed = True
+    try:
+        build_app = get_build_app()
 
-    # Prepare inputs and submit
-    futures = []
-    input_hashes = []
-    for inp in build_inputs:
-        if isinstance(inp, BuildInput):
-            input_dict = inp.model_dump()
-            input_dict["_build_dir"] = str(output_dir / inp.hash)
-            input_hashes.append(inp.hash)
-        elif isinstance(inp, dict):
-            model = BuildInput(**inp)
-            input_dict = inp.copy()
-            input_dict["_build_dir"] = str(output_dir / model.hash)
-            input_hashes.append(model.hash)
-        else:
-            raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
-        futures.append(build_app(input_dict))
+        # Prepare inputs and submit
+        futures = []
+        input_hashes = []
+        for inp in build_inputs:
+            if isinstance(inp, BuildInput):
+                input_dict = inp.model_dump()
+                input_dict["_build_dir"] = str(output_dir / inp.hash)
+                input_hashes.append(inp.hash)
+            elif isinstance(inp, dict):
+                model = BuildInput(**inp)
+                input_dict = inp.copy()
+                input_dict["_build_dir"] = str(output_dir / model.hash)
+                input_hashes.append(model.hash)
+            else:
+                raise TypeError(f"Expected BuildInput or dict, got {type(inp)}")
+            futures.append(build_app(input_dict))
 
-    logger.info(f"Submitted {len(futures)} build(s) to Parsl")
+        logger.info(f"Submitted {len(futures)} build(s) to Parsl")
 
-    if not wait:
-        return futures
+        if not wait:
+            logger.warning("Returning raw futures — caller must call parsl.clear() when done.")
+            cleanup_needed = False
+            return futures
 
-    # Poll futures with live status reporting
-    results = _wait_with_progress(futures, hashes=input_hashes)
-    _shutdown_parsl()
-    return results
+        # Poll futures with live status reporting
+        results = _wait_with_progress(futures, hashes=input_hashes)
+        return results
+    finally:
+        if cleanup_needed:
+            _shutdown_parsl()
 
 
 def _shutdown_parsl():
     """Shut down Parsl and cancel any remaining SLURM jobs."""
     try:
+        import parsl  # type: ignore[import-not-found]
+    except ImportError:
+        return
+
+    job_ids = []
+    try:
         dfk = parsl.dfk()
-        # Collect SLURM job IDs before cleanup
         job_ids = _get_slurm_job_ids(dfk)
-        parsl.clear()
-        # Explicitly scancel anything still alive
-        if job_ids:
-            _scancel_jobs(job_ids)
     except Exception as exc:
-        logger.debug(f"Parsl shutdown error (non-fatal): {exc}")
+        logger.debug(f"Could not query Parsl DFK for SLURM jobs: {exc}")
+
+    try:
+        parsl.clear()
+    except Exception as exc:
+        logger.warning(f"Parsl shutdown failed — DFK may still be loaded: {exc}")
+
+    # Always attempt scancel if we found job IDs
+    if job_ids:
+        _scancel_jobs(job_ids)
 
 
 def _get_slurm_job_ids(dfk) -> list[str]:
@@ -105,8 +130,8 @@ def _get_slurm_job_ids(dfk) -> list[str]:
                     job_id = resource.get("remote_job_id") or resource.get("job_id")
                     if job_id:
                         job_ids.append(str(job_id))
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug(f"Could not enumerate SLURM jobs for explicit scancel: {exc}")
     return job_ids
 
 
@@ -189,6 +214,8 @@ def _wait_with_progress(
     def _get_block_status() -> str:
         """Query Parsl for SLURM block (job) statuses."""
         try:
+            import parsl  # type: ignore[import-not-found]
+
             dfk = parsl.dfk()
             counts: dict[str, int] = {}
             for executor in dfk.executors.values():

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -186,6 +186,37 @@ def _wait_with_progress(
     )
     task_id = progress.add_task("builds", total=total, succeeded=0, failed=0, running=0)
 
+    def _get_block_status() -> str:
+        """Query Parsl for SLURM block (job) statuses."""
+        try:
+            dfk = parsl.dfk()
+            counts: dict[str, int] = {}
+            for executor in dfk.executors.values():
+                if not hasattr(executor, "status"):
+                    continue
+                block_statuses = executor.status()
+                for _block_id, job_status in block_statuses.items():
+                    state = str(job_status.state.name).lower()
+                    counts[state] = counts.get(state, 0) + 1
+            if not counts:
+                return ""
+            parts = []
+            if counts.get("running", 0):
+                parts.append(f"[green]{counts['running']} running[/]")
+            if counts.get("pending", 0):
+                parts.append(f"[yellow]{counts['pending']} pending[/]")
+            if counts.get("completed", 0):
+                parts.append(f"[dim]{counts['completed']} completed[/]")
+            if counts.get("failed", 0):
+                parts.append(f"[red]{counts['failed']} failed[/]")
+            # Catch-all for other states
+            for state, count in counts.items():
+                if state not in ("running", "pending", "completed", "failed"):
+                    parts.append(f"[dim]{count} {state}[/]")
+            return " · ".join(parts)
+        except Exception:
+            return ""
+
     def _render():
         done_count = succeeded + failed
         running = sum(1 for i, f in enumerate(futures) if results[i] is None and _is_running(f))
@@ -196,8 +227,11 @@ def _wait_with_progress(
             failed=failed,
             running=running,
         )
-        # Combine progress bar + activity log
+        # Combine progress bar + SLURM status + activity log
         parts = [progress]
+        block_info = _get_block_status()
+        if block_info:
+            parts.append(Text.from_markup(f"  SLURM jobs: {block_info}"))
         if activity:
             parts.append(Text(""))  # blank line
             for line in activity[-max_activity:]:

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -76,8 +77,54 @@ def build_systems(
 
     # Poll futures with live status reporting
     results = _wait_with_progress(futures, hashes=input_hashes)
-    parsl.clear()
+    _shutdown_parsl()
     return results
+
+
+def _shutdown_parsl():
+    """Shut down Parsl and cancel any remaining SLURM jobs."""
+    try:
+        dfk = parsl.dfk()
+        # Collect SLURM job IDs before cleanup
+        job_ids = _get_slurm_job_ids(dfk)
+        parsl.clear()
+        # Explicitly scancel anything still alive
+        if job_ids:
+            _scancel_jobs(job_ids)
+    except Exception as exc:
+        logger.debug(f"Parsl shutdown error (non-fatal): {exc}")
+
+
+def _get_slurm_job_ids(dfk) -> list[str]:
+    """Extract active SLURM job IDs from the Parsl DataFlowKernel."""
+    job_ids = []
+    try:
+        for executor in dfk.executors.values():
+            if hasattr(executor, "provider") and hasattr(executor.provider, "resources"):
+                for _block_id, resource in executor.provider.resources.items():
+                    job_id = resource.get("remote_job_id") or resource.get("job_id")
+                    if job_id:
+                        job_ids.append(str(job_id))
+    except Exception:
+        pass
+    return job_ids
+
+
+def _scancel_jobs(job_ids: list[str]):
+    """Run scancel on the given SLURM job IDs."""
+    if not job_ids:
+        return
+    try:
+        cmd = ["scancel"] + job_ids
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
+        if result.returncode == 0:
+            logger.info(f"Cancelled SLURM jobs: {', '.join(job_ids)}")
+        else:
+            logger.debug(f"scancel stderr: {result.stderr.strip()}")
+    except FileNotFoundError:
+        logger.debug("scancel not found (not on SLURM cluster)")
+    except Exception as exc:
+        logger.debug(f"scancel failed: {exc}")
 
 
 def _wait_with_progress(
@@ -122,7 +169,7 @@ def _wait_with_progress(
     succeeded = 0
     failed = 0
     # Activity log (last N events)
-    max_activity = 8
+    max_activity = 12
     activity: list[Text] = []
 
     # Progress bar
@@ -183,16 +230,17 @@ def _wait_with_progress(
                             line.append("  done", style="dim")
                             activity.append(line)
                         except Exception as exc:
+                            error_msg = str(exc)
                             results[i] = {
                                 "hash": display_hashes[i],
                                 "status": "failed",
-                                "error": str(exc),
+                                "error": error_msg,
                             }
                             failed += 1
                             line = Text()
                             line.append("  ✗ ", style="bold red")
                             line.append(display_hashes[i][:12], style="cyan")
-                            line.append(f"  {str(exc)[:50]}", style="red")
+                            line.append(f"  {error_msg}", style="red")
                             activity.append(line)
                         done_count += 1
 
@@ -204,10 +252,8 @@ def _wait_with_progress(
                 time.sleep(poll_interval)
 
     except KeyboardInterrupt:
-        console.print(
-            "\n[bold yellow]Interrupted — shutting down Parsl (cancelling SLURM jobs)...[/]"
-        )
-        parsl.clear()
+        console.print("\n[bold yellow]Interrupted — cancelling SLURM jobs...[/]")
+        _shutdown_parsl()
         raise
 
     return [r for r in results if r is not None]

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -107,6 +107,10 @@ class ExecutorConfig(BaseModel):
         """
         with open(path) as f:
             data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Executor config YAML is empty or invalid (expected a mapping): {path}"
+            )
         provider = data.get("provider", "local")
         if provider == "slurm":
             return SlurmExecutorConfig(**data)

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -1,0 +1,194 @@
+# ABOUTME: Pydantic models for Parsl executor configuration
+# ABOUTME: Supports local and SLURM providers with YAML serialization
+"""Executor configuration models for Parsl workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import parsl
+import yaml
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import LocalProvider, SlurmProvider
+from pydantic import BaseModel
+
+
+class ExecutorConfig(BaseModel):
+    """Base executor configuration for Parsl workflows.
+
+    Parameters
+    ----------
+    provider : str
+        Execution provider type ("local" or "slurm").
+    worker_init : str
+        Shell commands to run before starting workers (module loads, activation).
+    working_directory : Path or None
+        Working directory for the executor.
+    max_workers_per_node : int
+        Maximum number of parallel tasks per compute node.
+    max_blocks : int
+        Maximum number of execution blocks (for local: process groups).
+
+    """
+
+    provider: Literal["local", "slurm"] = "local"
+    worker_init: str = ""
+    working_directory: Path | None = None
+    max_workers_per_node: int = 1
+    max_blocks: int = 1
+
+    def to_parsl_config(self) -> parsl.Config:
+        """Build a Parsl Config with HighThroughputExecutor + LocalProvider.
+
+        Returns
+        -------
+        parsl.Config
+            Configured Parsl Config object.
+
+        """
+        provider = LocalProvider(
+            worker_init=self.worker_init,
+            min_blocks=0,
+            init_blocks=1,
+            max_blocks=self.max_blocks,
+            parallelism=1,
+        )
+        executor = HighThroughputExecutor(
+            label="local",
+            provider=provider,
+            max_workers_per_node=self.max_workers_per_node,
+            working_dir=str(self.working_directory) if self.working_directory else None,
+        )
+        return parsl.Config(executors=[executor])
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "ExecutorConfig | SlurmExecutorConfig":
+        """Load executor configuration from a YAML file.
+
+        Parameters
+        ----------
+        path : Path
+            Path to the YAML configuration file.
+
+        Returns
+        -------
+        ExecutorConfig or SlurmExecutorConfig
+            The appropriate config model based on the ``provider`` field.
+
+        """
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        provider = data.get("provider", "local")
+        if provider == "slurm":
+            return SlurmExecutorConfig(**data)
+        return cls(**data)
+
+
+class SlurmExecutorConfig(ExecutorConfig):
+    """SLURM executor configuration for Parsl workflows.
+
+    Field names mirror sbatch flags where possible. The only Parsl-specific
+    field is ``max_workers_per_node`` (number of parallel tasks per node).
+
+    Parameters
+    ----------
+    account : str
+        SLURM account (``--account``).
+    partition : str
+        SLURM partition (``--partition``).
+    walltime : str
+        Wall-clock time limit (``--time``).
+    nodes : int
+        Number of nodes per SLURM job (``--nodes``).
+    cpus_per_node : int
+        CPUs per node (``--cpus-per-task`` equivalent).
+    gres : str or None
+        Generic resource specification (``--gres``), e.g. ``"gpu:l40s:1"``.
+    mem : str or None
+        Memory per node (``--mem``), e.g. ``"32G"``.
+    qos : str or None
+        Quality of service (``--qos``).
+    constraint : str or None
+        Node feature constraint (``--constraint``).
+    max_blocks : int
+        Maximum number of simultaneous SLURM jobs. Each block is one
+        SLURM job; set this to control how many run in parallel.
+    scheduler_options : str
+        Additional raw ``#SBATCH`` lines for anything not covered above.
+
+    Examples
+    --------
+    .. code-block:: yaml
+
+        provider: slurm
+        account: hpc_chem
+        partition: gpu
+        walltime: "4:00:00"
+        nodes: 1
+        cpus_per_node: 12
+        gres: "gpu:l40s:1"
+        max_blocks: 5
+        max_workers_per_node: 1
+        worker_init: |
+          eval "$(pixi shell-hook -e default)"
+
+    """
+
+    provider: Literal["slurm"] = "slurm"
+    account: str
+    partition: str = "gpu"
+    walltime: str = "2:00:00"
+    nodes: int = 1
+    cpus_per_node: int = 12
+    gres: str | None = None
+    mem: str | None = None
+    qos: str | None = None
+    constraint: str | None = None
+    max_workers_per_node: int = 1
+    max_blocks: int = 1
+    scheduler_options: str = ""
+
+    def to_parsl_config(self) -> parsl.Config:
+        """Build a Parsl Config with HighThroughputExecutor + SlurmProvider.
+
+        Returns
+        -------
+        parsl.Config
+            Configured Parsl Config object.
+
+        """
+        # Build scheduler_options from structured fields + raw extras
+        opts = []
+        if self.gres:
+            opts.append(f"#SBATCH --gres={self.gres}")
+        if self.mem:
+            opts.append(f"#SBATCH --mem={self.mem}")
+        if self.qos:
+            opts.append(f"#SBATCH --qos={self.qos}")
+        if self.constraint:
+            opts.append(f"#SBATCH --constraint={self.constraint}")
+        if self.scheduler_options:
+            opts.append(self.scheduler_options)
+        scheduler_options = "\n".join(opts)
+
+        provider = SlurmProvider(
+            account=self.account,
+            partition=self.partition,
+            walltime=self.walltime,
+            nodes_per_block=self.nodes,
+            cores_per_node=self.cpus_per_node,
+            worker_init=self.worker_init,
+            scheduler_options=scheduler_options,
+            min_blocks=0,
+            init_blocks=1,
+            max_blocks=self.max_blocks,
+            parallelism=1,
+        )
+        executor = HighThroughputExecutor(
+            label="slurm",
+            provider=provider,
+            max_workers_per_node=self.max_workers_per_node,
+            working_dir=str(self.working_directory) if self.working_directory else None,
+        )
+        return parsl.Config(executors=[executor])

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -5,13 +5,37 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-import parsl
 import yaml
-from parsl.executors import HighThroughputExecutor
-from parsl.providers import LocalProvider, SlurmProvider
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    import parsl
+
+
+def _import_parsl():
+    """Import parsl with a clear error message if not installed.
+
+    Returns
+    -------
+    module
+        The parsl module.
+
+    Raises
+    ------
+    ImportError
+        If parsl is not installed.
+
+    """
+    try:
+        import parsl  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "parsl is required for build orchestration. "
+            "Install with `pip install 'mdfactory[parsl]'`."
+        ) from exc
+    return parsl
 
 
 class ExecutorConfig(BaseModel):
@@ -38,7 +62,7 @@ class ExecutorConfig(BaseModel):
     max_workers_per_node: int = 1
     max_blocks: int = 1
 
-    def to_parsl_config(self) -> parsl.Config:
+    def to_parsl_config(self) -> "parsl.Config":
         """Build a Parsl Config with HighThroughputExecutor + LocalProvider.
 
         Returns
@@ -47,6 +71,10 @@ class ExecutorConfig(BaseModel):
             Configured Parsl Config object.
 
         """
+        parsl = _import_parsl()
+        from parsl.executors import HighThroughputExecutor
+        from parsl.providers import LocalProvider
+
         provider = LocalProvider(
             worker_init=self.worker_init,
             min_blocks=0,
@@ -149,7 +177,7 @@ class SlurmExecutorConfig(ExecutorConfig):
     max_blocks: int = 1
     scheduler_options: str = ""
 
-    def to_parsl_config(self) -> parsl.Config:
+    def to_parsl_config(self) -> "parsl.Config":
         """Build a Parsl Config with HighThroughputExecutor + SlurmProvider.
 
         Returns
@@ -158,6 +186,10 @@ class SlurmExecutorConfig(ExecutorConfig):
             Configured Parsl Config object.
 
         """
+        parsl = _import_parsl()
+        from parsl.executors import HighThroughputExecutor
+        from parsl.providers import SlurmProvider
+
         # Build scheduler_options from structured fields + raw extras
         opts = []
         if self.gres:

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -53,6 +53,13 @@ class ExecutorConfig(BaseModel):
         Maximum number of parallel tasks per compute node.
     max_blocks : int
         Maximum number of execution blocks (for local: process groups).
+    available_accelerators : int or list[str]
+        GPU pinning for Parsl workers. An integer count (or explicit list of
+        device IDs) makes Parsl assign each worker a distinct accelerator and
+        set ``CUDA_VISIBLE_DEVICES`` accordingly. Defaults to ``0`` (no pinning,
+        all workers share the node's uncontrolled GPU context). Set this when
+        running ``max_workers_per_node > 1`` on GPU nodes to avoid silent
+        wrong-GPU contention.
     run_dir : Path
         Directory where Parsl writes its ``runinfo`` logs and database.
         Defaults to ``~/.parsl/mdfactory`` so logs land in a predictable,
@@ -66,6 +73,7 @@ class ExecutorConfig(BaseModel):
     working_directory: Path | None = None
     max_workers_per_node: int = 1
     max_blocks: int = 1
+    available_accelerators: int | list[str] = 0
     run_dir: Path = Field(default_factory=lambda: Path("~/.parsl/mdfactory").expanduser())
 
     @field_validator("run_dir", mode="before")
@@ -103,6 +111,7 @@ class ExecutorConfig(BaseModel):
             label="local",
             provider=provider,
             max_workers_per_node=self.max_workers_per_node,
+            available_accelerators=self.available_accelerators,
             working_dir=str(self.working_directory) if self.working_directory else None,
         )
         return parsl.Config(executors=[executor], run_dir=str(self.run_dir))
@@ -168,7 +177,14 @@ class SlurmExecutorConfig(ExecutorConfig):
         Maximum number of simultaneous SLURM jobs. Each block is one
         SLURM job; set this to control how many run in parallel.
     scheduler_options : str
-        Additional raw ``#SBATCH`` lines for anything not covered above.
+        Additional raw ``#SBATCH`` lines for anything not covered above
+        (allocation-level flags injected into the job script).
+    launch_options : str
+        Extra ``srun`` flags forwarded to Parsl's ``SrunLauncher(overrides=...)``
+        for task-placement / binding control (e.g.
+        ``"--cpu-bind=cores --distribution=block:block"`` for NUMA-local CPU
+        binding in MPI+OpenMP workers). Empty string leaves Parsl's default
+        launcher untouched.
 
     Examples
     --------
@@ -199,6 +215,7 @@ class SlurmExecutorConfig(ExecutorConfig):
     qos: str | None = None
     constraint: str | None = None
     scheduler_options: str = ""
+    launch_options: str = ""
 
     @field_validator("walltime", mode="before")
     @classmethod
@@ -288,6 +305,14 @@ class SlurmExecutorConfig(ExecutorConfig):
             opts.append(self.scheduler_options)
         scheduler_options = "\n".join(opts)
 
+        # Only override Parsl's default launcher when srun-level flags are given,
+        # so NUMA/task-placement binding is opt-in (relevant for MPI+OpenMP work).
+        provider_kwargs: dict[str, Any] = {}
+        if self.launch_options:
+            from parsl.launchers import SrunLauncher
+
+            provider_kwargs["launcher"] = SrunLauncher(overrides=self.launch_options)
+
         provider = SlurmProvider(
             account=self.account,
             partition=self.partition,
@@ -300,11 +325,13 @@ class SlurmExecutorConfig(ExecutorConfig):
             init_blocks=1,
             max_blocks=self.max_blocks,
             parallelism=1,
+            **provider_kwargs,
         )
         executor = HighThroughputExecutor(
             label="slurm",
             provider=provider,
             max_workers_per_node=self.max_workers_per_node,
+            available_accelerators=self.available_accelerators,
             working_dir=str(self.working_directory) if self.working_directory else None,
         )
         return parsl.Config(executors=[executor], run_dir=str(self.run_dir))

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 if TYPE_CHECKING:
     import parsl
@@ -53,6 +53,11 @@ class ExecutorConfig(BaseModel):
         Maximum number of parallel tasks per compute node.
     max_blocks : int
         Maximum number of execution blocks (for local: process groups).
+    run_dir : Path
+        Directory where Parsl writes its ``runinfo`` logs and database.
+        Defaults to ``~/.parsl/mdfactory`` so logs land in a predictable,
+        controllable location instead of scattering ``runinfo/`` into the
+        current working directory (typically the login-node home on HPC).
 
     """
 
@@ -61,6 +66,18 @@ class ExecutorConfig(BaseModel):
     working_directory: Path | None = None
     max_workers_per_node: int = 1
     max_blocks: int = 1
+    run_dir: Path = Field(default_factory=lambda: Path("~/.parsl/mdfactory").expanduser())
+
+    @field_validator("run_dir", mode="before")
+    @classmethod
+    def _expand_run_dir(cls, v: Any) -> Any:
+        """Expand ``~`` in user-supplied run_dir values."""
+        return Path(v).expanduser() if v is not None else v
+
+    @field_serializer("run_dir", "working_directory")
+    def _serialize_paths(self, v: Path | None) -> str | None:
+        """Serialize Path fields as plain strings for YAML compatibility."""
+        return str(v) if v is not None else None
 
     def to_parsl_config(self) -> "parsl.Config":
         """Build a Parsl Config with HighThroughputExecutor + LocalProvider.
@@ -88,7 +105,7 @@ class ExecutorConfig(BaseModel):
             max_workers_per_node=self.max_workers_per_node,
             working_dir=str(self.working_directory) if self.working_directory else None,
         )
-        return parsl.Config(executors=[executor])
+        return parsl.Config(executors=[executor], run_dir=str(self.run_dir))
 
     @classmethod
     def from_yaml(cls, path: Path) -> "ExecutorConfig | SlurmExecutorConfig":
@@ -134,7 +151,11 @@ class SlurmExecutorConfig(ExecutorConfig):
     nodes : int
         Number of nodes per SLURM job (``--nodes``).
     cpus_per_node : int
-        CPUs per node (``--cpus-per-task`` equivalent).
+        CPUs requested per node. Wired to Parsl ``SlurmProvider(cores_per_node=...)``,
+        which Parsl uses to size the worker pool (roughly ``--ntasks`` /
+        cores-per-node) — it is **not** the sbatch ``--cpus-per-task`` flag. For
+        MPI+OpenMP workloads (e.g. GROMACS), OpenMP threads-per-rank must be set
+        separately via ``scheduler_options`` / ``worker_init``.
     gres : str or None
         Generic resource specification (``--gres``), e.g. ``"gpu:l40s:1"``.
     mem : str or None
@@ -286,4 +307,4 @@ class SlurmExecutorConfig(ExecutorConfig):
             max_workers_per_node=self.max_workers_per_node,
             working_dir=str(self.working_directory) if self.working_directory else None,
         )
-        return parsl.Config(executors=[executor])
+        return parsl.Config(executors=[executor], run_dir=str(self.run_dir))

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -230,69 +230,15 @@ class SlurmExecutorConfig(ExecutorConfig):
             If SLURM is unavailable *and* the required ``account`` or
             ``partition`` value cannot be resolved from config.
         """
-        from mdfactory.performance.cluster import discover_cluster, select_partition
-        from mdfactory.settings import settings
+        from mdfactory.performance.slurm_config import resolve_slurm_fields
 
-        cluster = discover_cluster()
-
-        # --- account: explicit kwarg > config.ini > autodiscovery ---
-        resolved_account: str | None = extra_fields.pop("account", None)
-        if resolved_account is None:
-            resolved_account = settings.slurm_account
-        if resolved_account is None:
-            if cluster is None:
-                raise RuntimeError(
-                    "SLURM autodiscovery failed and no account configured. "
-                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
-                )
-            resolved_account = cluster.default_account
-            if resolved_account is None:
-                raise RuntimeError(
-                    "No SLURM account available. "
-                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
-                )
-
-        # --- partition: explicit kwarg > config.ini (cpu/gpu) > autodiscovery ---
-        resolved_partition: str | None = extra_fields.pop("partition", None)
-        if resolved_partition is None:
-            resolved_partition = (
-                settings.slurm_partition_gpu if needs_gpu else settings.slurm_partition_cpu
-            )
-        if resolved_partition is None:
-            if cluster is None:
-                raise RuntimeError(
-                    "SLURM autodiscovery failed and no partition configured. "
-                    "Set [slurm] PARTITION_CPU or PARTITION_GPU in config.ini "
-                    "or pass partition= explicitly."
-                )
-            selected = select_partition(
-                cluster,
-                needs_gpu=needs_gpu,
-                min_cpus=min_cpus,
-                min_mem_gb=min_mem_gb,
-            )
-            if selected is None:
-                raise RuntimeError(
-                    f"No suitable partition found for requirements: "
-                    f"needs_gpu={needs_gpu}, cpus={min_cpus}, mem={min_mem_gb}GB"
-                )
-            resolved_partition = selected.name
-
-        # --- qos: explicit kwarg > config.ini ---
-        resolved_qos: str | None = extra_fields.pop("qos", None)
-        if resolved_qos is None:
-            resolved_qos = settings.slurm_qos
-
-        # --- constraint: explicit kwarg only ---
-        resolved_constraint: str | None = extra_fields.pop("constraint", None)
-
-        return cls(
-            account=resolved_account,
-            partition=resolved_partition,
-            qos=resolved_qos,
-            constraint=resolved_constraint,
+        fields = resolve_slurm_fields(
+            needs_gpu=needs_gpu,
+            min_cpus=min_cpus,
+            min_mem_gb=min_mem_gb,
             **extra_fields,
         )
+        return cls(**fields)
 
     def to_parsl_config(self) -> "parsl.Config":
         """Build a Parsl Config with HighThroughputExecutor + SlurmProvider.

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+
+from mdfactory.performance.slurm_config import BaseSlurmConfig
 
 if TYPE_CHECKING:
     import parsl
@@ -143,11 +145,24 @@ class ExecutorConfig(BaseModel):
         return cls(**data)
 
 
-class SlurmExecutorConfig(ExecutorConfig):
+class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
     """SLURM executor configuration for Parsl workflows.
+
+    Inherits the four cross-cutting SLURM fields (``account``, ``partition``,
+    ``qos``, ``constraint``) and the authoritative ``from_cluster()`` factory
+    from :class:`~mdfactory.performance.slurm_config.BaseSlurmConfig`, and the
+    Parsl executor fields (``run_dir``, ``available_accelerators``, …) from
+    :class:`ExecutorConfig`. Only Parsl/SLURM-job-specific fields are declared
+    here.
 
     Field names mirror sbatch flags where possible. The only Parsl-specific
     field is ``max_workers_per_node`` (number of parallel tasks per node).
+
+    Notes
+    -----
+    ``BaseSlurmConfig`` is frozen (immutable), but executor configs are mutated
+    in places (e.g. the TUI wizard), so this subclass explicitly sets
+    ``frozen=False`` to match :class:`ExecutorConfig`'s mutable behaviour.
 
     Parameters
     ----------
@@ -204,16 +219,17 @@ class SlurmExecutorConfig(ExecutorConfig):
 
     """
 
+    model_config = ConfigDict(frozen=False)
+
     provider: Literal["slurm"] = "slurm"
-    account: str
-    partition: str = "cpu"
+    # account, partition, qos, constraint inherited from BaseSlurmConfig.
+    # from_cluster() inherited from BaseSlurmConfig — extra fields below are
+    # forwarded to the constructor via resolve_slurm_fields().
     walltime: str = Field(default="2h", validate_default=True)
     nodes: int = 1
     cpus_per_node: int = 12
     gres: str | None = None
     mem: str | None = None
-    qos: str | None = None
-    constraint: str | None = None
     scheduler_options: str = ""
     launch_options: str = ""
 
@@ -224,59 +240,6 @@ class SlurmExecutorConfig(ExecutorConfig):
         from mdfactory.performance.slurm_config import normalize_slurm_time
 
         return normalize_slurm_time(v)
-
-    @classmethod
-    def from_cluster(
-        cls,
-        *,
-        needs_gpu: bool = False,
-        min_cpus: int = 1,
-        min_mem_gb: int = 1,
-        **extra_fields: Any,
-    ) -> "SlurmExecutorConfig":
-        """Create an instance with SLURM fields auto-populated from the cluster.
-
-        Three-tier precedence (highest wins):
-
-        1. Explicit keyword arguments passed by the caller.
-        2. ``[slurm]`` section in ``config.ini`` — read via
-           ``mdfactory.settings.settings``.
-        3. Live ``sinfo`` / ``sacctmgr`` autodiscovery via
-           ``mdfactory.performance.cluster``.
-
-        Parameters
-        ----------
-        needs_gpu : bool
-            Select a GPU-capable partition when ``True``.
-        min_cpus : int
-            Minimum CPUs per node required (passed to ``select_partition()``).
-        min_mem_gb : int
-            Minimum memory per node in GB (passed to ``select_partition()``).
-        **extra_fields
-            Additional fields forwarded to the constructor.  Base SLURM
-            fields (``account``, ``partition``, ``qos``, ``constraint``)
-            may be passed here to override autodiscovery.
-
-        Returns
-        -------
-        SlurmExecutorConfig
-            A fully initialised instance.
-
-        Raises
-        ------
-        RuntimeError
-            If SLURM is unavailable *and* the required ``account`` or
-            ``partition`` value cannot be resolved from config.
-        """
-        from mdfactory.performance.slurm_config import resolve_slurm_fields
-
-        fields = resolve_slurm_fields(
-            needs_gpu=needs_gpu,
-            min_cpus=min_cpus,
-            min_mem_gb=min_mem_gb,
-            **extra_fields,
-        )
-        return cls(**fields)
 
     def to_parsl_config(self) -> "parsl.Config":
         """Build a Parsl Config with HighThroughputExecutor + SlurmProvider.

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -5,10 +5,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 if TYPE_CHECKING:
     import parsl
@@ -169,17 +169,130 @@ class SlurmExecutorConfig(ExecutorConfig):
 
     provider: Literal["slurm"] = "slurm"
     account: str
-    partition: str = "gpu"
-    walltime: str = "2:00:00"
+    partition: str = "cpu"
+    walltime: str = Field(default="2h", validate_default=True)
     nodes: int = 1
     cpus_per_node: int = 12
     gres: str | None = None
     mem: str | None = None
     qos: str | None = None
     constraint: str | None = None
-    max_workers_per_node: int = 1
-    max_blocks: int = 1
     scheduler_options: str = ""
+
+    @field_validator("walltime", mode="before")
+    @classmethod
+    def _normalize_walltime(cls, v: str) -> str:
+        """Normalize walltime string on construction."""
+        from mdfactory.performance.slurm_config import normalize_slurm_time
+
+        return normalize_slurm_time(v)
+
+    @classmethod
+    def from_cluster(
+        cls,
+        *,
+        needs_gpu: bool = False,
+        min_cpus: int = 1,
+        min_mem_gb: int = 1,
+        **extra_fields: Any,
+    ) -> "SlurmExecutorConfig":
+        """Create an instance with SLURM fields auto-populated from the cluster.
+
+        Three-tier precedence (highest wins):
+
+        1. Explicit keyword arguments passed by the caller.
+        2. ``[slurm]`` section in ``config.ini`` — read via
+           ``mdfactory.settings.settings``.
+        3. Live ``sinfo`` / ``sacctmgr`` autodiscovery via
+           ``mdfactory.performance.cluster``.
+
+        Parameters
+        ----------
+        needs_gpu : bool
+            Select a GPU-capable partition when ``True``.
+        min_cpus : int
+            Minimum CPUs per node required (passed to ``select_partition()``).
+        min_mem_gb : int
+            Minimum memory per node in GB (passed to ``select_partition()``).
+        **extra_fields
+            Additional fields forwarded to the constructor.  Base SLURM
+            fields (``account``, ``partition``, ``qos``, ``constraint``)
+            may be passed here to override autodiscovery.
+
+        Returns
+        -------
+        SlurmExecutorConfig
+            A fully initialised instance.
+
+        Raises
+        ------
+        RuntimeError
+            If SLURM is unavailable *and* the required ``account`` or
+            ``partition`` value cannot be resolved from config.
+        """
+        from mdfactory.performance.cluster import discover_cluster, select_partition
+        from mdfactory.settings import settings
+
+        cluster = discover_cluster()
+
+        # --- account: explicit kwarg > config.ini > autodiscovery ---
+        resolved_account: str | None = extra_fields.pop("account", None)
+        if resolved_account is None:
+            resolved_account = settings.slurm_account
+        if resolved_account is None:
+            if cluster is None:
+                raise RuntimeError(
+                    "SLURM autodiscovery failed and no account configured. "
+                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
+                )
+            resolved_account = cluster.default_account
+            if resolved_account is None:
+                raise RuntimeError(
+                    "No SLURM account available. "
+                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
+                )
+
+        # --- partition: explicit kwarg > config.ini (cpu/gpu) > autodiscovery ---
+        resolved_partition: str | None = extra_fields.pop("partition", None)
+        if resolved_partition is None:
+            resolved_partition = (
+                settings.slurm_partition_gpu if needs_gpu else settings.slurm_partition_cpu
+            )
+        if resolved_partition is None:
+            if cluster is None:
+                raise RuntimeError(
+                    "SLURM autodiscovery failed and no partition configured. "
+                    "Set [slurm] PARTITION_CPU or PARTITION_GPU in config.ini "
+                    "or pass partition= explicitly."
+                )
+            selected = select_partition(
+                cluster,
+                needs_gpu=needs_gpu,
+                min_cpus=min_cpus,
+                min_mem_gb=min_mem_gb,
+            )
+            if selected is None:
+                raise RuntimeError(
+                    f"No suitable partition found for requirements: "
+                    f"needs_gpu={needs_gpu}, cpus={min_cpus}, mem={min_mem_gb}GB"
+                )
+            resolved_partition = selected.name
+
+        # --- qos: explicit kwarg > config.ini ---
+        resolved_qos: str | None = extra_fields.pop("qos", None)
+        if resolved_qos is None:
+            resolved_qos = settings.slurm_qos
+
+        # --- constraint: explicit kwarg only ---
+        resolved_constraint: str | None = extra_fields.pop("constraint", None)
+
+        return cls(
+            account=resolved_account,
+            partition=resolved_partition,
+            qos=resolved_qos,
+            constraint=resolved_constraint,
+            **extra_fields,
+        )
 
     def to_parsl_config(self) -> "parsl.Config":
         """Build a Parsl Config with HighThroughputExecutor + SlurmProvider.

--- a/mdfactory/orchestration/session.py
+++ b/mdfactory/orchestration/session.py
@@ -1,0 +1,180 @@
+# ABOUTME: Generic Parsl session lifecycle management (guard, load, shutdown)
+# ABOUTME: Reusable context manager shared by build/simulation/benchmark orchestration
+"""Parsl session management.
+
+Provides :func:`parsl_session`, a context manager that owns the full Parsl
+``DataFlowKernel`` lifecycle — guarding against an already-active DFK, loading
+the executor config, and guaranteeing shutdown (including ``scancel`` of any
+lingering SLURM jobs) on exit. Build, simulation, and benchmark orchestration
+all share this single implementation rather than duplicating the guard / load /
+cleanup boilerplate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from .config import _import_parsl
+
+if TYPE_CHECKING:
+    from .config import ExecutorConfig
+
+
+@dataclass
+class ParslSession:
+    """Handle yielded by :func:`parsl_session`.
+
+    Parameters
+    ----------
+    parsl : module
+        The imported ``parsl`` module, for submitting apps or inspecting the DFK.
+    detached : bool
+        When ``True``, the context manager will **not** shut down the DFK on
+        exit; the caller takes ownership of cleanup. Set via :meth:`detach`.
+
+    """
+
+    parsl: object
+    detached: bool = False
+
+    def detach(self) -> None:
+        """Transfer DFK ownership to the caller (skip shutdown on exit).
+
+        Used when returning raw futures (e.g. ``wait=False``): the caller is
+        then responsible for calling ``parsl.clear()`` once all futures
+        complete.
+        """
+        self.detached = True
+
+
+@contextmanager
+def parsl_session(config: "ExecutorConfig") -> Iterator[ParslSession]:
+    """Manage a Parsl ``DataFlowKernel`` lifecycle for an orchestration run.
+
+    Guards against an already-active DFK, loads ``config``'s Parsl config,
+    yields a :class:`ParslSession`, and guarantees shutdown on exit unless the
+    session was detached via :meth:`ParslSession.detach`.
+
+    Examples
+    --------
+    >>> with parsl_session(config) as session:  # doctest: +SKIP
+    ...     futures = [app(x) for x in inputs]
+    ...     results = wait(futures)
+
+    Parameters
+    ----------
+    config : ExecutorConfig
+        Executor configuration whose ``to_parsl_config()`` drives the DFK.
+
+    Yields
+    ------
+    ParslSession
+        Session handle exposing the ``parsl`` module and a ``detach()`` escape
+        hatch.
+
+    Raises
+    ------
+    RuntimeError
+        If a Parsl ``DataFlowKernel`` is already active.
+
+    """
+    parsl = _import_parsl()
+    _guard_no_active_dfk(parsl)
+    parsl.load(config.to_parsl_config())
+    session = ParslSession(parsl=parsl)
+    try:
+        yield session
+    finally:
+        if not session.detached:
+            _shutdown_parsl()
+
+
+def _guard_no_active_dfk(parsl) -> None:
+    """Raise if a Parsl ``DataFlowKernel`` is already loaded.
+
+    Parameters
+    ----------
+    parsl : module
+        The imported ``parsl`` module.
+
+    Raises
+    ------
+    RuntimeError
+        If a DFK is already active.
+
+    """
+    try:
+        parsl.dfk()
+    except Exception:
+        return  # No active DFK, good
+    raise RuntimeError(
+        "A Parsl DataFlowKernel is already active. "
+        "Call parsl.clear() before starting a new session."
+    )
+
+
+def _shutdown_parsl():
+    """Shut down Parsl and cancel any remaining SLURM jobs."""
+    try:
+        import parsl  # type: ignore[import-not-found]
+    except ImportError:
+        return
+
+    job_ids = []
+    try:
+        dfk = parsl.dfk()
+        job_ids = _get_slurm_job_ids(dfk)
+    except Exception as exc:
+        logger.debug(f"Could not query Parsl DFK for SLURM jobs: {exc}")
+
+    try:
+        parsl.clear()
+    except Exception as exc:
+        logger.warning(f"Parsl shutdown failed — DFK may still be loaded: {exc}")
+
+    # Always attempt scancel if we found job IDs
+    if job_ids:
+        _scancel_jobs(job_ids)
+
+
+def _get_slurm_job_ids(dfk) -> list[str]:
+    """Extract active SLURM job IDs from the Parsl DataFlowKernel."""
+    job_ids = []
+    try:
+        for executor in dfk.executors.values():
+            if hasattr(executor, "provider") and hasattr(executor.provider, "resources"):
+                for _block_id, resource in executor.provider.resources.items():
+                    job_id = resource.get("remote_job_id") or resource.get("job_id")
+                    if job_id:
+                        job_ids.append(str(job_id))
+    except Exception as exc:
+        logger.debug(f"Could not enumerate SLURM jobs for explicit scancel: {exc}")
+    return job_ids
+
+
+def _scancel_jobs(job_ids: list[str]):
+    """Run scancel on the given SLURM job IDs."""
+    if not job_ids:
+        return
+    try:
+        cmd = ["scancel"] + job_ids
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
+        if result.returncode == 0:
+            logger.info(f"Cancelled SLURM jobs: {', '.join(job_ids)}")
+        else:
+            logger.debug(f"scancel stderr: {result.stderr.strip()}")
+    except FileNotFoundError:
+        logger.debug("scancel not found (not on SLURM cluster)")
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            f"scancel timed out after 10 s — SLURM jobs {', '.join(job_ids)} may still "
+            f"be running. Run `scancel {' '.join(job_ids)}` manually."
+        )
+    except Exception as exc:
+        logger.debug(f"scancel failed: {exc}")

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -1,0 +1,540 @@
+# ABOUTME: Interactive SLURM configuration wizard using questionary.
+# ABOUTME: Leverages cluster autodiscovery to guide users through executor setup.
+"""Interactive SLURM configuration wizard.
+
+Provides a terminal-based wizard that queries the local SLURM cluster
+(via :func:`~mdfactory.performance.cluster.discover_cluster`) and guides
+the user through selecting accounts, partitions, and resource limits.
+The result is a :class:`~mdfactory.orchestration.config.SlurmExecutorConfig`
+that can be saved as YAML and used with Parsl-based workflows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import questionary
+import yaml
+
+from mdfactory.orchestration.config import SlurmExecutorConfig
+from mdfactory.performance.cluster import ClusterInfo, Partition, discover_cluster
+
+
+def _default_worker_init() -> str:
+    """Auto-detect the pixi environment and return an appropriate worker_init.
+
+    On HPC clusters with a shared filesystem, workers need the same pixi
+    environment as the submitting process.  This function locates the
+    project root via ``mdfactory.__file__`` and returns a pixi shell-hook
+    command if the environment exists.
+
+    Returns
+    -------
+    str
+        A shell command to activate the pixi environment, or ``""`` if
+        no pixi environment is detected.
+    """
+    try:
+        import mdfactory as _mdf
+
+        project_root = Path(_mdf.__file__).parent.parent
+        pixi_env = project_root / ".pixi" / "envs" / "default"
+        if pixi_env.exists():
+            return f'eval "$(pixi shell-hook --manifest-path {project_root} -e default)"'
+    except Exception:
+        pass
+    return ""
+
+
+class UserCancelledError(Exception):
+    """Raised when the user cancels an interactive prompt."""
+
+
+def _require(value: str | None, label: str) -> str:
+    """Return *value* or raise if the user cancelled the prompt.
+
+    Parameters
+    ----------
+    value : str or None
+        Return value from a ``questionary`` ``.ask()`` call.
+    label : str
+        Human-readable label used in the error message.
+
+    Returns
+    -------
+    str
+        The validated, non-None value.
+
+    Raises
+    ------
+    UserCancelledError
+        If *value* is None (user pressed Ctrl-C / Ctrl-D).
+    """
+    if value is None:
+        raise UserCancelledError(f"Prompt cancelled at: {label}")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Partition / node helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_node_type_summary(partition: Partition) -> str:
+    """Build a one-line summary of node hardware for a partition label.
+
+    Parameters
+    ----------
+    partition : Partition
+        Partition whose node types to summarise.
+
+    Returns
+    -------
+    str
+        Human-readable summary, e.g. ``"96 cpu, 512 GB, 4×a100"``
+    """
+    parts: list[str] = []
+    for nt in partition.node_types:
+        items = [f"{nt.cpus} cpu", f"{nt.memory_mb // 1024} GB"]
+        for count, gpu_type in nt.gpu_specs:
+            gpu_label = f"{count}×{gpu_type}" if gpu_type else f"{count}×gpu"
+            items.append(gpu_label)
+        parts.append(", ".join(items))
+    return " | ".join(parts)
+
+
+def _partition_has_gpus(partition: Partition) -> bool:
+    """Check whether any node type in *partition* has GPUs."""
+    return any(len(nt.gpu_specs) > 0 for nt in partition.node_types)
+
+
+def _suggest_gres(partition: Partition) -> str:
+    """Suggest a ``--gres`` string from the first GPU-equipped node type.
+
+    Parameters
+    ----------
+    partition : Partition
+        Selected partition.
+
+    Returns
+    -------
+    str
+        Suggested GRES string, e.g. ``"gpu:a100:1"``, or empty string.
+    """
+    for nt in partition.node_types:
+        for count, gpu_type in nt.gpu_specs:
+            if gpu_type:
+                return f"gpu:{gpu_type}:1"
+            return "gpu:1"
+    return ""
+
+
+def _suggest_mem(partition: Partition) -> str:
+    """Suggest a ``--mem`` value from the first node type.
+
+    Parameters
+    ----------
+    partition : Partition
+        Selected partition.
+
+    Returns
+    -------
+    str
+        Suggested memory string in GB, e.g. ``"64G"``.
+    """
+    if partition.node_types:
+        mem_gb = partition.node_types[0].memory_mb // 1024
+        return f"{mem_gb}G"
+    return "16G"
+
+
+def _default_walltime(partition: Partition) -> str:
+    """Pick a sensible default walltime from the partition.
+
+    Parameters
+    ----------
+    partition : Partition
+        Selected partition.
+
+    Returns
+    -------
+    str
+        Walltime string (falls back to ``"2:00:00"``).
+    """
+    mt = partition.max_time
+    if mt and mt not in ("unknown", "infinite"):
+        return mt
+    return "2:00:00"
+
+
+# ---------------------------------------------------------------------------
+# Selection helpers
+# ---------------------------------------------------------------------------
+
+
+def _select_with_custom(
+    message: str,
+    choices: list[str],
+    default: str = "",
+) -> str:
+    """Present a selection list with a "Custom…" escape hatch.
+
+    Parameters
+    ----------
+    message : str
+        Prompt message shown to the user.
+    choices : list[str]
+        Pre-defined choices (e.g. ``["1h", "2h", "4h"]``).
+    default : str
+        Pre-selected value in the list.
+
+    Returns
+    -------
+    str
+        The selected or custom-entered value.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels.
+    """
+    _CUSTOM = "Custom…"
+    all_choices = [*choices, _CUSTOM]
+    selected = _require(
+        questionary.select(message, choices=all_choices, default=default).ask(),
+        message,
+    )
+    if selected == _CUSTOM:
+        return _require(
+            questionary.text(f"{message} (enter value):").ask(),
+            message,
+        )
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompts — cluster-assisted
+# ---------------------------------------------------------------------------
+
+
+def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
+    """Run the interactive wizard using autodiscovered cluster info.
+
+    Parameters
+    ----------
+    cluster : ClusterInfo
+        Cluster information from ``discover_cluster()``.
+
+    Returns
+    -------
+    SlurmExecutorConfig
+        Fully populated SLURM executor config.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels any prompt.
+    """
+    # --- Account ---
+    if cluster.accounts:
+        account = _require(
+            questionary.select(
+                "SLURM account:",
+                choices=cluster.accounts,
+                default=cluster.default_account or cluster.accounts[0],
+            ).ask(),
+            "account",
+        )
+    else:
+        account = _require(
+            questionary.text("SLURM account (no accounts discovered):").ask(),
+            "account",
+        )
+
+    # --- Partition ---
+    up_partitions = [p for p in cluster.partitions if p.state == "up"]
+    if not up_partitions:
+        print("⚠ No partitions in 'up' state — showing all partitions.")
+        up_partitions = list(cluster.partitions)
+
+    if not up_partitions:
+        raise UserCancelledError("No partitions available on the cluster.")
+
+    partition_choices = [
+        questionary.Choice(
+            title=f"{p.name}  ({p.total_nodes} nodes — {_format_node_type_summary(p)})",
+            value=p.name,
+        )
+        for p in up_partitions
+    ]
+    default_partition = next((p.name for p in up_partitions if p.is_default), up_partitions[0].name)
+
+    partition_name = _require(
+        questionary.select(
+            "SLURM partition:",
+            choices=partition_choices,
+            default=default_partition,
+        ).ask(),
+        "partition",
+    )
+
+    partition = next(p for p in up_partitions if p.name == partition_name)
+
+    # --- Display node types ---
+    print(f"\n  Partition '{partition_name}' node types:")
+    for nt in partition.node_types:
+        gpu_info = ""
+        if nt.gpu_specs:
+            gpu_parts = [f"{c}×{t}" if t else f"{c}×gpu" for c, t in nt.gpu_specs]
+            gpu_info = f", GPUs: {', '.join(gpu_parts)}"
+        print(f"    {nt.count} nodes — {nt.cpus} CPUs, {nt.memory_mb // 1024} GB RAM{gpu_info}")
+    print()
+
+    # --- Walltime ---
+    walltime = _select_with_custom(
+        "Walltime (--time):",
+        choices=["30m", "1h", "2h", "4h", "8h", "12h", "1d"],
+        default="2h",
+    )
+
+    # --- CPUs per node ---
+    max_cpus = partition.node_types[0].cpus if partition.node_types else 128
+    cpu_choices = [str(c) for c in [1, 2, 4, 8, 16, 32, 64, max_cpus] if c <= max_cpus]
+    # Deduplicate (max_cpus might equal one of the fixed values)
+    cpu_choices = list(dict.fromkeys(cpu_choices))
+    cpus_per_node = int(
+        _select_with_custom(
+            "CPUs per node (--cpus-per-task):",
+            choices=cpu_choices,
+            default="4" if "4" in cpu_choices else cpu_choices[0],
+        )
+    )
+
+    # --- GPU ---
+    gres: str | None = None
+    if _partition_has_gpus(partition):
+        gres_default = _suggest_gres(partition)
+        gres_input = _require(
+            questionary.text(
+                "GRES (--gres), leave empty to skip:",
+                default=gres_default,
+            ).ask(),
+            "gres",
+        )
+        gres = gres_input.strip() or None
+
+    # --- Memory ---
+    mem_gb = partition.node_types[0].memory_mb // 1024 if partition.node_types else 128
+    mem_choices = [f"{m}G" for m in [10, 20, 50, 100, 200, 500, mem_gb] if m <= mem_gb]
+    mem_choices = list(dict.fromkeys(mem_choices))
+    mem_selected = _select_with_custom(
+        "Memory per node (--mem):",
+        choices=mem_choices,
+        default="20G" if "20G" in mem_choices else mem_choices[0],
+    )
+    mem: str | None = mem_selected.strip() or None
+
+    # --- Max blocks ---
+    max_blocks = int(
+        _select_with_custom(
+            "Max simultaneous SLURM jobs (max_blocks):",
+            choices=["1", "2", "4", "8", "16", "32"],
+            default="4",
+        )
+    )
+
+    # --- Worker init ---
+    default_init = _default_worker_init()
+    worker_init = _require(
+        questionary.text(
+            "Worker init script (activates environment on compute nodes):",
+            default=default_init,
+        ).ask(),
+        "worker_init",
+    )
+
+    # --- QOS ---
+    qos: str | None = None
+    if cluster.qos_policies:
+        use_qos = questionary.confirm("Configure QOS?", default=False).ask()
+        if use_qos is None:
+            raise UserCancelledError("Prompt cancelled at: qos confirm")
+        if use_qos:
+            qos = _require(
+                questionary.select("QOS policy:", choices=cluster.qos_policies).ask(),
+                "qos",
+            )
+
+    return SlurmExecutorConfig(
+        account=account,
+        partition=partition_name,
+        walltime=walltime,
+        cpus_per_node=cpus_per_node,
+        gres=gres,
+        mem=mem,
+        qos=qos,
+        max_blocks=max_blocks,
+        worker_init=worker_init,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompts — manual fallback
+# ---------------------------------------------------------------------------
+
+
+def _configure_manual() -> SlurmExecutorConfig:
+    """Run the interactive wizard with manual text entry (no cluster info).
+
+    Returns
+    -------
+    SlurmExecutorConfig
+        Fully populated SLURM executor config.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels any prompt.
+    """
+    account = _require(questionary.text("SLURM account:").ask(), "account")
+    partition = _require(questionary.text("SLURM partition:", default="gpu").ask(), "partition")
+    walltime = _require(questionary.text("Walltime (--time):", default="2:00:00").ask(), "walltime")
+    cpus_per_node = int(
+        _require(questionary.text("CPUs per node:", default="12").ask(), "cpus_per_node")
+    )
+
+    gres_input = _require(
+        questionary.text("GRES (--gres), leave empty to skip:", default="").ask(),
+        "gres",
+    )
+    gres: str | None = gres_input.strip() or None
+
+    mem_input = _require(
+        questionary.text("Memory per node (--mem), leave empty to skip:", default="").ask(),
+        "mem",
+    )
+    mem: str | None = mem_input.strip() or None
+
+    qos_input = _require(
+        questionary.text("QOS (--qos), leave empty to skip:", default="").ask(),
+        "qos",
+    )
+    qos: str | None = qos_input.strip() or None
+
+    max_blocks = int(
+        _require(
+            questionary.text("Max simultaneous SLURM jobs (max_blocks):", default="4").ask(),
+            "max_blocks",
+        )
+    )
+
+    default_init = _default_worker_init()
+    worker_init = _require(
+        questionary.text(
+            "Worker init script (activates environment on compute nodes):",
+            default=default_init,
+        ).ask(),
+        "worker_init",
+    )
+
+    return SlurmExecutorConfig(
+        account=account,
+        partition=partition,
+        walltime=walltime,
+        cpus_per_node=cpus_per_node,
+        gres=gres,
+        mem=mem,
+        qos=qos,
+        max_blocks=max_blocks,
+        worker_init=worker_init,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def configure_slurm_interactive() -> SlurmExecutorConfig:
+    """Interactive SLURM configuration wizard.
+
+    Attempts to autodiscover the SLURM cluster. If discovery succeeds,
+    the wizard presents select menus populated with real partitions,
+    accounts, and hardware specs. Otherwise it falls back to free-text
+    prompts.
+
+    Returns
+    -------
+    SlurmExecutorConfig
+        A validated SLURM executor config ready for use with Parsl.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels any prompt (Ctrl-C / Ctrl-D).
+    """
+    print("Querying SLURM cluster...")
+    cluster = discover_cluster()
+
+    if cluster is not None:
+        print(
+            f"✓ Cluster discovered: {len(cluster.partitions)} partitions, "
+            f"{len(cluster.accounts)} accounts\n"
+        )
+        return _configure_with_cluster(cluster)
+
+    print("⚠ SLURM not detected (sinfo unavailable). Falling back to manual entry.\n")
+    proceed = questionary.confirm("Enter SLURM configuration manually?", default=True).ask()
+    if not proceed:
+        raise UserCancelledError("User declined manual SLURM configuration.")
+    return _configure_manual()
+
+
+def save_slurm_config_yaml(config: SlurmExecutorConfig, path: Path) -> None:
+    """Write a SLURM executor config to a YAML file.
+
+    Parameters
+    ----------
+    config : SlurmExecutorConfig
+        The config to serialise.
+    path : Path
+        Destination file path. Parent directories are created if needed.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = config.model_dump(exclude_none=True)
+    with open(path, "w") as fh:
+        yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
+
+    print(f"✓ SLURM config written to {path}")
+
+
+def configure_and_save_slurm() -> SlurmExecutorConfig:
+    """Run the interactive wizard and save the result to YAML.
+
+    Combines :func:`configure_slurm_interactive` with a file-save prompt.
+
+    Returns
+    -------
+    SlurmExecutorConfig
+        The config that was saved.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels any prompt.
+    """
+    try:
+        config = configure_slurm_interactive()
+    except UserCancelledError:
+        print("Configuration cancelled.")
+        raise
+
+    save_path = _require(
+        questionary.text("Save config to:", default="slurm_executor.yaml").ask(),
+        "save path",
+    )
+
+    save_slurm_config_yaml(config, Path(save_path))
+    return config

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -13,11 +13,42 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import questionary
 import yaml
+from rich.console import Console
 
 from mdfactory.orchestration.config import SlurmExecutorConfig
 from mdfactory.performance.cluster import ClusterInfo, Partition, discover_cluster
+
+console = Console()
+
+
+def _import_questionary():
+    """Import questionary with a clear error message if not installed.
+
+    ``questionary`` ships in the ``[parsl]`` optional extra. Importing it
+    lazily (rather than at module level) means ``import mdfactory.orchestration``
+    succeeds for users who never touch the TUI, matching the lazy-import
+    pattern used for ``parsl`` and ``rich``.
+
+    Returns
+    -------
+    module
+        The questionary module.
+
+    Raises
+    ------
+    ImportError
+        If questionary is not installed.
+
+    """
+    try:
+        import questionary
+    except ImportError as exc:
+        raise ImportError(
+            "questionary is required for the SLURM TUI. "
+            "Install with: pip install 'mdfactory[parsl]'"
+        ) from exc
+    return questionary
 
 
 def _default_worker_init() -> str:
@@ -198,6 +229,7 @@ def _select_with_custom(
     UserCancelledError
         If the user cancels.
     """
+    questionary = _import_questionary()
     _CUSTOM = "Custom…"
     all_choices = [*choices, _CUSTOM]
     selected = _require(
@@ -235,6 +267,7 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
     UserCancelledError
         If the user cancels any prompt.
     """
+    questionary = _import_questionary()
     # --- Account ---
     if cluster.accounts:
         account = _require(
@@ -254,7 +287,7 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
     # --- Partition ---
     up_partitions = [p for p in cluster.partitions if p.state == "up"]
     if not up_partitions:
-        print("⚠ No partitions in 'up' state — showing all partitions.")
+        console.print("⚠ No partitions in 'up' state — showing all partitions.")
         up_partitions = list(cluster.partitions)
 
     if not up_partitions:
@@ -281,14 +314,16 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
     partition = next(p for p in up_partitions if p.name == partition_name)
 
     # --- Display node types ---
-    print(f"\n  Partition '{partition_name}' node types:")
+    console.print(f"\n  Partition '{partition_name}' node types:")
     for nt in partition.node_types:
         gpu_info = ""
         if nt.gpu_specs:
             gpu_parts = [f"{c}×{t}" if t else f"{c}×gpu" for c, t in nt.gpu_specs]
             gpu_info = f", GPUs: {', '.join(gpu_parts)}"
-        print(f"    {nt.count} nodes — {nt.cpus} CPUs, {nt.memory_mb // 1024} GB RAM{gpu_info}")
-    print()
+        console.print(
+            f"    {nt.count} nodes — {nt.cpus} CPUs, {nt.memory_mb // 1024} GB RAM{gpu_info}"
+        )
+    console.print()
 
     # --- Walltime ---
     walltime = _select_with_custom(
@@ -396,6 +431,7 @@ def _configure_manual() -> SlurmExecutorConfig:
     UserCancelledError
         If the user cancels any prompt.
     """
+    questionary = _import_questionary()
     account = _require(questionary.text("SLURM account:").ask(), "account")
     partition = _require(questionary.text("SLURM partition:", default="gpu").ask(), "partition")
     walltime = _require(questionary.text("Walltime (--time):", default="2:00:00").ask(), "walltime")
@@ -473,17 +509,18 @@ def configure_slurm_interactive() -> SlurmExecutorConfig:
     UserCancelledError
         If the user cancels any prompt (Ctrl-C / Ctrl-D).
     """
-    print("Querying SLURM cluster...")
+    questionary = _import_questionary()
+    console.print("Querying SLURM cluster...")
     cluster = discover_cluster()
 
     if cluster is not None:
-        print(
+        console.print(
             f"✓ Cluster discovered: {len(cluster.partitions)} partitions, "
             f"{len(cluster.accounts)} accounts\n"
         )
         return _configure_with_cluster(cluster)
 
-    print("⚠ SLURM not detected (sinfo unavailable). Falling back to manual entry.\n")
+    console.print("⚠ SLURM not detected (sinfo unavailable). Falling back to manual entry.\n")
     proceed = questionary.confirm("Enter SLURM configuration manually?", default=True).ask()
     if not proceed:
         raise UserCancelledError("User declined manual SLURM configuration.")
@@ -507,7 +544,7 @@ def save_slurm_config_yaml(config: SlurmExecutorConfig, path: Path) -> None:
     with open(path, "w") as fh:
         yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
 
-    print(f"✓ SLURM config written to {path}")
+    console.print(f"✓ SLURM config written to {path}")
 
 
 def configure_and_save_slurm() -> SlurmExecutorConfig:
@@ -525,10 +562,11 @@ def configure_and_save_slurm() -> SlurmExecutorConfig:
     UserCancelledError
         If the user cancels any prompt.
     """
+    questionary = _import_questionary()
     try:
         config = configure_slurm_interactive()
     except UserCancelledError:
-        print("Configuration cancelled.")
+        console.print("Configuration cancelled.")
         raise
 
     save_path = _require(

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -400,6 +400,16 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
                 "qos",
             )
 
+    # --- Constraint ---
+    constraint_input = _require(
+        questionary.text(
+            "Node feature constraint (--constraint), leave empty to skip:",
+            default="",
+        ).ask(),
+        "constraint",
+    )
+    constraint: str | None = constraint_input.strip() or None
+
     return SlurmExecutorConfig(
         account=account,
         partition=partition_name,
@@ -408,6 +418,7 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
         gres=gres,
         mem=mem,
         qos=qos,
+        constraint=constraint,
         max_blocks=max_blocks,
         worker_init=worker_init,
     )

--- a/mdfactory/parametrize.py
+++ b/mdfactory/parametrize.py
@@ -269,6 +269,11 @@ def parametrize_smirnoff_gromacs(
         if not itp_path.is_file():
             workdir.mkdir(parents=True, exist_ok=True)
             molecule = species.openff_molecule
+            # Force molecule name to "SOL" for consistent Interchange output,
+            # regardless of the user-provided resname (e.g. "WAT").
+            # This ensures atom types are always SOL_0, SOL_1, ... and the
+            # generated ITP is always SOL_SOL.itp.
+            molecule.name = "SOL"
             topology = Topology.from_molecules([molecule])
             forcefield = ForceField(water_model)
             interchange = Interchange.from_smirnoff(force_field=forcefield, topology=topology)
@@ -280,6 +285,9 @@ def parametrize_smirnoff_gromacs(
                 generated_itp = workdir / "SOL_SOL.itp"
                 if generated_itp.is_file():
                     generated_itp.rename(itp_path)
+            # Remove stale params if atomtypes were regenerated
+            if params_itp_path.is_file():
+                params_itp_path.unlink()
         if top_path.is_file() and atomtypes_path.is_file() and not params_itp_path.is_file():
             _build_smirnoff_parameter_itp(top_path, atomtypes_path, params_itp_path)
 

--- a/mdfactory/performance/slurm_config.py
+++ b/mdfactory/performance/slurm_config.py
@@ -34,6 +34,114 @@ from typing import Any, Self
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
+def resolve_slurm_fields(
+    *,
+    needs_gpu: bool = False,
+    min_cpus: int = 1,
+    min_mem_gb: int = 1,
+    **extra_fields: Any,
+) -> dict[str, Any]:
+    """Resolve SLURM scheduling fields via three-tier precedence.
+
+    Three-tier precedence (highest wins):
+
+    1. Explicit keyword arguments passed via ``extra_fields``
+       (``account``, ``partition``, ``qos``, ``constraint``).
+    2. ``[slurm]`` section in ``config.ini`` — read via
+       ``mdfactory.settings.settings``.
+    3. Live ``sinfo`` / ``sacctmgr`` autodiscovery via
+       ``mdfactory.performance.cluster``.
+
+    Parameters
+    ----------
+    needs_gpu : bool
+        Select a GPU-capable partition when ``True``.
+    min_cpus : int
+        Minimum CPUs per node required (passed to ``select_partition()``).
+    min_mem_gb : int
+        Minimum memory per node in GB (passed to ``select_partition()``).
+    **extra_fields
+        Any additional fields.  The keys ``account``, ``partition``,
+        ``qos``, and ``constraint`` are consumed for SLURM resolution;
+        remaining keys are passed through unchanged.
+
+    Returns
+    -------
+    dict[str, Any]
+        A dict with at least ``account``, ``partition``, ``qos``, and
+        ``constraint`` plus any remaining ``extra_fields``.
+
+    Raises
+    ------
+    RuntimeError
+        If SLURM is unavailable *and* the required ``account`` or
+        ``partition`` value cannot be resolved from config.
+    """
+    from mdfactory.performance.cluster import discover_cluster, select_partition
+    from mdfactory.settings import settings
+
+    cluster = discover_cluster()
+
+    # --- account: explicit kwarg > config.ini > autodiscovery ---
+    resolved_account: str | None = extra_fields.pop("account", None)
+    if resolved_account is None:
+        resolved_account = settings.slurm_account
+    if resolved_account is None:
+        if cluster is None:
+            raise RuntimeError(
+                "SLURM autodiscovery failed and no account configured. "
+                "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
+            )
+        resolved_account = cluster.default_account
+        if resolved_account is None:
+            raise RuntimeError(
+                "No SLURM account available. "
+                "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
+            )
+
+    # --- partition: explicit kwarg > config.ini (cpu/gpu) > autodiscovery ---
+    resolved_partition: str | None = extra_fields.pop("partition", None)
+    if resolved_partition is None:
+        resolved_partition = (
+            settings.slurm_partition_gpu if needs_gpu else settings.slurm_partition_cpu
+        )
+    if resolved_partition is None:
+        if cluster is None:
+            raise RuntimeError(
+                "SLURM autodiscovery failed and no partition configured. "
+                "Set [slurm] PARTITION_CPU or PARTITION_GPU in config.ini "
+                "or pass partition= explicitly."
+            )
+        selected = select_partition(
+            cluster,
+            needs_gpu=needs_gpu,
+            min_cpus=min_cpus,
+            min_mem_gb=min_mem_gb,
+        )
+        if selected is None:
+            raise RuntimeError(
+                f"No suitable partition found for requirements: "
+                f"needs_gpu={needs_gpu}, cpus={min_cpus}, mem={min_mem_gb}GB"
+            )
+        resolved_partition = selected.name
+
+    # --- qos: explicit kwarg > config.ini ---
+    resolved_qos: str | None = extra_fields.pop("qos", None)
+    if resolved_qos is None:
+        resolved_qos = settings.slurm_qos
+
+    # --- constraint: explicit kwarg only (no config.ini equivalent) ---
+    resolved_constraint: str | None = extra_fields.pop("constraint", None)
+
+    return {
+        "account": resolved_account,
+        "partition": resolved_partition,
+        "qos": resolved_qos,
+        "constraint": resolved_constraint,
+        **extra_fields,
+    }
+
+
 def normalize_slurm_time(value: str) -> str:
     """Normalize SLURM time strings to ``HH:MM:SS`` or ``D-HH:MM:SS`` format.
 
@@ -171,69 +279,13 @@ class BaseSlurmConfig(BaseModel):
             If SLURM is unavailable *and* the required ``account`` or
             ``partition`` value cannot be resolved from config.
         """
-        from mdfactory.performance.cluster import discover_cluster, select_partition
-        from mdfactory.settings import settings
-
-        cluster = discover_cluster()
-
-        # --- account: explicit kwarg > config.ini > autodiscovery ---
-        resolved_account: str | None = extra_fields.pop("account", None)
-        if resolved_account is None:
-            resolved_account = settings.slurm_account
-        if resolved_account is None:
-            if cluster is None:
-                raise RuntimeError(
-                    "SLURM autodiscovery failed and no account configured. "
-                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
-                )
-            resolved_account = cluster.default_account
-            if resolved_account is None:
-                raise RuntimeError(
-                    "No SLURM account available. "
-                    "Set [slurm] ACCOUNT in config.ini or pass account= explicitly."
-                )
-
-        # --- partition: explicit kwarg > config.ini (cpu/gpu) > autodiscovery ---
-        resolved_partition: str | None = extra_fields.pop("partition", None)
-        if resolved_partition is None:
-            resolved_partition = (
-                settings.slurm_partition_gpu if needs_gpu else settings.slurm_partition_cpu
-            )
-        if resolved_partition is None:
-            if cluster is None:
-                raise RuntimeError(
-                    "SLURM autodiscovery failed and no partition configured. "
-                    "Set [slurm] PARTITION_CPU or PARTITION_GPU in config.ini "
-                    "or pass partition= explicitly."
-                )
-            selected = select_partition(
-                cluster,
-                needs_gpu=needs_gpu,
-                min_cpus=min_cpus,
-                min_mem_gb=min_mem_gb,
-            )
-            if selected is None:
-                raise RuntimeError(
-                    f"No suitable partition found for requirements: "
-                    f"needs_gpu={needs_gpu}, cpus={min_cpus}, mem={min_mem_gb}GB"
-                )
-            resolved_partition = selected.name
-
-        # --- qos: explicit kwarg > config.ini ---
-        resolved_qos: str | None = extra_fields.pop("qos", None)
-        if resolved_qos is None:
-            resolved_qos = settings.slurm_qos
-
-        # --- constraint: explicit kwarg only (no config.ini equivalent) ---
-        resolved_constraint: str | None = extra_fields.pop("constraint", None)
-
-        return cls(
-            account=resolved_account,
-            partition=resolved_partition,
-            qos=resolved_qos,
-            constraint=resolved_constraint,
+        fields = resolve_slurm_fields(
+            needs_gpu=needs_gpu,
+            min_cpus=min_cpus,
+            min_mem_gb=min_mem_gb,
             **extra_fields,
         )
+        return cls(**fields)
 
 
 class SlurmConfig(BaseSlurmConfig):

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -36,19 +36,20 @@ class FakeBuildInput:
 
 
 def test_build_systems_dry_run(monkeypatch, tmp_path):
-    """build_systems_dry_run describes planned builds without loading Parsl."""
+    """build_systems with dry_run=True describes planned builds without loading Parsl."""
     import mdfactory.orchestration.build as build_mod
-    from mdfactory.orchestration.build import build_systems_dry_run
+    from mdfactory.orchestration.build import build_systems
 
     mock_model = FakeBuildInput(
         hash="ABC123", simulation_type="bilayer", parametrization="smirnoff"
     )
     monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
 
-    results = build_systems_dry_run(
+    results = build_systems(
         [mock_model],
         ExecutorConfig(),
         output_dir=tmp_path,
+        dry_run=True,
     )
 
     assert len(results) == 1
@@ -58,14 +59,14 @@ def test_build_systems_dry_run(monkeypatch, tmp_path):
 
 
 def test_build_systems_dry_run_multiple(monkeypatch, tmp_path):
-    """build_systems_dry_run handles multiple inputs."""
+    """build_systems with dry_run=True handles multiple inputs."""
     import mdfactory.orchestration.build as build_mod
-    from mdfactory.orchestration.build import build_systems_dry_run
+    from mdfactory.orchestration.build import build_systems
 
     models = [FakeBuildInput(hash=f"HASH{i}") for i in range(3)]
     monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
 
-    results = build_systems_dry_run(models, ExecutorConfig(), output_dir=tmp_path)
+    results = build_systems(models, ExecutorConfig(), output_dir=tmp_path, dry_run=True)
     assert len(results) == 3
     assert [r["hash"] for r in results] == ["HASH0", "HASH1", "HASH2"]
 
@@ -151,11 +152,11 @@ def test_build_systems_no_wait(monkeypatch, tmp_path):
 
 
 def test_build_systems_dry_run_invalid_input_type(tmp_path):
-    """build_systems_dry_run raises TypeError for invalid input."""
-    from mdfactory.orchestration.build import build_systems_dry_run
+    """build_systems with dry_run=True raises TypeError for invalid input."""
+    from mdfactory.orchestration.build import build_systems
 
     with pytest.raises(TypeError, match="Expected BuildInput or dict"):
-        build_systems_dry_run([42], ExecutorConfig(), output_dir=tmp_path)
+        build_systems([42], ExecutorConfig(), output_dir=tmp_path, dry_run=True)
 
 
 # --- Finding 5: Tests for _build_system_impl ---
@@ -316,8 +317,8 @@ def test_keyboard_interrupt_triggers_shutdown(monkeypatch, tmp_path):
 
 
 def test_build_systems_dry_run_with_dict_input(monkeypatch, tmp_path):
-    """build_systems_dry_run handles dict input correctly."""
-    from mdfactory.orchestration.build import build_systems_dry_run
+    """build_systems with dry_run=True handles dict input correctly."""
+    from mdfactory.orchestration.build import build_systems
 
     input_dict = {
         "simulation_type": "mixedbox",
@@ -326,7 +327,7 @@ def test_build_systems_dry_run_with_dict_input(monkeypatch, tmp_path):
         "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
     }
 
-    results = build_systems_dry_run([input_dict], ExecutorConfig(), output_dir=tmp_path)
+    results = build_systems([input_dict], ExecutorConfig(), output_dir=tmp_path, dry_run=True)
 
     assert len(results) == 1
     assert results[0]["simulation_type"] == "mixedbox"

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -1,0 +1,148 @@
+# ABOUTME: Tests for orchestration build dispatch and dry-run functions
+# ABOUTME: Validates Parsl submission, dry-run output, and error handling
+"""Tests for orchestration build dispatch."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mdfactory.orchestration.config import ExecutorConfig
+
+
+class FakeBuildInput:
+    """Fake BuildInput for testing isinstance checks."""
+
+    def __init__(
+        self,
+        hash="TEST",
+        simulation_type="mixedbox",
+        parametrization="cgenff",
+        engine="gromacs",
+    ):
+        self.hash = hash
+        self.simulation_type = simulation_type
+        self.parametrization = parametrization
+        self.engine = engine
+
+    def model_dump(self):
+        """Return dict representation."""
+        return {
+            "simulation_type": self.simulation_type,
+            "parametrization": self.parametrization,
+            "engine": self.engine,
+        }
+
+
+def test_build_systems_dry_run(monkeypatch, tmp_path):
+    """build_systems_dry_run describes planned builds without loading Parsl."""
+    import mdfactory.orchestration.build as build_mod
+    from mdfactory.orchestration.build import build_systems_dry_run
+
+    mock_model = FakeBuildInput(
+        hash="ABC123", simulation_type="bilayer", parametrization="smirnoff"
+    )
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+
+    results = build_systems_dry_run(
+        [mock_model],
+        ExecutorConfig(),
+        output_dir=tmp_path,
+    )
+
+    assert len(results) == 1
+    assert results[0]["hash"] == "ABC123"
+    assert results[0]["simulation_type"] == "bilayer"
+    assert str(tmp_path / "ABC123") in results[0]["output_directory"]
+
+
+def test_build_systems_dry_run_multiple(monkeypatch, tmp_path):
+    """build_systems_dry_run handles multiple inputs."""
+    import mdfactory.orchestration.build as build_mod
+    from mdfactory.orchestration.build import build_systems_dry_run
+
+    models = [FakeBuildInput(hash=f"HASH{i}") for i in range(3)]
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+
+    results = build_systems_dry_run(models, ExecutorConfig(), output_dir=tmp_path)
+    assert len(results) == 3
+    assert [r["hash"] for r in results] == ["HASH0", "HASH1", "HASH2"]
+
+
+def test_build_systems_submits_correct_count(monkeypatch, tmp_path):
+    """build_systems submits one Parsl task per input."""
+    mock_app_fn = MagicMock()
+    mock_future = MagicMock()
+    mock_future.result.return_value = {"hash": "H1", "status": "success", "directory": "/tmp/H1"}
+    mock_app_fn.return_value = mock_future
+
+    import mdfactory.orchestration.build as build_mod
+
+    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
+    monkeypatch.setattr(build_mod.parsl, "load", MagicMock())
+    monkeypatch.setattr(build_mod.parsl, "clear", MagicMock())
+
+    mock_model = FakeBuildInput(hash="H1")
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+
+    cfg = ExecutorConfig()
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+    results = build_mod.build_systems([mock_model], cfg, output_dir=tmp_path)
+
+    assert mock_app_fn.call_count == 1
+    assert len(results) == 1
+    assert results[0]["status"] == "success"
+
+
+def test_build_systems_handles_failed_future(monkeypatch, tmp_path):
+    """build_systems captures exceptions from failed futures."""
+    mock_app_fn = MagicMock()
+    mock_future = MagicMock()
+    mock_future.result.side_effect = RuntimeError("CUDA OOM")
+    mock_app_fn.return_value = mock_future
+
+    import mdfactory.orchestration.build as build_mod
+
+    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
+    monkeypatch.setattr(build_mod.parsl, "load", MagicMock())
+    monkeypatch.setattr(build_mod.parsl, "clear", MagicMock())
+
+    mock_model = FakeBuildInput(hash="FAIL1", simulation_type="bilayer")
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+    cfg = ExecutorConfig()
+    results = build_mod.build_systems([mock_model], cfg, output_dir=tmp_path)
+
+    assert len(results) == 1
+    assert results[0]["status"] == "failed"
+    assert "CUDA OOM" in results[0]["error"]
+
+
+def test_build_systems_no_wait(monkeypatch, tmp_path):
+    """build_systems with wait=False returns futures directly."""
+    mock_app_fn = MagicMock()
+    mock_future = MagicMock()
+    mock_app_fn.return_value = mock_future
+
+    import mdfactory.orchestration.build as build_mod
+
+    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
+    monkeypatch.setattr(build_mod.parsl, "load", MagicMock())
+
+    mock_model = FakeBuildInput(hash="NW1")
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+    cfg = ExecutorConfig()
+    futures = build_mod.build_systems([mock_model], cfg, output_dir=tmp_path, wait=False)
+
+    assert futures == [mock_future]
+
+
+def test_build_systems_dry_run_invalid_input_type(tmp_path):
+    """build_systems_dry_run raises TypeError for invalid input."""
+    from mdfactory.orchestration.build import build_systems_dry_run
+
+    with pytest.raises(TypeError, match="Expected BuildInput or dict"):
+        build_systems_dry_run([42], ExecutorConfig(), output_dir=tmp_path)

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -308,8 +308,7 @@ def test_keyboard_interrupt_triggers_shutdown(monkeypatch, tmp_path):
     with pytest.raises(KeyboardInterrupt):
         build_mod.build_systems([mock_model], cfg, output_dir=tmp_path)
 
-    # parsl.clear should have been called (via _shutdown_parsl in KeyboardInterrupt handler
-    # AND in the finally block)
+    # parsl.clear should have been called via _shutdown_parsl in the finally block
     assert parsl_mod.clear.called
 
 
@@ -371,3 +370,52 @@ def test_build_systems_with_dict_input(monkeypatch, tmp_path):
     assert len(captured_args) == 1
     assert "_build_dir" in captured_args[0]
     assert results[0]["status"] == "success"
+
+
+# --- Finding 9: Multi-iteration polling test ---
+
+
+def test_wait_with_progress_multi_iteration(monkeypatch):
+    """_wait_with_progress exercises multi-iteration polling when future is not immediately done."""
+    from mdfactory.orchestration.build import _wait_with_progress
+
+    mock_future = MagicMock()
+    mock_future.done.side_effect = [False, False, True]
+    mock_future.result.return_value = {"hash": "POLL1", "status": "success", "directory": "/tmp"}
+    mock_future.task_status.return_value = "running"
+
+    results = _wait_with_progress([mock_future], hashes=["POLL1"], poll_interval=0.01)
+
+    assert len(results) == 1
+    assert results[0]["status"] == "success"
+    # done() should have been called at least twice (False then True)
+    assert mock_future.done.call_count >= 2
+
+
+# --- Finding 10: Assert non-cleanup in no_wait ---
+
+
+def test_build_systems_no_wait_does_not_clear(monkeypatch, tmp_path):
+    """build_systems with wait=False does NOT call parsl.clear()."""
+    import parsl
+
+    mock_app_fn = MagicMock()
+    mock_future = MagicMock()
+    mock_app_fn.return_value = mock_future
+
+    import mdfactory.orchestration.build as build_mod
+
+    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
+    monkeypatch.setattr(parsl, "load", MagicMock())
+    mock_clear = MagicMock()
+    monkeypatch.setattr(parsl, "clear", mock_clear)
+
+    mock_model = FakeBuildInput(hash="NW2")
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+    cfg = ExecutorConfig()
+    futures = build_mod.build_systems([mock_model], cfg, output_dir=tmp_path, wait=False)
+
+    assert futures == [mock_future]
+    mock_clear.assert_not_called()

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -126,6 +126,9 @@ def test_build_systems_handles_failed_future(monkeypatch, tmp_path):
     assert len(results) == 1
     assert results[0]["status"] == "failed"
     assert "CUDA OOM" in results[0]["error"]
+    # Finding 10: failure metadata is surfaced for future retry logic.
+    assert results[0]["failure_type"] == "RuntimeError"
+    assert results[0]["error_detail"] == "CUDA OOM"
 
 
 def test_build_systems_no_wait(monkeypatch, tmp_path):
@@ -420,3 +423,52 @@ def test_build_systems_no_wait_does_not_clear(monkeypatch, tmp_path):
 
     assert futures == [mock_future]
     mock_clear.assert_not_called()
+
+
+# --- Finding 10: failure description helper ---
+
+
+def test_describe_failure_plain_exception():
+    """_describe_failure returns the exception type name and message."""
+    from mdfactory.orchestration.build import _describe_failure
+
+    failure_type, detail = _describe_failure(RuntimeError("boom"))
+    assert failure_type == "RuntimeError"
+    assert detail == "boom"
+
+
+def test_describe_failure_unwraps_legacy_e_value():
+    """_describe_failure unwraps a legacy Parsl wrapper exposing .e_value."""
+    from mdfactory.orchestration.build import _describe_failure
+
+    class FakeAppFailure(Exception):
+        """Mimic an older Parsl wrapper carrying the underlying error."""
+
+        def __init__(self, e_value):
+            super().__init__("wrapped")
+            self.e_value = e_value
+
+    underlying = ValueError("real GROMACS crash")
+    failure_type, detail = _describe_failure(FakeAppFailure(underlying))
+    assert failure_type == "ValueError"
+    assert detail == "real GROMACS crash"
+
+
+# --- Finding 12: completeness guard ---
+
+
+def test_collect_results_returns_complete_list():
+    """_collect_results returns all results when every slot is captured."""
+    from mdfactory.orchestration.build import _collect_results
+
+    results = [{"hash": "A"}, {"hash": "B"}]
+    assert _collect_results(results, ["A", "B"]) == results
+
+
+def test_collect_results_raises_on_uncaptured_slot():
+    """_collect_results raises rather than silently dropping a None slot."""
+    from mdfactory.orchestration.build import _collect_results
+
+    results = [{"hash": "A"}, None]
+    with pytest.raises(RuntimeError, match="never captured"):
+        _collect_results(results, ["AAAA", "BBBB"])

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -2,11 +2,13 @@
 # ABOUTME: Validates Parsl submission, dry-run output, and error handling
 """Tests for orchestration build dispatch."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mdfactory.orchestration.config import ExecutorConfig
+parsl = pytest.importorskip("parsl", reason="parsl not installed")
+
+from mdfactory.orchestration.config import ExecutorConfig  # noqa: E402
 
 
 class FakeBuildInput:
@@ -70,6 +72,8 @@ def test_build_systems_dry_run_multiple(monkeypatch, tmp_path):
 
 def test_build_systems_submits_correct_count(monkeypatch, tmp_path):
     """build_systems submits one Parsl task per input."""
+    import parsl
+
     mock_app_fn = MagicMock()
     mock_future = MagicMock()
     mock_future.result.return_value = {"hash": "H1", "status": "success", "directory": "/tmp/H1"}
@@ -78,8 +82,9 @@ def test_build_systems_submits_correct_count(monkeypatch, tmp_path):
     import mdfactory.orchestration.build as build_mod
 
     monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
-    monkeypatch.setattr(build_mod.parsl, "load", MagicMock())
-    monkeypatch.setattr(build_mod.parsl, "clear", MagicMock())
+    monkeypatch.setattr(parsl, "load", MagicMock())
+    monkeypatch.setattr(parsl, "clear", MagicMock())
+    monkeypatch.setattr(parsl, "dfk", MagicMock(side_effect=RuntimeError("No DFK")))
 
     mock_model = FakeBuildInput(hash="H1")
     monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
@@ -96,6 +101,8 @@ def test_build_systems_submits_correct_count(monkeypatch, tmp_path):
 
 def test_build_systems_handles_failed_future(monkeypatch, tmp_path):
     """build_systems captures exceptions from failed futures."""
+    import parsl
+
     mock_app_fn = MagicMock()
     mock_future = MagicMock()
     mock_future.result.side_effect = RuntimeError("CUDA OOM")
@@ -104,8 +111,9 @@ def test_build_systems_handles_failed_future(monkeypatch, tmp_path):
     import mdfactory.orchestration.build as build_mod
 
     monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
-    monkeypatch.setattr(build_mod.parsl, "load", MagicMock())
-    monkeypatch.setattr(build_mod.parsl, "clear", MagicMock())
+    monkeypatch.setattr(parsl, "load", MagicMock())
+    monkeypatch.setattr(parsl, "clear", MagicMock())
+    monkeypatch.setattr(parsl, "dfk", MagicMock(side_effect=RuntimeError("No DFK")))
 
     mock_model = FakeBuildInput(hash="FAIL1", simulation_type="bilayer")
     monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
@@ -121,6 +129,8 @@ def test_build_systems_handles_failed_future(monkeypatch, tmp_path):
 
 def test_build_systems_no_wait(monkeypatch, tmp_path):
     """build_systems with wait=False returns futures directly."""
+    import parsl
+
     mock_app_fn = MagicMock()
     mock_future = MagicMock()
     mock_app_fn.return_value = mock_future
@@ -128,7 +138,7 @@ def test_build_systems_no_wait(monkeypatch, tmp_path):
     import mdfactory.orchestration.build as build_mod
 
     monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
-    monkeypatch.setattr(build_mod.parsl, "load", MagicMock())
+    monkeypatch.setattr(parsl, "load", MagicMock())
 
     mock_model = FakeBuildInput(hash="NW1")
     monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
@@ -146,3 +156,218 @@ def test_build_systems_dry_run_invalid_input_type(tmp_path):
 
     with pytest.raises(TypeError, match="Expected BuildInput or dict"):
         build_systems_dry_run([42], ExecutorConfig(), output_dir=tmp_path)
+
+
+# --- Finding 5: Tests for _build_system_impl ---
+
+
+def test_build_system_impl_strips_internal_keys_and_chdirs(monkeypatch, tmp_path):
+    """_build_system_impl strips _-prefixed keys and chdirs to build_dir."""
+    from mdfactory.orchestration.apps import _build_system_impl
+
+    build_dir = tmp_path / "OUT"
+    captured_model = {}
+
+    def mock_run_build(model):
+        import os
+
+        captured_model["hash"] = model.hash
+        captured_model["cwd"] = os.getcwd()
+
+    monkeypatch.setattr("mdfactory.workflows.run_build_from_dict", mock_run_build)
+
+    # Provide minimal valid BuildInput fields plus internal keys
+    input_dict = {
+        "simulation_type": "mixedbox",
+        "parametrization": "cgenff",
+        "engine": "gromacs",
+        "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+        "_build_dir": str(build_dir),
+        "_internal_flag": "should_be_stripped",
+    }
+    result = _build_system_impl(input_dict)
+
+    assert result["status"] == "success"
+    assert result["directory"] == str(build_dir.resolve())
+    assert build_dir.exists()
+    # Verify we chdir'd to build_dir during execution
+    assert captured_model["cwd"] == str(build_dir)
+
+
+def test_build_system_impl_restores_cwd_on_failure(monkeypatch, tmp_path):
+    """_build_system_impl restores original cwd even if build fails."""
+    import os
+
+    from mdfactory.orchestration.apps import _build_system_impl
+
+    build_dir = tmp_path / "FAIL"
+    original_cwd = os.getcwd()
+
+    def mock_run_build_fail(model):
+        raise RuntimeError("Build exploded")
+
+    monkeypatch.setattr("mdfactory.workflows.run_build_from_dict", mock_run_build_fail)
+
+    input_dict = {
+        "simulation_type": "mixedbox",
+        "parametrization": "cgenff",
+        "engine": "gromacs",
+        "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+        "_build_dir": str(build_dir),
+    }
+    with pytest.raises(RuntimeError, match="Build exploded"):
+        _build_system_impl(input_dict)
+
+    # cwd should be restored
+    assert os.getcwd() == original_cwd
+
+
+# --- Finding 9: Tests for SLURM cleanup functions ---
+
+
+def test_shutdown_parsl_calls_clear_and_scancel(monkeypatch):
+    """_shutdown_parsl calls parsl.clear() and scancels SLURM jobs."""
+    import parsl as parsl_mod
+
+    from mdfactory.orchestration.build import _shutdown_parsl
+
+    mock_dfk = MagicMock()
+    mock_executor = MagicMock()
+    mock_executor.provider.resources = {"block-1": {"remote_job_id": "12345"}}
+    mock_dfk.executors = {"htex": mock_executor}
+
+    monkeypatch.setattr(parsl_mod, "dfk", MagicMock(return_value=mock_dfk))
+    monkeypatch.setattr(parsl_mod, "clear", MagicMock())
+
+    with patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        _shutdown_parsl()
+
+    parsl_mod.clear.assert_called_once()
+    mock_subprocess.assert_called_once()
+    assert "12345" in mock_subprocess.call_args[0][0]
+
+
+def test_shutdown_parsl_attempts_scancel_even_if_clear_fails(monkeypatch):
+    """_shutdown_parsl runs scancel even when parsl.clear() raises."""
+    import parsl as parsl_mod
+
+    from mdfactory.orchestration.build import _shutdown_parsl
+
+    mock_dfk = MagicMock()
+    mock_executor = MagicMock()
+    mock_executor.provider.resources = {"block-1": {"remote_job_id": "99999"}}
+    mock_dfk.executors = {"htex": mock_executor}
+
+    monkeypatch.setattr(parsl_mod, "dfk", MagicMock(return_value=mock_dfk))
+    monkeypatch.setattr(parsl_mod, "clear", MagicMock(side_effect=RuntimeError("timeout")))
+
+    with patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        _shutdown_parsl()
+
+    # scancel should still be called despite clear() failing
+    mock_subprocess.assert_called_once()
+    assert "99999" in mock_subprocess.call_args[0][0]
+
+
+def test_get_slurm_job_ids_handles_missing_resources(monkeypatch):
+    """_get_slurm_job_ids handles executors without resources attribute."""
+    from mdfactory.orchestration.build import _get_slurm_job_ids
+
+    mock_dfk = MagicMock()
+    mock_executor = MagicMock(spec=[])  # no attributes
+    mock_dfk.executors = {"htex": mock_executor}
+
+    result = _get_slurm_job_ids(mock_dfk)
+    assert result == []
+
+
+def test_keyboard_interrupt_triggers_shutdown(monkeypatch, tmp_path):
+    """KeyboardInterrupt during _wait_with_progress triggers _shutdown_parsl."""
+    import parsl as parsl_mod
+
+    import mdfactory.orchestration.build as build_mod
+
+    mock_app_fn = MagicMock()
+    # Future that raises KeyboardInterrupt when polled
+    mock_future = MagicMock()
+    mock_future.done.side_effect = KeyboardInterrupt()
+    mock_app_fn.return_value = mock_future
+
+    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
+    monkeypatch.setattr(parsl_mod, "load", MagicMock())
+    monkeypatch.setattr(parsl_mod, "clear", MagicMock())
+    monkeypatch.setattr(parsl_mod, "dfk", MagicMock(side_effect=RuntimeError("No DFK")))
+
+    mock_model = FakeBuildInput(hash="INT1")
+    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+    cfg = ExecutorConfig()
+    with pytest.raises(KeyboardInterrupt):
+        build_mod.build_systems([mock_model], cfg, output_dir=tmp_path)
+
+    # parsl.clear should have been called (via _shutdown_parsl in KeyboardInterrupt handler
+    # AND in the finally block)
+    assert parsl_mod.clear.called
+
+
+# --- Finding 10: Tests for dict input path ---
+
+
+def test_build_systems_dry_run_with_dict_input(monkeypatch, tmp_path):
+    """build_systems_dry_run handles dict input correctly."""
+    from mdfactory.orchestration.build import build_systems_dry_run
+
+    input_dict = {
+        "simulation_type": "mixedbox",
+        "parametrization": "cgenff",
+        "engine": "gromacs",
+        "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+    }
+
+    results = build_systems_dry_run([input_dict], ExecutorConfig(), output_dir=tmp_path)
+
+    assert len(results) == 1
+    assert results[0]["simulation_type"] == "mixedbox"
+    assert results[0]["parametrization"] == "cgenff"
+    assert results[0]["hash"]  # hash should be computed
+
+
+def test_build_systems_with_dict_input(monkeypatch, tmp_path):
+    """build_systems handles dict input and injects _build_dir."""
+    import parsl as parsl_mod
+
+    import mdfactory.orchestration.build as build_mod
+
+    captured_args = []
+    mock_app_fn = MagicMock()
+    mock_future = MagicMock()
+    mock_future.result.return_value = {"hash": "X", "status": "success", "directory": "/tmp/X"}
+
+    def capture_app_call(input_dict):
+        captured_args.append(input_dict)
+        return mock_future
+
+    mock_app_fn.side_effect = capture_app_call
+
+    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
+    monkeypatch.setattr(parsl_mod, "load", MagicMock())
+    monkeypatch.setattr(parsl_mod, "clear", MagicMock())
+    monkeypatch.setattr(parsl_mod, "dfk", MagicMock(side_effect=RuntimeError("No DFK")))
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+    input_dict = {
+        "simulation_type": "mixedbox",
+        "parametrization": "cgenff",
+        "engine": "gromacs",
+        "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+    }
+
+    cfg = ExecutorConfig()
+    results = build_mod.build_systems([input_dict], cfg, output_dir=tmp_path)
+
+    assert len(captured_args) == 1
+    assert "_build_dir" in captured_args[0]
+    assert results[0]["status"] == "success"

--- a/mdfactory/tests/test_orchestration_cli.py
+++ b/mdfactory/tests/test_orchestration_cli.py
@@ -136,6 +136,79 @@ class TestBuildCommandSummaryYAML:
         with pytest.raises(SystemExit):
             _build_from_summary_yaml(data, tmp_path)
 
+    def test_summary_yaml_mismatched_lengths_exits(self, tmp_path):
+        """Summary YAML with mismatched list lengths causes exit."""
+        from mdfactory.cli import _build_from_summary_yaml
+
+        data = {"system_directory": [str(tmp_path), str(tmp_path)], "hash": ["A"]}
+        with pytest.raises(SystemExit):
+            _build_from_summary_yaml(data, tmp_path)
+
+    def test_summary_yaml_dry_run(self, tmp_path):
+        """Summary YAML with --dry-run calls build_systems_dry_run."""
+        from mdfactory.cli import _build_from_summary_yaml
+
+        hash_val = "TESTHASH123"
+        build_dir = tmp_path / hash_val
+        build_dir.mkdir()
+        yaml_data = {
+            "simulation_type": "mixedbox",
+            "parametrization": "cgenff",
+            "engine": "gromacs",
+            "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+        }
+        (build_dir / f"{hash_val}.yaml").write_text(yaml.safe_dump(yaml_data))
+        data = {"system_directory": [str(build_dir)], "hash": [hash_val]}
+
+        with patch("mdfactory.orchestration.build_systems_dry_run") as mock_dry_run:
+            mock_dry_run.return_value = [{"hash": hash_val}]
+            _build_from_summary_yaml(data, tmp_path, dry_run=True)
+
+        mock_dry_run.assert_called_once()
+
+    def test_summary_yaml_sequential(self, tmp_path):
+        """Summary YAML without --config builds sequentially."""
+        from mdfactory.cli import _build_from_summary_yaml
+
+        hash_val = "SEQHASH456"
+        build_dir = tmp_path / hash_val
+        build_dir.mkdir()
+        yaml_data = {
+            "simulation_type": "mixedbox",
+            "parametrization": "cgenff",
+            "engine": "gromacs",
+            "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+        }
+        (build_dir / f"{hash_val}.yaml").write_text(yaml.safe_dump(yaml_data))
+        data = {"system_directory": [str(build_dir)], "hash": [hash_val]}
+
+        with patch("mdfactory.cli.run_build_from_dict") as mock_build:
+            _build_from_summary_yaml(data, tmp_path, config=None, dry_run=False)
+
+        mock_build.assert_called_once()
+
+    def test_summary_yaml_parallel(self, tmp_path, sample_config):
+        """Summary YAML with --config dispatches via build_systems."""
+        from mdfactory.cli import _build_from_summary_yaml
+
+        hash_val = "PARHASH789"
+        build_dir = tmp_path / hash_val
+        build_dir.mkdir()
+        yaml_data = {
+            "simulation_type": "mixedbox",
+            "parametrization": "cgenff",
+            "engine": "gromacs",
+            "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+        }
+        (build_dir / f"{hash_val}.yaml").write_text(yaml.safe_dump(yaml_data))
+        data = {"system_directory": [str(build_dir)], "hash": [hash_val]}
+
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = [{"hash": hash_val, "status": "success"}]
+            _build_from_summary_yaml(data, tmp_path, config=sample_config, dry_run=False)
+
+        mock_build.assert_called_once()
+
 
 class TestBuildCommandErrors:
     """Tests for error handling in build command."""
@@ -148,3 +221,45 @@ class TestBuildCommandErrors:
         txt_file.write_text("hello")
         with pytest.raises(SystemExit):
             build_system(txt_file, output=tmp_path)
+
+    def test_malformed_csv_exits(self, tmp_path):
+        """CSV with missing required columns causes sys.exit."""
+        from mdfactory.cli import _build_from_csv
+
+        # Missing simulation_type column
+        csv_content = "system.species.SOL.smiles,system.species.SOL.count\nO,100\n"
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text(csv_content)
+        with pytest.raises(SystemExit):
+            _build_from_csv(csv_path, tmp_path, config=None, dry_run=False)
+
+    def test_empty_yaml_exits(self, tmp_path):
+        """Empty YAML file causes sys.exit with clear message."""
+        from mdfactory.cli import _build_from_yaml
+
+        empty_yaml = tmp_path / "empty.yaml"
+        empty_yaml.write_text("")
+        with pytest.raises(SystemExit):
+            _build_from_yaml(empty_yaml, tmp_path)
+
+
+class TestBuildCommandRouting:
+    """Tests for build_system() top-level routing logic."""
+
+    def test_csv_routes_to_csv_handler(self, sample_csv, tmp_path):
+        """build_system() with .csv file routes to CSV handler."""
+        from mdfactory.cli import build_system
+
+        with patch("mdfactory.cli.run_build_from_dict") as mock_build:
+            build_system(sample_csv, output=tmp_path)
+
+        mock_build.assert_called_once()
+
+    def test_yaml_routes_to_yaml_handler(self, sample_yaml, tmp_path):
+        """build_system() with .yaml file routes to YAML handler."""
+        from mdfactory.cli import build_system
+
+        with patch("mdfactory.cli.run_build_from_file") as mock_build:
+            build_system(sample_yaml, output=tmp_path)
+
+        mock_build.assert_called_once()

--- a/mdfactory/tests/test_orchestration_cli.py
+++ b/mdfactory/tests/test_orchestration_cli.py
@@ -61,6 +61,21 @@ class TestBuildCommandCSV:
         mock_build.assert_called_once()
         assert mock_build.call_args[1]["dry_run"] is True
 
+    def test_csv_dry_run_no_filesystem_side_effects(self, sample_csv, tmp_path, monkeypatch):
+        """CSV dry-run does not create directories or summary YAML."""
+        from mdfactory.cli import _build_from_csv
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = []
+            _build_from_csv(sample_csv, output_dir, dry_run=True)
+
+        # No summary YAML or hash directories should be created in output
+        assert not (output_dir / "input.yaml").exists()
+        assert len(list(output_dir.iterdir())) == 0
+
     def test_csv_sequential_builds_locally(self, sample_csv, tmp_path, monkeypatch):
         """CSV input without --config builds sequentially."""
         from mdfactory.cli import _build_from_csv
@@ -69,6 +84,24 @@ class TestBuildCommandCSV:
             _build_from_csv(sample_csv, tmp_path, config=None, dry_run=False)
 
         mock_build.assert_called_once()
+
+    def test_csv_generates_summary_yaml(self, sample_csv, tmp_path, monkeypatch):
+        """CSV build generates a summary YAML matching prepare-build format."""
+        from mdfactory.cli import _build_from_csv
+
+        with patch("mdfactory.cli.run_build_from_dict"):
+            _build_from_csv(sample_csv, tmp_path, config=None, dry_run=False)
+
+        summary_path = tmp_path / "input.yaml"
+        assert summary_path.exists()
+        with open(summary_path) as f:
+            summary = yaml.safe_load(f)
+        assert summary["n_systems"] == 1
+        assert str(sample_csv) == summary["input"]
+        assert len(summary["hash"]) == 1
+        assert len(summary["system_directory"]) == 1
+        assert "date" in summary
+        assert "simulation_type" in summary
 
     def test_csv_with_config_uses_parsl(self, sample_csv, sample_config, tmp_path, monkeypatch):
         """CSV input with --config dispatches via build_systems."""

--- a/mdfactory/tests/test_orchestration_cli.py
+++ b/mdfactory/tests/test_orchestration_cli.py
@@ -1,0 +1,150 @@
+# ABOUTME: Integration tests for the CLI build command orchestration paths
+# ABOUTME: Tests CSV/YAML/summary-YAML dispatch, dry-run, and error handling
+"""Integration tests for CLI build command with orchestration."""
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+parsl = pytest.importorskip("parsl", reason="parsl not installed")
+
+
+@pytest.fixture()
+def sample_csv(tmp_path):
+    """Create a minimal CSV input file for testing."""
+    csv_content = (
+        "simulation_type,system.species.SOL.smiles,system.species.SOL.count,parametrization\n"
+        "mixedbox,O,100,cgenff\n"
+    )
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text(csv_content)
+    return csv_path
+
+
+@pytest.fixture()
+def sample_yaml(tmp_path):
+    """Create a minimal single-build YAML input file."""
+    data = {
+        "simulation_type": "mixedbox",
+        "system": {"species": [{"smiles": "O", "count": 100, "resname": "SOL"}]},
+        "parametrization": "cgenff",
+        "engine": "gromacs",
+    }
+    yaml_path = tmp_path / "build.yaml"
+    with open(yaml_path, "w") as f:
+        yaml.safe_dump(data, f)
+    return yaml_path
+
+
+@pytest.fixture()
+def sample_config(tmp_path):
+    """Create a minimal executor config YAML."""
+    data = {"provider": "local", "max_workers_per_node": 1}
+    cfg_path = tmp_path / "config.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(data, f)
+    return cfg_path
+
+
+class TestBuildCommandCSV:
+    """Tests for CSV input dispatch path."""
+
+    def test_csv_dry_run(self, sample_csv, tmp_path, monkeypatch):
+        """CSV input with --dry-run calls build_systems_dry_run."""
+        from mdfactory.cli import _build_from_csv
+
+        with patch("mdfactory.orchestration.build_systems_dry_run") as mock_dry_run:
+            mock_dry_run.return_value = [{"hash": "X", "simulation_type": "mixedbox"}]
+            _build_from_csv(sample_csv, tmp_path, dry_run=True)
+
+        mock_dry_run.assert_called_once()
+
+    def test_csv_sequential_builds_locally(self, sample_csv, tmp_path, monkeypatch):
+        """CSV input without --config builds sequentially."""
+        from mdfactory.cli import _build_from_csv
+
+        with patch("mdfactory.cli.run_build_from_dict") as mock_build:
+            _build_from_csv(sample_csv, tmp_path, config=None, dry_run=False)
+
+        mock_build.assert_called_once()
+
+    def test_csv_with_config_uses_parsl(self, sample_csv, sample_config, tmp_path, monkeypatch):
+        """CSV input with --config dispatches via build_systems."""
+        from mdfactory.cli import _build_from_csv
+
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = [{"hash": "X", "status": "success"}]
+            _build_from_csv(sample_csv, tmp_path, config=sample_config, dry_run=False)
+
+        mock_build.assert_called_once()
+
+
+class TestBuildCommandYAML:
+    """Tests for single-YAML input dispatch path."""
+
+    def test_yaml_sequential_builds_into_hash_dir(self, sample_yaml, tmp_path, monkeypatch):
+        """Single YAML without --config builds into output/{hash}/."""
+        from mdfactory.cli import _build_from_yaml
+
+        with patch("mdfactory.cli.run_build_from_file") as mock_build:
+            _build_from_yaml(sample_yaml, tmp_path)
+
+        mock_build.assert_called_once()
+        # Verify the working directory was a hash-based subdirectory
+        call_args = mock_build.call_args
+        # run_build_from_file is called with the input path
+        assert call_args[0][0] == sample_yaml
+
+    def test_yaml_dry_run(self, sample_yaml, tmp_path, monkeypatch):
+        """Single YAML with --dry-run calls build_systems_dry_run."""
+        from mdfactory.cli import _build_from_yaml
+
+        with patch("mdfactory.orchestration.build_systems_dry_run") as mock_dry_run:
+            mock_dry_run.return_value = [{"hash": "X", "simulation_type": "mixedbox"}]
+            _build_from_yaml(sample_yaml, tmp_path, dry_run=True)
+
+        mock_dry_run.assert_called_once()
+
+    def test_yaml_with_config_uses_parsl(self, sample_yaml, sample_config, tmp_path, monkeypatch):
+        """Single YAML with --config dispatches via build_systems."""
+        from mdfactory.cli import _build_from_yaml
+
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = [{"hash": "X", "status": "success"}]
+            _build_from_yaml(sample_yaml, tmp_path, config=sample_config, dry_run=False)
+
+        mock_build.assert_called_once()
+
+
+class TestBuildCommandSummaryYAML:
+    """Tests for summary YAML (prepare-build output) dispatch path."""
+
+    def test_summary_yaml_empty_dirs_exits(self, tmp_path):
+        """Summary YAML with no directories causes exit."""
+        from mdfactory.cli import _build_from_summary_yaml
+
+        data = {"system_directory": [], "hash": []}
+        with pytest.raises(SystemExit):
+            _build_from_summary_yaml(data, tmp_path)
+
+    def test_summary_yaml_missing_build_file_exits(self, tmp_path):
+        """Summary YAML referencing non-existent build file exits."""
+        from mdfactory.cli import _build_from_summary_yaml
+
+        data = {"system_directory": [str(tmp_path / "nonexistent")], "hash": ["ABC123"]}
+        with pytest.raises(SystemExit):
+            _build_from_summary_yaml(data, tmp_path)
+
+
+class TestBuildCommandErrors:
+    """Tests for error handling in build command."""
+
+    def test_unsupported_extension_exits(self, tmp_path):
+        """Unsupported file extension causes sys.exit."""
+        from mdfactory.cli import build_system
+
+        txt_file = tmp_path / "input.txt"
+        txt_file.write_text("hello")
+        with pytest.raises(SystemExit):
+            build_system(txt_file, output=tmp_path)

--- a/mdfactory/tests/test_orchestration_cli.py
+++ b/mdfactory/tests/test_orchestration_cli.py
@@ -51,14 +51,15 @@ class TestBuildCommandCSV:
     """Tests for CSV input dispatch path."""
 
     def test_csv_dry_run(self, sample_csv, tmp_path, monkeypatch):
-        """CSV input with --dry-run calls build_systems_dry_run."""
+        """CSV input with --dry-run calls build_systems with dry_run=True."""
         from mdfactory.cli import _build_from_csv
 
-        with patch("mdfactory.orchestration.build_systems_dry_run") as mock_dry_run:
-            mock_dry_run.return_value = [{"hash": "X", "simulation_type": "mixedbox"}]
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = [{"hash": "X", "simulation_type": "mixedbox"}]
             _build_from_csv(sample_csv, tmp_path, dry_run=True)
 
-        mock_dry_run.assert_called_once()
+        mock_build.assert_called_once()
+        assert mock_build.call_args[1]["dry_run"] is True
 
     def test_csv_sequential_builds_locally(self, sample_csv, tmp_path, monkeypatch):
         """CSV input without --config builds sequentially."""
@@ -97,14 +98,15 @@ class TestBuildCommandYAML:
         assert call_args[0][0] == sample_yaml
 
     def test_yaml_dry_run(self, sample_yaml, tmp_path, monkeypatch):
-        """Single YAML with --dry-run calls build_systems_dry_run."""
+        """Single YAML with --dry-run calls build_systems with dry_run=True."""
         from mdfactory.cli import _build_from_yaml
 
-        with patch("mdfactory.orchestration.build_systems_dry_run") as mock_dry_run:
-            mock_dry_run.return_value = [{"hash": "X", "simulation_type": "mixedbox"}]
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = [{"hash": "X", "simulation_type": "mixedbox"}]
             _build_from_yaml(sample_yaml, tmp_path, dry_run=True)
 
-        mock_dry_run.assert_called_once()
+        mock_build.assert_called_once()
+        assert mock_build.call_args[1]["dry_run"] is True
 
     def test_yaml_with_config_uses_parsl(self, sample_yaml, sample_config, tmp_path, monkeypatch):
         """Single YAML with --config dispatches via build_systems."""
@@ -145,7 +147,7 @@ class TestBuildCommandSummaryYAML:
             _build_from_summary_yaml(data, tmp_path)
 
     def test_summary_yaml_dry_run(self, tmp_path):
-        """Summary YAML with --dry-run calls build_systems_dry_run."""
+        """Summary YAML with --dry-run calls build_systems with dry_run=True."""
         from mdfactory.cli import _build_from_summary_yaml
 
         hash_val = "TESTHASH123"
@@ -160,11 +162,12 @@ class TestBuildCommandSummaryYAML:
         (build_dir / f"{hash_val}.yaml").write_text(yaml.safe_dump(yaml_data))
         data = {"system_directory": [str(build_dir)], "hash": [hash_val]}
 
-        with patch("mdfactory.orchestration.build_systems_dry_run") as mock_dry_run:
-            mock_dry_run.return_value = [{"hash": hash_val}]
+        with patch("mdfactory.orchestration.build_systems") as mock_build:
+            mock_build.return_value = [{"hash": hash_val}]
             _build_from_summary_yaml(data, tmp_path, dry_run=True)
 
-        mock_dry_run.assert_called_once()
+        mock_build.assert_called_once()
+        assert mock_build.call_args[1]["dry_run"] is True
 
     def test_summary_yaml_sequential(self, tmp_path):
         """Summary YAML without --config builds sequentially."""

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -30,8 +30,8 @@ def test_slurm_executor_config_defaults():
     cfg = SlurmExecutorConfig(account="my_account")
     assert cfg.provider == "slurm"
     assert cfg.account == "my_account"
-    assert cfg.partition == "gpu"
-    assert cfg.walltime == "2:00:00"
+    assert cfg.partition == "cpu"
+    assert cfg.walltime == "02:00:00"
     assert cfg.nodes == 1
     assert cfg.cpus_per_node == 12
     assert cfg.gres is None

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -134,6 +134,30 @@ def test_constraint_in_scheduler_options():
     assert "#SBATCH --constraint=a100" in provider.scheduler_options
 
 
+def test_slurm_executor_config_inherits_base_slurm_config():
+    """SlurmExecutorConfig unifies with the shared BaseSlurmConfig hierarchy.
+
+    Guards against re-introducing a divergent third copy of the SLURM fields
+    (issue #20): account/partition/qos/constraint and from_cluster() must come
+    from BaseSlurmConfig, not be redeclared here.
+    """
+    from mdfactory.performance.slurm_config import BaseSlurmConfig
+
+    assert issubclass(SlurmExecutorConfig, BaseSlurmConfig)
+    # from_cluster is inherited, not reimplemented.
+    assert SlurmExecutorConfig.from_cluster.__func__ is BaseSlurmConfig.from_cluster.__func__
+    # The shared SLURM fields are not redeclared on the subclass itself.
+    own_fields = set(vars(SlurmExecutorConfig).get("__annotations__", {}))
+    assert not ({"account", "qos", "constraint"} & own_fields)
+
+
+def test_slurm_executor_config_is_mutable():
+    """Despite BaseSlurmConfig being frozen, the executor config stays mutable."""
+    cfg = SlurmExecutorConfig(account="acc")
+    cfg.partition = "gpu"  # must not raise (frozen=False)
+    assert cfg.partition == "gpu"
+
+
 def test_raw_scheduler_options_appended():
     """Raw scheduler_options are appended after structured fields."""
     cfg = SlurmExecutorConfig(account="acc", gres="gpu:1", scheduler_options="#SBATCH --exclusive")

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -1,0 +1,164 @@
+# ABOUTME: Tests for orchestration executor configuration models
+# ABOUTME: Validates config construction, serialization, and Parsl config generation
+"""Tests for orchestration executor configuration."""
+
+import pytest
+import yaml
+
+from mdfactory.orchestration.config import ExecutorConfig, SlurmExecutorConfig
+
+
+def test_executor_config_defaults():
+    """ExecutorConfig has sensible defaults."""
+    cfg = ExecutorConfig()
+    assert cfg.provider == "local"
+    assert cfg.worker_init == ""
+    assert cfg.working_directory is None
+    assert cfg.max_workers_per_node == 1
+
+
+def test_slurm_executor_config_requires_account():
+    """SlurmExecutorConfig requires account field."""
+    with pytest.raises(Exception):
+        SlurmExecutorConfig()
+
+
+def test_slurm_executor_config_defaults():
+    """SlurmExecutorConfig has expected SLURM defaults."""
+    cfg = SlurmExecutorConfig(account="my_account")
+    assert cfg.provider == "slurm"
+    assert cfg.account == "my_account"
+    assert cfg.partition == "gpu"
+    assert cfg.walltime == "2:00:00"
+    assert cfg.nodes == 1
+    assert cfg.cpus_per_node == 12
+    assert cfg.gres is None
+    assert cfg.mem is None
+
+
+def test_executor_config_from_yaml_local(tmp_path):
+    """from_yaml loads a local executor config."""
+    cfg_data = {"provider": "local", "max_workers_per_node": 4}
+    cfg_path = tmp_path / "config.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg_data, f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert isinstance(loaded, ExecutorConfig)
+    assert not isinstance(loaded, SlurmExecutorConfig)
+    assert loaded.max_workers_per_node == 4
+
+
+def test_executor_config_from_yaml_slurm(tmp_path):
+    """from_yaml loads a SLURM executor config."""
+    cfg_data = {
+        "provider": "slurm",
+        "account": "hpc_team",
+        "partition": "gpu-large",
+        "walltime": "4:00:00",
+        "cpus_per_node": 24,
+        "gres": "gpu:l40s:2",
+    }
+    cfg_path = tmp_path / "slurm.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg_data, f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert isinstance(loaded, SlurmExecutorConfig)
+    assert loaded.account == "hpc_team"
+    assert loaded.partition == "gpu-large"
+    assert loaded.cpus_per_node == 24
+    assert loaded.gres == "gpu:l40s:2"
+
+
+def test_executor_config_to_parsl_config():
+    """to_parsl_config produces a valid Parsl Config for local provider."""
+    cfg = ExecutorConfig(max_workers_per_node=2, worker_init="module load cuda/12.0")
+    result = cfg.to_parsl_config()
+
+    import parsl
+
+    assert isinstance(result, parsl.Config)
+    assert len(result.executors) == 1
+    assert result.executors[0].label == "local"
+
+
+def test_slurm_executor_config_to_parsl_config():
+    """to_parsl_config produces a valid Parsl Config for SLURM provider."""
+    cfg = SlurmExecutorConfig(account="my_account", gres="gpu:l40s:1")
+    result = cfg.to_parsl_config()
+
+    import parsl
+
+    assert isinstance(result, parsl.Config)
+    assert len(result.executors) == 1
+    assert result.executors[0].label == "slurm"
+
+
+def test_worker_init_propagation():
+    """worker_init string is passed to the SLURM provider."""
+    cfg = SlurmExecutorConfig(account="acc", worker_init="module load cuda/12.0")
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert "module load cuda/12.0" in provider.worker_init
+
+
+def test_gres_in_scheduler_options():
+    """gres field becomes --gres in scheduler_options."""
+    cfg = SlurmExecutorConfig(account="acc", gres="gpu:l40s:2")
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert "#SBATCH --gres=gpu:l40s:2" in provider.scheduler_options
+
+
+def test_mem_and_qos_in_scheduler_options():
+    """mem and qos fields are included in scheduler_options."""
+    cfg = SlurmExecutorConfig(account="acc", mem="64G", qos="high")
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert "#SBATCH --mem=64G" in provider.scheduler_options
+    assert "#SBATCH --qos=high" in provider.scheduler_options
+
+
+def test_constraint_in_scheduler_options():
+    """constraint field becomes --constraint in scheduler_options."""
+    cfg = SlurmExecutorConfig(account="acc", constraint="a100")
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert "#SBATCH --constraint=a100" in provider.scheduler_options
+
+
+def test_raw_scheduler_options_appended():
+    """Raw scheduler_options are appended after structured fields."""
+    cfg = SlurmExecutorConfig(account="acc", gres="gpu:1", scheduler_options="#SBATCH --exclusive")
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert "#SBATCH --gres=gpu:1" in provider.scheduler_options
+    assert "#SBATCH --exclusive" in provider.scheduler_options
+
+
+def test_config_yaml_roundtrip(tmp_path):
+    """Config can be written to YAML and loaded back identically."""
+    original = SlurmExecutorConfig(
+        account="test_account",
+        partition="gpu-dev",
+        walltime="1:00:00",
+        gres="gpu:l40s:1",
+        worker_init="source activate env",
+    )
+    cfg_path = tmp_path / "roundtrip.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(original.model_dump(), f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert isinstance(loaded, SlurmExecutorConfig)
+    assert loaded.account == original.account
+    assert loaded.partition == original.partition
+    assert loaded.walltime == original.walltime
+    assert loaded.gres == original.gres
+    assert loaded.worker_init == original.worker_init

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -144,6 +144,77 @@ def test_raw_scheduler_options_appended():
     assert "#SBATCH --exclusive" in provider.scheduler_options
 
 
+def test_run_dir_default_and_expanduser():
+    """run_dir defaults under the home dir and expands ``~`` in supplied values."""
+    cfg = ExecutorConfig()
+    assert str(cfg.run_dir).endswith("/.parsl/mdfactory")
+    assert "~" not in str(cfg.run_dir)
+
+    cfg2 = ExecutorConfig(run_dir="~/scratch/parsl")
+    assert "~" not in str(cfg2.run_dir)
+    assert str(cfg2.run_dir).endswith("/scratch/parsl")
+
+    # run_dir flows into the Parsl Config
+    assert str(cfg.run_dir) == cfg.to_parsl_config().run_dir
+
+
+def test_paths_serialize_as_strings():
+    """run_dir / working_directory serialize as plain strings for YAML."""
+    cfg = ExecutorConfig(working_directory="/tmp/work")
+    dumped = cfg.model_dump()
+    assert isinstance(dumped["run_dir"], str)
+    assert isinstance(dumped["working_directory"], str)
+    # Round-trips through yaml without RepresenterError
+    yaml.safe_dump(dumped)
+
+
+def test_available_accelerators_wired_local():
+    """available_accelerators is forwarded to the local HighThroughputExecutor."""
+    cfg = ExecutorConfig(max_workers_per_node=2, available_accelerators=2)
+    executor = cfg.to_parsl_config().executors[0]
+    # Parsl normalises an int count into a list of device IDs.
+    assert executor.available_accelerators == ["0", "1"]
+
+
+def test_available_accelerators_wired_slurm():
+    """available_accelerators is forwarded to the SLURM HighThroughputExecutor."""
+    cfg = SlurmExecutorConfig(account="acc", available_accelerators=["0", "1"])
+    executor = cfg.to_parsl_config().executors[0]
+    assert executor.available_accelerators == ["0", "1"]
+
+
+def test_launch_options_sets_srun_launcher():
+    """launch_options wires a SrunLauncher with the given overrides."""
+    from parsl.launchers import SrunLauncher
+
+    cfg = SlurmExecutorConfig(
+        account="acc",
+        launch_options="--cpu-bind=cores --distribution=block:block",
+    )
+    provider = cfg.to_parsl_config().executors[0].provider
+    assert isinstance(provider.launcher, SrunLauncher)
+    assert provider.launcher.overrides == "--cpu-bind=cores --distribution=block:block"
+
+
+def test_no_launch_options_keeps_default_launcher():
+    """Without launch_options, Parsl's default launcher is left untouched."""
+    from parsl.launchers import SrunLauncher
+
+    cfg = SlurmExecutorConfig(account="acc")
+    provider = cfg.to_parsl_config().executors[0].provider
+    assert not isinstance(provider.launcher, SrunLauncher)
+
+
+def test_launch_options_roundtrip_yaml(tmp_path):
+    """launch_options survives a YAML round-trip."""
+    original = SlurmExecutorConfig(account="acc", launch_options="--cpu-bind=cores")
+    cfg_path = tmp_path / "launch.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(original.model_dump(), f)
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert loaded.launch_options == "--cpu-bind=cores"
+
+
 def test_config_yaml_roundtrip(tmp_path):
     """Config can be written to YAML and loaded back identically."""
     original = SlurmExecutorConfig(

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -5,6 +5,8 @@
 import pytest
 import yaml
 
+pytest.importorskip("parsl", reason="parsl not installed")
+
 from mdfactory.orchestration.config import ExecutorConfig, SlurmExecutorConfig
 
 

--- a/mdfactory/tests/test_orchestration_from_cluster.py
+++ b/mdfactory/tests/test_orchestration_from_cluster.py
@@ -1,0 +1,140 @@
+# ABOUTME: Tests for SlurmExecutorConfig.from_cluster() and walltime validation
+# ABOUTME: Verifies 3-tier autodiscovery precedence and time normalization
+"""Tests for SlurmExecutorConfig cluster autodiscovery and walltime."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mdfactory.orchestration.config import SlurmExecutorConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_settings(**overrides):
+    s = MagicMock()
+    s.slurm_account = overrides.get("slurm_account", None)
+    s.slurm_partition_cpu = overrides.get("slurm_partition_cpu", None)
+    s.slurm_partition_gpu = overrides.get("slurm_partition_gpu", None)
+    s.slurm_qos = overrides.get("slurm_qos", None)
+    return s
+
+
+def _mock_cluster(default_account="test_acc", accounts=None):
+    c = MagicMock()
+    c.default_account = default_account
+    c.accounts = accounts or [default_account]
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Walltime normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestWalltimeNormalization:
+    """Walltime shorthand is expanded on construction."""
+
+    def test_walltime_normalization(self):
+        assert SlurmExecutorConfig(account="x", walltime="2h").walltime == "02:00:00"
+        assert SlurmExecutorConfig(account="x", walltime="30m").walltime == "00:30:00"
+        assert SlurmExecutorConfig(account="x", walltime="1d").walltime == "1-00:00:00"
+        assert SlurmExecutorConfig(account="x", walltime="01:30:00").walltime == "01:30:00"
+
+    def test_walltime_default_normalized(self):
+        cfg = SlurmExecutorConfig(account="x")
+        assert cfg.walltime == "02:00:00"
+
+
+# ---------------------------------------------------------------------------
+# from_cluster() tests
+# ---------------------------------------------------------------------------
+
+# Patch targets — from_cluster imports these inside the method body, so we
+# patch the canonical module locations.
+_DISCOVER = "mdfactory.performance.cluster.discover_cluster"
+_SELECT = "mdfactory.performance.cluster.select_partition"
+_SETTINGS = "mdfactory.settings.settings"
+
+
+class TestFromCluster:
+    """Tests for the three-tier autodiscovery in from_cluster()."""
+
+    @patch(_DISCOVER, return_value=None)
+    @patch(_SETTINGS, _mock_settings())
+    def test_explicit_kwargs(self, _discover):
+        cfg = SlurmExecutorConfig.from_cluster(account="myacc", partition="gpu")
+        assert cfg.account == "myacc"
+        assert cfg.partition == "gpu"
+
+    @patch(_DISCOVER, return_value=None)
+    @patch(
+        _SETTINGS,
+        _mock_settings(slurm_account="cfg_account", slurm_partition_cpu="cfg_partition"),
+    )
+    def test_config_ini_fallback(self, _discover):
+        cfg = SlurmExecutorConfig.from_cluster()
+        assert cfg.account == "cfg_account"
+        assert cfg.partition == "cfg_partition"
+
+    @patch(_SELECT)
+    @patch(_DISCOVER)
+    @patch(_SETTINGS, _mock_settings())
+    def test_autodiscovery(self, mock_discover, mock_select):
+        mock_discover.return_value = _mock_cluster(default_account="discovered_acc")
+        part = MagicMock()
+        part.name = "auto_part"
+        mock_select.return_value = part
+
+        cfg = SlurmExecutorConfig.from_cluster()
+        assert cfg.account == "discovered_acc"
+        assert cfg.partition == "auto_part"
+
+    @patch(_SELECT)
+    @patch(_DISCOVER)
+    @patch(_SETTINGS, _mock_settings(slurm_account="cfg_acc"))
+    def test_precedence_explicit_wins(self, mock_discover, mock_select):
+        mock_discover.return_value = _mock_cluster(default_account="disc_acc")
+        part = MagicMock()
+        part.name = "disc_part"
+        mock_select.return_value = part
+
+        cfg = SlurmExecutorConfig.from_cluster(account="explicit")
+        assert cfg.account == "explicit"
+
+    @patch(_DISCOVER, return_value=None)
+    @patch(_SETTINGS, _mock_settings())
+    def test_no_account_raises(self, _discover):
+        with pytest.raises(RuntimeError, match="account"):
+            SlurmExecutorConfig.from_cluster()
+
+    @patch(_DISCOVER, return_value=None)
+    @patch(_SETTINGS, _mock_settings(slurm_account="has_acc"))
+    def test_no_partition_raises(self, _discover):
+        with pytest.raises(RuntimeError, match="partition"):
+            SlurmExecutorConfig.from_cluster()
+
+    @patch(_SELECT)
+    @patch(_DISCOVER)
+    @patch(_SETTINGS, _mock_settings())
+    def test_extra_fields_forwarded(self, mock_discover, mock_select):
+        mock_discover.return_value = _mock_cluster()
+        part = MagicMock()
+        part.name = "cpu"
+        mock_select.return_value = part
+
+        cfg = SlurmExecutorConfig.from_cluster(walltime="4h", cpus_per_node=24, gres="gpu:a100:1")
+        assert cfg.walltime == "04:00:00"
+        assert cfg.cpus_per_node == 24
+        assert cfg.gres == "gpu:a100:1"
+
+    @patch(_DISCOVER, return_value=None)
+    @patch(
+        _SETTINGS,
+        _mock_settings(slurm_account="acc", slurm_partition_gpu="gpu-big"),
+    )
+    def test_needs_gpu_selects_gpu_partition(self, _discover):
+        cfg = SlurmExecutorConfig.from_cluster(needs_gpu=True)
+        assert cfg.partition == "gpu-big"

--- a/mdfactory/tests/test_orchestration_session.py
+++ b/mdfactory/tests/test_orchestration_session.py
@@ -1,0 +1,71 @@
+# ABOUTME: Tests for the reusable Parsl session context manager
+# ABOUTME: Validates DFK guard, load, shutdown, and detach semantics
+"""Tests for orchestration Parsl session management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+parsl = pytest.importorskip("parsl", reason="parsl not installed")
+
+from mdfactory.orchestration.config import ExecutorConfig  # noqa: E402
+from mdfactory.orchestration.session import (  # noqa: E402
+    ParslSession,
+    parsl_session,
+)
+
+
+def _patch_parsl(monkeypatch, *, active_dfk=False):
+    """Patch parsl.load/clear/dfk for session tests."""
+    monkeypatch.setattr(parsl, "load", MagicMock())
+    monkeypatch.setattr(parsl, "clear", MagicMock())
+    if active_dfk:
+        monkeypatch.setattr(parsl, "dfk", MagicMock(return_value=MagicMock(executors={})))
+    else:
+        monkeypatch.setattr(parsl, "dfk", MagicMock(side_effect=RuntimeError("No DFK")))
+    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
+
+
+def test_parsl_session_loads_and_shuts_down(monkeypatch):
+    """parsl_session loads the config and clears the DFK on exit."""
+    _patch_parsl(monkeypatch)
+
+    with parsl_session(ExecutorConfig()) as session:
+        assert isinstance(session, ParslSession)
+        assert session.detached is False
+
+    parsl.load.assert_called_once()
+    parsl.clear.assert_called_once()
+
+
+def test_parsl_session_detach_skips_shutdown(monkeypatch):
+    """A detached session does not shut down the DFK on exit."""
+    _patch_parsl(monkeypatch)
+
+    with parsl_session(ExecutorConfig()) as session:
+        session.detach()
+
+    parsl.load.assert_called_once()
+    parsl.clear.assert_not_called()
+
+
+def test_parsl_session_guards_active_dfk(monkeypatch):
+    """parsl_session raises if a DFK is already active and does not load."""
+    _patch_parsl(monkeypatch, active_dfk=True)
+
+    with pytest.raises(RuntimeError, match="already active"):
+        with parsl_session(ExecutorConfig()):
+            pass
+
+    parsl.load.assert_not_called()
+
+
+def test_parsl_session_shuts_down_on_exception(monkeypatch):
+    """parsl_session clears the DFK even when the body raises."""
+    _patch_parsl(monkeypatch)
+
+    with pytest.raises(ValueError, match="boom"):
+        with parsl_session(ExecutorConfig()):
+            raise ValueError("boom")
+
+    parsl.clear.assert_called_once()

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -1,0 +1,170 @@
+# ABOUTME: Tests for the interactive SLURM configuration TUI wizard
+# ABOUTME: Uses mocked questionary to verify prompt flow and config generation
+"""Tests for orchestration TUI wizard."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from mdfactory.orchestration.config import SlurmExecutorConfig
+from mdfactory.orchestration.tui import (
+    UserCancelledError,
+    _require,
+    configure_slurm_interactive,
+    save_slurm_config_yaml,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cluster():
+    """Create a mock ClusterInfo for TUI tests."""
+    nt = MagicMock()
+    nt.cpus = 96
+    nt.memory_mb = 512 * 1024
+    nt.gpu_specs = ((4, "a100"),)
+    nt.features = ("avx512",)
+    nt.count = 10
+
+    partition = MagicMock()
+    partition.name = "gpu"
+    partition.state = "up"
+    partition.total_nodes = 10
+    partition.node_types = [nt]
+    partition.is_default = True
+    partition.max_time = "24:00:00"
+
+    cluster = MagicMock()
+    cluster.partitions = [partition]
+    cluster.accounts = ["hpc_chem", "hpc_bio"]
+    cluster.qos_policies = ["normal", "high"]
+    cluster.default_account = "hpc_chem"
+    return cluster
+
+
+# ---------------------------------------------------------------------------
+# _require tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequire:
+    def test_returns_value(self):
+        assert _require("hello", "test") == "hello"
+
+    def test_raises_on_none(self):
+        with pytest.raises(UserCancelledError):
+            _require(None, "test")
+
+
+# ---------------------------------------------------------------------------
+# configure_slurm_interactive tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureManualFallback:
+    """When discover_cluster returns None, wizard uses manual entry."""
+
+    @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
+    @patch("mdfactory.orchestration.tui.questionary")
+    def test_configure_manual_fallback(self, mock_q, _discover):
+        # confirm → proceed with manual config
+        mock_q.confirm.return_value.ask.return_value = True
+        # text prompts in order: account, partition, walltime, cpus,
+        # gres, mem, qos, max_blocks, worker_init
+        mock_q.text.return_value.ask.side_effect = [
+            "manual_acc",
+            "gpu",
+            "4:00:00",
+            "24",
+            "gpu:a100:1",
+            "64G",
+            "",
+            "4",
+            "",
+        ]
+
+        cfg = configure_slurm_interactive()
+        assert cfg.account == "manual_acc"
+        assert cfg.partition == "gpu"
+        assert cfg.walltime == "4:00:00"
+        assert cfg.cpus_per_node == 24
+        assert cfg.gres == "gpu:a100:1"
+        assert cfg.mem == "64G"
+
+
+class TestConfigureWithCluster:
+    """When cluster is discovered, wizard uses select menus."""
+
+    @patch("mdfactory.orchestration.tui.discover_cluster")
+    @patch("mdfactory.orchestration.tui.questionary")
+    def test_configure_with_cluster(self, mock_q, mock_discover):
+        mock_discover.return_value = _make_cluster()
+
+        # select prompts: account, partition, walltime, cpus, mem, max_blocks
+        mock_q.select.return_value.ask.side_effect = [
+            "hpc_chem",
+            "gpu",
+            "2h",
+            "16",
+            "50G",
+            "4",
+        ]
+        # text prompts: gres, worker_init
+        mock_q.text.return_value.ask.side_effect = [
+            "gpu:a100:1",
+            "",
+        ]
+        # confirm for QOS
+        mock_q.confirm.return_value.ask.return_value = False
+
+        cfg = configure_slurm_interactive()
+        assert cfg.account == "hpc_chem"
+        assert cfg.partition == "gpu"
+        assert cfg.walltime == "02:00:00"
+        assert cfg.cpus_per_node == 16
+        assert cfg.mem == "50G"
+        assert cfg.max_blocks == 4
+
+
+class TestUserCancellation:
+    """If a questionary prompt returns None, UserCancelledError is raised."""
+
+    @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
+    @patch("mdfactory.orchestration.tui.questionary")
+    def test_user_cancellation(self, mock_q, _discover):
+        # confirm manual? → None (cancelled)
+        mock_q.confirm.return_value.ask.return_value = None
+
+        with pytest.raises(UserCancelledError):
+            configure_slurm_interactive()
+
+
+# ---------------------------------------------------------------------------
+# save_slurm_config_yaml tests
+# ---------------------------------------------------------------------------
+
+
+class TestSaveYaml:
+    def test_save_slurm_config_yaml(self, tmp_path):
+        cfg = SlurmExecutorConfig(
+            account="test_acc",
+            partition="cpu",
+            walltime="1h",
+            cpus_per_node=16,
+            gres="gpu:v100:1",
+            max_blocks=3,
+        )
+        out = tmp_path / "slurm.yaml"
+        save_slurm_config_yaml(cfg, out)
+
+        data = yaml.safe_load(out.read_text())
+        assert data["account"] == "test_acc"
+        assert data["partition"] == "cpu"
+        assert data["walltime"] == "01:00:00"
+        assert data["cpus_per_node"] == 16
+        assert data["gres"] == "gpu:v100:1"
+        assert data["max_blocks"] == 3
+        assert data["provider"] == "slurm"

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -68,8 +68,9 @@ class TestConfigureManualFallback:
     """When discover_cluster returns None, wizard uses manual entry."""
 
     @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
-    @patch("mdfactory.orchestration.tui.questionary")
-    def test_configure_manual_fallback(self, mock_q, _discover):
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_configure_manual_fallback(self, mock_iq, _discover):
+        mock_q = mock_iq.return_value
         # confirm → proceed with manual config
         mock_q.confirm.return_value.ask.return_value = True
         # text prompts in order: account, partition, walltime, cpus,
@@ -99,8 +100,9 @@ class TestConfigureWithCluster:
     """When cluster is discovered, wizard uses select menus."""
 
     @patch("mdfactory.orchestration.tui.discover_cluster")
-    @patch("mdfactory.orchestration.tui.questionary")
-    def test_configure_with_cluster(self, mock_q, mock_discover):
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_configure_with_cluster(self, mock_iq, mock_discover):
+        mock_q = mock_iq.return_value
         mock_discover.return_value = _make_cluster()
 
         # select prompts: account, partition, walltime, cpus, mem, max_blocks
@@ -133,8 +135,9 @@ class TestUserCancellation:
     """If a questionary prompt returns None, UserCancelledError is raised."""
 
     @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
-    @patch("mdfactory.orchestration.tui.questionary")
-    def test_user_cancellation(self, mock_q, _discover):
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_user_cancellation(self, mock_iq, _discover):
+        mock_q = mock_iq.return_value
         # confirm manual? → None (cancelled)
         mock_q.confirm.return_value.ask.return_value = None
 

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -114,10 +114,11 @@ class TestConfigureWithCluster:
             "50G",
             "4",
         ]
-        # text prompts: gres, worker_init
+        # text prompts: gres, worker_init, constraint
         mock_q.text.return_value.ask.side_effect = [
             "gpu:a100:1",
             "",
+            "a100",
         ]
         # confirm for QOS
         mock_q.confirm.return_value.ask.return_value = False
@@ -129,6 +130,7 @@ class TestConfigureWithCluster:
         assert cfg.cpus_per_node == 16
         assert cfg.mem == "50G"
         assert cfg.max_blocks == 4
+        assert cfg.constraint == "a100"
 
 
 class TestUserCancellation:

--- a/mdfactory/tests/test_parametrization.py
+++ b/mdfactory/tests/test_parametrization.py
@@ -263,6 +263,28 @@ def test_smirnoff_parametrization_water(tmp_path):
 
 
 @pytest.mark.skipif(not is_openff_available(), reason="OpenFF not available")
+def test_smirnoff_parametrization_water_wat_resname(tmp_path):
+    """Test SMIRNOFF parametrization of water with non-SOL resname (regression).
+
+    Verifies that water parametrization with resname="WAT" still produces
+    consistent SOL-based atom types and ITP files. Before the fix, this
+    caused a KeyError due to mismatched atom type prefixes (WAT_0 vs SOL_0).
+    """
+    config.parameter_store = tmp_path / "parameters"
+
+    spec = SingleMoleculeSpecies(smiles="O", count=1, resname="WAT")
+    param = parametrize_smirnoff_gromacs(spec)
+
+    assert param.itp.is_file()
+    # Molecule type should always be SOL regardless of input resname
+    assert param.moleculetype == "SOL"
+    assert param.parametrization == "smirnoff"
+    # Verify the parameter ITP was generated correctly
+    assert param.parameter_itp is not None
+    assert param.parameter_itp.is_file()
+
+
+@pytest.mark.skipif(not is_openff_available(), reason="OpenFF not available")
 def test_smirnoff_parametrization_ions(tmp_path):
     """Test SMIRNOFF parametrization of ions."""
     config.parameter_store = tmp_path / "parameters"

--- a/pixi.lock
+++ b/pixi.lock
@@ -7223,7 +7223,7 @@ packages:
 - pypi: ./
   name: mdfactory
   version: 0.1.0
-  sha256: 18de6b3b8cf9142a6aa9068a5ece95bf5e6836a1761b4bdf5699f8ced3e8d109
+  sha256: 93b4b57f5ba28fbf3f493c44623d0ca6a4fd42618369c890a1912389aee16a80
   requires_dist:
   - cyclopts
   - loguru

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -322,6 +320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/ed/139ce29a650d9d4d35ce78b3fc4741da3d2a6d0f4db7b88d5f4ffcff8c77/griddataformats-1.1.0-py3-none-any.whl
@@ -330,10 +329,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3c/f1/efea3da858043ed9c078f507ab744b6d00933c7bc8a75a24821937600178/mmtf_python-1.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
       - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -639,6 +643,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/ed/139ce29a650d9d4d35ce78b3fc4741da3d2a6d0f4db7b88d5f4ffcff8c77/griddataformats-1.1.0-py3-none-any.whl
@@ -647,10 +652,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3c/f1/efea3da858043ed9c078f507ab744b6d00933c7bc8a75a24821937600178/mmtf_python-1.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -956,6 +966,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/ed/139ce29a650d9d4d35ce78b3fc4741da3d2a6d0f4db7b88d5f4ffcff8c77/griddataformats-1.1.0-py3-none-any.whl
@@ -964,18 +975,21 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3c/f1/efea3da858043ed9c078f507ab744b6d00933c7bc8a75a24821937600178/mmtf_python-1.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
       - pypi: ./
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1291,57 +1305,67 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/ed/ad1755f82cd5a0baafe342e7154696a93e57f04f86515402f14e5beceb36/bump_my_version-1.2.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/36/01/b168791bfbfb0322ef6d38d236f6f17a02e41fb7753e23e4cdb0f19ac969/bump_my_version-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/ed/139ce29a650d9d4d35ce78b3fc4741da3d2a6d0f4db7b88d5f4ffcff8c77/griddataformats-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/8a/11ae7e271870f0ad8fa0012e4265982bebe0fdc21766b161fb8b8fc3aefc/hatch-1.16.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/bd/0a7f877ec78e6910868e39a68c2a1964fa0737a4008ee1f3fd7e2fd8915f/hatch-1.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/16/ad7fc0f8948075b9ab7f6957519492e861b2f16469f1ab0a916f7c3c4243/mdanalysis-2.10.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/f1/efea3da858043ed9c078f507ab744b6d00933c7bc8a75a24821937600178/mmtf_python-1.1.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/4d/2ca3ca9906ce6e05070f431c54d54ccbaf57a980cfa58032d35b0b0ac1f8/pyinstrument-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/79/34/b104c413079874493eed7bf11838b47b697cf1f0ed7e9de374ea37b4e4e0/uv-0.10.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/c4/8112b3c95db60a39c98db0641dd49bd4228f2fedb9d0ef5e4f3f48b52a0d/uv-0.11.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl
       - pypi: ./
       osx-64:
@@ -1648,54 +1672,63 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/ed/ad1755f82cd5a0baafe342e7154696a93e57f04f86515402f14e5beceb36/bump_my_version-1.2.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/36/01/b168791bfbfb0322ef6d38d236f6f17a02e41fb7753e23e4cdb0f19ac969/bump_my_version-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d1/81/4ce2fdd909c5a0ed1f6dedb88aa57ab79b6d1fbd9b588c1ac7ef45659566/coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/ed/139ce29a650d9d4d35ce78b3fc4741da3d2a6d0f4db7b88d5f4ffcff8c77/griddataformats-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/8a/11ae7e271870f0ad8fa0012e4265982bebe0fdc21766b161fb8b8fc3aefc/hatch-1.16.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/bd/0a7f877ec78e6910868e39a68c2a1964fa0737a4008ee1f3fd7e2fd8915f/hatch-1.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/8c/8d037a8010e92959631fa05811df43e4710b8e828bd18ea3da73189d5ce8/mdanalysis-2.10.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/f1/efea3da858043ed9c078f507ab744b6d00933c7bc8a75a24821937600178/mmtf_python-1.1.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/d9/8fa5571ddd21b2b7189bd8b0bb4e90be1659a54dda5af51c7f6bf2b5666f/pyinstrument-5.1.2-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6f/34/2e5cd576d312eb1131b615f49ee95ff6efb740965324843617adae729cf2/uv-0.10.9-py3-none-macosx_10_12_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/38/ad/57a31ea9ffc53a2fb5cd9a60b5edb9e4df7c526ba80be4517c6d73cf4fa7/uv-0.11.18-py3-none-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl
       - pypi: ./
       osx-arm64:
@@ -2002,54 +2035,63 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/ed/ad1755f82cd5a0baafe342e7154696a93e57f04f86515402f14e5beceb36/bump_my_version-1.2.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/36/01/b168791bfbfb0322ef6d38d236f6f17a02e41fb7753e23e4cdb0f19ac969/bump_my_version-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/96/5238b1efc5922ddbdc9b0db9243152c09777804fb7c02ad1741eb18a11c0/coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/ed/139ce29a650d9d4d35ce78b3fc4741da3d2a6d0f4db7b88d5f4ffcff8c77/griddataformats-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/8a/11ae7e271870f0ad8fa0012e4265982bebe0fdc21766b161fb8b8fc3aefc/hatch-1.16.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/bd/0a7f877ec78e6910868e39a68c2a1964fa0737a4008ee1f3fd7e2fd8915f/hatch-1.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/e8/baae856d6764901cd13fe928cd4086ed755ae22f66928301a9327a4a2a3e/mdanalysis-2.10.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/f1/efea3da858043ed9c078f507ab744b6d00933c7bc8a75a24821937600178/mmtf_python-1.1.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/50/0512adb83cadfeaa1a215dc9784defff5043c5aa052d15015e3d8013af75/pyinstrument-5.1.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/89/35/684f641de4de2b20db7d2163c735b2bb211e3b3c84c241706d6448e5e868/uv-0.10.9-py3-none-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/af/3b/130515418bdd4be1aec5941ca2fa53dc0281750434e835ff633e6f8cd944/uv-0.11.18-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl
       - pypi: ./
 packages:
@@ -2726,10 +2768,10 @@ packages:
   - pkg:pypi/bson?source=hash-mapping
   size: 16836
   timestamp: 1736456262819
-- pypi: https://files.pythonhosted.org/packages/46/ed/ad1755f82cd5a0baafe342e7154696a93e57f04f86515402f14e5beceb36/bump_my_version-1.2.7-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/36/01/b168791bfbfb0322ef6d38d236f6f17a02e41fb7753e23e4cdb0f19ac969/bump_my_version-1.3.0-py3-none-any.whl
   name: bump-my-version
-  version: 1.2.7
-  sha256: 16f89360f979c0a8eb3249ebe3e13ae4f0cb5481d7bb58e12a9f66996922acfd
+  version: 1.3.0
+  sha256: 3cdaa54588d2443a29303b77e7539417187952c3d22f87bfdd32c0fe6af2f570
   requires_dist:
   - click<8.4
   - httpx>=0.28.1
@@ -2740,7 +2782,7 @@ packages:
   - rich-click
   - tomlkit
   - wcmatch>=8.5.1
-  requires_python: '>=3.8'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -3109,24 +3151,24 @@ packages:
   - pkg:pypi/contourpy?source=compressed-mapping
   size: 286084
   timestamp: 1769156157865
-- pypi: https://files.pythonhosted.org/packages/5d/96/5238b1efc5922ddbdc9b0db9243152c09777804fb7c02ad1741eb18a11c0/coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3
+  version: 7.14.1
+  sha256: 6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3
+  version: 7.14.1
+  sha256: a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/d1/81/4ce2fdd909c5a0ed1f6dedb88aa57ab79b6d1fbd9b588c1ac7ef45659566/coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459
+  version: 7.14.1
+  sha256: fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
@@ -3141,36 +3183,15 @@ packages:
   purls: []
   size: 46463
   timestamp: 1772728929620
-- pypi: https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
   name: cryptography
-  version: 46.0.5
-  sha256: 3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed
+  version: 48.0.0
+  sha256: a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f
   requires_dist:
-  - cffi>=1.14 ; python_full_version == '3.8.*' and platform_python_implementation != 'PyPy'
-  - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
+  - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
-  - nox[uv]>=2024.4.15 ; extra == 'nox'
-  - cryptography-vectors==46.0.5 ; extra == 'test'
-  - pytest>=7.4.0 ; extra == 'test'
-  - pytest-benchmark>=4.0 ; extra == 'test'
-  - pytest-cov>=2.10.1 ; extra == 'test'
-  - pytest-xdist>=3.5.0 ; extra == 'test'
-  - pretend>=0.7 ; extra == 'test'
-  - certifi>=2024 ; extra == 'test'
-  - pytest-randomly ; extra == 'test-randomorder'
-  - sphinx>=5.3.0 ; extra == 'docs'
-  - sphinx-rtd-theme>=3.0.0 ; extra == 'docs'
-  - sphinx-inline-tabs ; extra == 'docs'
-  - pyenchant>=3 ; extra == 'docstest'
-  - readme-renderer>=30.0 ; extra == 'docstest'
-  - sphinxcontrib-spelling>=7.3.1 ; extra == 'docstest'
-  - build>=1.0.0 ; extra == 'sdist'
-  - ruff>=0.11.11 ; extra == 'pep8test'
-  - mypy>=1.14 ; extra == 'pep8test'
-  - check-sdist ; extra == 'pep8test'
-  - click>=8.0.1 ; extra == 'pep8test'
-  requires_python: '>=3.8,!=3.9.0,!=3.9.1'
+  requires_python: '>=3.9,!=3.9.0,!=3.9.1'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.2.51-hecca717_0.conda
   sha256: 9de235d328b7124f715805715e9918eb7f8aa5b9c56a2afa62b84f84f98077a5
   md5: 0413baaa73be1a39d5d8e442184acc78
@@ -3353,10 +3374,23 @@ packages:
   - pkg:pypi/defusedxml?source=hash-mapping
   size: 24062
   timestamp: 1615232388757
-- pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+  name: dill
+  version: 0.4.1
+  sha256: 1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d
+  requires_dist:
+  - objgraph>=1.7.2 ; extra == 'graph'
+  - gprof2dot>=2022.7.29 ; extra == 'profile'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl
   name: distlib
-  version: 0.4.0
-  sha256: 9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16
+  version: 0.4.1
+  sha256: 9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97
+- pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
+  name: distro
+  version: 1.9.0
+  sha256: 7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl
   name: docstring-parser
   version: 0.17.0
@@ -3848,15 +3882,16 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
-- pypi: https://files.pythonhosted.org/packages/e4/8a/11ae7e271870f0ad8fa0012e4265982bebe0fdc21766b161fb8b8fc3aefc/hatch-1.16.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e4/bd/0a7f877ec78e6910868e39a68c2a1964fa0737a4008ee1f3fd7e2fd8915f/hatch-1.17.0-py3-none-any.whl
   name: hatch
-  version: 1.16.5
-  sha256: d9b8047f2cd10d3349eb6e8f278ad728a04f91495aace305c257d5c2747188fb
+  version: 1.17.0
+  sha256: cb742cc9113085c7dc88fde5a54e594846d8395102ae86e32179d5e72ff3c589
   requires_dist:
   - backports-zstd>=1.0.0 ; python_full_version < '3.14'
   - click>=8.0.6
+  - distro>=1.0.0 ; sys_platform == 'linux'
   - hatchling>=1.27.0
-  - httpx>=0.22.0
+  - httpx2>=0.22.0
   - hyperlink>=21.0.0
   - keyring>=23.5.0
   - packaging>=24.2
@@ -3872,10 +3907,10 @@ packages:
   - uv>=0.5.23
   - virtualenv>=21
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl
   name: hatchling
-  version: 1.29.0
-  sha256: 50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0
+  version: 1.30.1
+  sha256: 161eacafb3c6f91526e92116d21426369f2c36e98c36a864f11a96345ad4ee31
   requires_dist:
   - packaging>=24.2
   - pathspec>=0.10.1
@@ -4000,6 +4035,18 @@ packages:
   - pkg:pypi/httpcore?source=hash-mapping
   size: 49483
   timestamp: 1745602916758
+- pypi: https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl
+  name: httpcore2
+  version: 2.3.0
+  sha256: 477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415
+  requires_dist:
+  - h11>=0.16
+  - truststore>=0.10
+  - anyio>=4.5.0,<5.0 ; extra == 'asyncio'
+  - h2>=3,<5 ; extra == 'http2'
+  - socksio==1.* ; extra == 'socks'
+  - trio>=0.22.0,<1.0 ; extra == 'trio'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
   sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
   md5: d6989ead454181f4f9bc987d3dc4e285
@@ -4015,6 +4062,24 @@ packages:
   - pkg:pypi/httpx?source=hash-mapping
   size: 63082
   timestamp: 1733663449209
+- pypi: https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl
+  name: httpx2
+  version: 2.3.0
+  sha256: 6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7
+  requires_dist:
+  - anyio
+  - httpcore2==2.3.0
+  - idna
+  - truststore>=0.10
+  - brotli ; platform_python_implementation == 'CPython' and extra == 'brotli'
+  - brotlicffi ; platform_python_implementation != 'CPython' and extra == 'brotli'
+  - click==8.* ; extra == 'cli'
+  - pygments==2.* ; extra == 'cli'
+  - rich>=10,<15 ; extra == 'cli'
+  - h2>=3,<5 ; extra == 'http2'
+  - socksio==1.* ; extra == 'socks'
+  - zstandard>=0.18.0 ; python_full_version < '3.14' and extra == 'zstd'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -4066,10 +4131,10 @@ packages:
   purls: []
   size: 11857802
   timestamp: 1720853997952
-- pypi: https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
   name: identify
-  version: 2.6.18
-  sha256: 8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737
+  version: 2.6.19
+  sha256: 20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a
   requires_dist:
   - ukkonen ; extra == 'license'
   requires_python: '>=3.10'
@@ -4252,10 +4317,10 @@ packages:
   - pytest-enabler>=2.2 ; extra == 'testing'
   - pytest-ruff>=0.2.1 ; extra == 'testing'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
   name: jaraco-context
-  version: 6.1.1
-  sha256: 0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808
+  version: 6.1.2
+  sha256: bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535
   requires_dist:
   - backports-tarfile ; python_full_version < '3.12'
   - pytest>=6,!=8.1.* ; extra == 'test'
@@ -4267,17 +4332,16 @@ packages:
   - furo ; extra == 'doc'
   - sphinx-lint ; extra == 'doc'
   - jaraco-tidelift>=1.4 ; extra == 'doc'
-  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-checkdocs>=2.14 ; extra == 'check'
   - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
   - pytest-cov ; extra == 'cover'
   - pytest-enabler>=3.4 ; extra == 'enabler'
-  - pytest-mypy>=1.0.1 ; extra == 'type'
-  - mypy<1.19 ; platform_python_implementation == 'PyPy' and extra == 'type'
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+  - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
   name: jaraco-functools
-  version: 4.4.0
-  sha256: 9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176
+  version: 4.5.0
+  sha256: 79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4
   requires_dist:
   - more-itertools
   - pytest>=6,!=8.1.* ; extra == 'test'
@@ -4288,13 +4352,12 @@ packages:
   - furo ; extra == 'doc'
   - sphinx-lint ; extra == 'doc'
   - jaraco-tidelift>=1.4 ; extra == 'doc'
-  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-checkdocs>=2.14 ; extra == 'check'
   - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
   - pytest-cov ; extra == 'cover'
   - pytest-enabler>=3.4 ; extra == 'enabler'
-  - pytest-mypy>=1.0.1 ; extra == 'type'
-  - mypy<1.19 ; platform_python_implementation == 'PyPy' and extra == 'type'
-  requires_python: '>=3.9'
+  - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
@@ -7160,7 +7223,7 @@ packages:
 - pypi: ./
   name: mdfactory
   version: 0.1.0
-  sha256: af8931e0eb980b726a9ea87c3ac824699c1e83493882853bb4fff006fed99425
+  sha256: 18de6b3b8cf9142a6aa9068a5ece95bf5e6836a1761b4bdf5699f8ced3e8d109
   requires_dist:
   - cyclopts
   - loguru
@@ -7185,8 +7248,10 @@ packages:
   - ruff ; extra == 'dev'
   - tqdm ; extra == 'dev'
   - foundry-dev-tools ; extra == 'foundry'
+  - parsl>=2024.1.1 ; extra == 'parsl'
   - submitit>=1.5.1 ; extra == 'submitit'
   requires_python: '>=3.11'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mdtraj-1.11.1-np2py312h8baca0b_1.conda
   sha256: 66f32f08a8769482f1fae72051dccd74beaf4916cc33bffc9ad5b13db2d49066
   md5: a4c60c0060137d103145b33cdd8001c2
@@ -7315,11 +7380,11 @@ packages:
   - msgpack>=1.0.0
   - check-manifest ; extra == 'dev'
   - coverage ; extra == 'test'
-- pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
   name: more-itertools
-  version: 10.8.0
-  sha256: 52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b
-  requires_python: '>=3.9'
+  version: 11.1.0
+  sha256: 4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
   sha256: 1bf794ddf2c8b3a3e14ae182577c624fa92dea975537accff4bc7e5fea085212
   md5: aa14b9a5196a6d8dd364164b7ce56acf
@@ -8484,6 +8549,78 @@ packages:
   - pkg:pypi/parmed?source=hash-mapping
   size: 19381423
   timestamp: 1769768478779
+- pypi: https://files.pythonhosted.org/packages/65/1e/0f58a02b4310e495159421946abd298ae53897ea8f5ebb6b82fb7fd0f71d/parsl-2026.6.1-py3-none-any.whl
+  name: parsl
+  version: 2026.6.1
+  sha256: cba922c33d2a3df214700ec6477d72254d20f6664b7366d3ce853524e27731b9
+  requires_dist:
+  - pyzmq>=17.1.2
+  - typeguard>=2.10,!=3.*,<5
+  - typing-extensions>=4.6,<5
+  - dill
+  - tblib
+  - requests
+  - sortedcontainers
+  - psutil>=5.5.1
+  - setproctitle
+  - filelock>=3.13,<4
+  - sqlalchemy>=2,<2.1 ; extra == 'monitoring'
+  - pydot>=1.4.2 ; extra == 'visualization'
+  - networkx>=3.2,<3.3 ; extra == 'visualization'
+  - flask>=1.0.2 ; extra == 'visualization'
+  - flask-sqlalchemy ; extra == 'visualization'
+  - pandas>=2.2,<3 ; extra == 'visualization'
+  - plotly ; extra == 'visualization'
+  - python-daemon ; extra == 'visualization'
+  - boto3 ; extra == 'aws'
+  - kubernetes ; extra == 'kubernetes'
+  - ipython<=8.6.0 ; extra == 'docs'
+  - nbsphinx ; extra == 'docs'
+  - sphinx>=7.4,<8 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - google-auth ; extra == 'google-cloud'
+  - google-api-python-client ; extra == 'google-cloud'
+  - python-gssapi ; extra == 'gssapi'
+  - azure<=4 ; extra == 'azure'
+  - msrestazure ; extra == 'azure'
+  - work-queue ; extra == 'workqueue'
+  - pyyaml ; extra == 'flux'
+  - cffi ; extra == 'flux'
+  - jsonschema ; extra == 'flux'
+  - proxystore ; extra == 'proxystore'
+  - radical-pilot==1.90 ; extra == 'radical-pilot'
+  - radical-utils==1.90 ; extra == 'radical-pilot'
+  - globus-compute-sdk>=2.34.0 ; extra == 'globus-compute'
+  - globus-sdk ; extra == 'globus-transfer'
+  - sqlalchemy>=2,<2.1 ; extra == 'all'
+  - pydot>=1.4.2 ; extra == 'all'
+  - networkx>=3.2,<3.3 ; extra == 'all'
+  - flask>=1.0.2 ; extra == 'all'
+  - flask-sqlalchemy ; extra == 'all'
+  - pandas>=2.2,<3 ; extra == 'all'
+  - plotly ; extra == 'all'
+  - python-daemon ; extra == 'all'
+  - boto3 ; extra == 'all'
+  - kubernetes ; extra == 'all'
+  - ipython<=8.6.0 ; extra == 'all'
+  - nbsphinx ; extra == 'all'
+  - sphinx>=7.4,<8 ; extra == 'all'
+  - sphinx-rtd-theme ; extra == 'all'
+  - google-auth ; extra == 'all'
+  - google-api-python-client ; extra == 'all'
+  - python-gssapi ; extra == 'all'
+  - azure<=4 ; extra == 'all'
+  - msrestazure ; extra == 'all'
+  - work-queue ; extra == 'all'
+  - pyyaml ; extra == 'all'
+  - cffi ; extra == 'all'
+  - jsonschema ; extra == 'all'
+  - proxystore ; extra == 'all'
+  - radical-pilot==1.90 ; extra == 'all'
+  - radical-utils==1.90 ; extra == 'all'
+  - globus-compute-sdk>=2.34.0 ; extra == 'all'
+  - globus-sdk ; extra == 'all'
+  requires_python: '>=3.10.0'
 - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
   sha256: 42b2d77ccea60752f3aa929a6413a7835aaacdbbde679f2f5870a744fa836b94
   md5: 97c1ce2fffa1209e7afb432810ec6e12
@@ -8496,16 +8633,14 @@ packages:
   - pkg:pypi/parso?source=hash-mapping
   size: 82287
   timestamp: 1770676243987
-- pypi: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
   name: pathspec
-  version: 1.0.4
-  sha256: fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
+  version: 1.1.1
+  sha256: a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
   requires_dist:
   - hyperscan>=0.7 ; extra == 'hyperscan'
   - typing-extensions>=4 ; extra == 'optional'
   - google-re2>=1.1 ; extra == 're2'
-  - pytest>=9 ; extra == 'tests'
-  - typing-extensions>=4.15 ; extra == 'tests'
   requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
   sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
@@ -8726,10 +8861,10 @@ packages:
   - pytest-benchmark ; extra == 'testing'
   - coverage ; extra == 'testing'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
   name: pre-commit
-  version: 4.5.1
-  sha256: 3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77
+  version: 4.6.0
+  sha256: e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b
   requires_dist:
   - cfgv>=2.0.0
   - identify>=1.0.0
@@ -9042,16 +9177,16 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1715338
   timestamp: 1746625327204
-- pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl
   name: pydantic-settings
-  version: 2.13.1
-  sha256: d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237
+  version: 2.14.1
+  sha256: 6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de
   requires_dist:
   - pydantic>=2.7.0
   - python-dotenv>=0.21.0
   - typing-inspection>=0.4.0
-  - boto3-stubs[secretsmanager] ; extra == 'aws-secrets-manager'
   - boto3>=1.35.0 ; extra == 'aws-secrets-manager'
+  - types-boto3[secretsmanager] ; extra == 'aws-secrets-manager'
   - azure-identity>=1.16.0 ; extra == 'azure-key-vault'
   - azure-keyvault-secrets>=4.8.0 ; extra == 'azure-key-vault'
   - google-cloud-secret-manager>=2.23.1 ; extra == 'gcp-secret-manager'
@@ -9322,10 +9457,10 @@ packages:
   - pkg:pypi/tables?source=hash-mapping
   size: 1725636
   timestamp: 1772372138444
-- pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
   name: pytest
-  version: 9.0.2
-  sha256: 711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b
+  version: 9.0.3
+  sha256: 2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9
   requires_dist:
   - colorama>=0.4 ; sys_platform == 'win32'
   - exceptiongroup>=1 ; python_full_version < '3.11'
@@ -9342,10 +9477,10 @@ packages:
   - setuptools ; extra == 'dev'
   - xmlschema ; extra == 'dev'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
   name: pytest-cov
-  version: 7.0.0
-  sha256: 3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861
+  version: 7.1.0
+  sha256: a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678
   requires_dist:
   - coverage[toml]>=7.10.6
   - pluggy>=1.2
@@ -9459,10 +9594,10 @@ packages:
   - pkg:pypi/python-dateutil?source=hash-mapping
   size: 233310
   timestamp: 1751104122689
-- pypi: https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl
   name: python-discovery
-  version: 1.1.3
-  sha256: 90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e
+  version: 1.4.0
+  sha256: 26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da
   requires_dist:
   - filelock>=3.15.4
   - platformdirs>=4.3.6,<5
@@ -9470,6 +9605,8 @@ packages:
   - sphinx-autodoc-typehints>=3.6.3 ; extra == 'docs'
   - sphinx>=9.1 ; extra == 'docs'
   - sphinxcontrib-mermaid>=2 ; extra == 'docs'
+  - sphinxcontrib-towncrier>=0.4 ; extra == 'docs'
+  - towncrier>=25.8 ; extra == 'docs'
   - covdefaults>=2.3 ; extra == 'testing'
   - coverage>=7.5.4 ; extra == 'testing'
   - pytest-mock>=3.14 ; extra == 'testing'
@@ -10044,10 +10181,10 @@ packages:
   - pkg:pypi/rich?source=compressed-mapping
   size: 208472
   timestamp: 1771572730357
-- pypi: https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl
   name: rich-click
-  version: 1.9.7
-  sha256: 2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b
+  version: 1.9.8
+  sha256: 12873865396e6927835d4eabb1cc3996edcd65b7ac9b2391a29eca4f335a2f93
   requires_dist:
   - click>=8
   - colorama ; sys_platform == 'win32'
@@ -10063,7 +10200,7 @@ packages:
   - pytest-cov>=5 ; extra == 'dev'
   - rich-codex>=1.2.11 ; extra == 'dev'
   - ruff>=0.12.4 ; extra == 'dev'
-  - typer>=0.15 ; extra == 'dev'
+  - typer>=0.15,<0.26 ; extra == 'dev'
   - types-setuptools>=75.8.0.20250110 ; extra == 'dev'
   - markdown-include>=0.8.1 ; extra == 'docs'
   - mike>=2.1.3 ; extra == 'docs'
@@ -10077,7 +10214,7 @@ packages:
   - mkdocs-rss-plugin>=1.15 ; extra == 'docs'
   - mkdocstrings[python]>=0.26.1 ; extra == 'docs'
   - rich-codex>=1.2.11 ; extra == 'docs'
-  - typer>=0.15 ; extra == 'docs'
+  - typer>=0.15,<0.26 ; extra == 'docs'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
   name: rich-rst
@@ -10160,20 +10297,20 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 358853
   timestamp: 1764543161524
-- pypi: https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl
   name: ruff
-  version: 0.15.5
-  sha256: 6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080
+  version: 0.15.15
+  sha256: ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl
   name: ruff
-  version: 0.15.5
-  sha256: 89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010
+  version: 0.15.15
+  sha256: 77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ruff
-  version: 0.15.5
-  sha256: c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a
+  version: 0.15.15
+  sha256: 48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4
   requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
   sha256: e3ad577361d67f6c078a6a7a3898bf0617b937d44dc4ccd57aa3336f2b5778dd
@@ -10278,6 +10415,27 @@ packages:
   - pkg:pypi/send2trash?source=hash-mapping
   size: 24108
   timestamp: 1770937597662
+- pypi: https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: 2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: 2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
   md5: 8e194e7b992f99a5015edbd4ebd38efd
@@ -10386,6 +10544,10 @@ packages:
   - pkg:pypi/sniffio?source=hash-mapping
   size: 15698
   timestamp: 1762941572482
+- pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  name: sortedcontainers
+  version: 2.4.0
+  sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
 - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
   sha256: 23b71ecf089967d2900126920e7f9ff18cdcef82dbff3e2f54ffa360243a17ac
   md5: 18de09b20462742fe093ba39185d9bac
@@ -10486,6 +10648,11 @@ packages:
   purls: []
   size: 181262
   timestamp: 1762509955687
+- pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  name: tblib
+  version: 3.2.2
+  sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   sha256: 6b6727a13d1ca6a23de5e6686500d0669081a117736a87c8abf444d60c1e40eb
   md5: 17b43cee5cc84969529d5d0b0309b2cb
@@ -10571,10 +10738,10 @@ packages:
   version: 1.2.0
   sha256: 188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
   name: tomlkit
-  version: 0.14.0
-  sha256: 592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680
+  version: 0.15.0
+  sha256: 4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738
   requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.8.2-pyhd8ed1ab_0.conda
   sha256: d3171f8d6689db5208e36f1acab7bcaa38fe4ce0cbbd0cfa59e100813754ceab
@@ -10657,10 +10824,23 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110051
   timestamp: 1733367480074
-- pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl
   name: trove-classifiers
-  version: 2026.1.14.14
-  sha256: 1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d
+  version: 2026.6.1.19
+  sha256: ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3
+- pypi: https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl
+  name: truststore
+  version: 0.10.4
+  sha256: adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl
+  name: typeguard
+  version: 4.5.2
+  sha256: fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf
+  requires_dist:
+  - importlib-metadata>=3.6 ; python_full_version < '3.10'
+  - typing-extensions>=4.14.0
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -10787,32 +10967,32 @@ packages:
   requires_dist:
   - click
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/6f/34/2e5cd576d312eb1131b615f49ee95ff6efb740965324843617adae729cf2/uv-0.10.9-py3-none-macosx_10_12_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/38/ad/57a31ea9ffc53a2fb5cd9a60b5edb9e4df7c526ba80be4517c6d73cf4fa7/uv-0.11.18-py3-none-macosx_10_12_x86_64.whl
   name: uv
-  version: 0.10.9
-  sha256: 880dd4cffe4bd184e8871ddf4c7d3c3b042e1f16d2682310644aa8d61eaea3e6
+  version: 0.11.18
+  sha256: 90685bda9e15600ae9a2a10c326008a69f28d8652555a2e760e1493e4b1ae7b5
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/79/34/b104c413079874493eed7bf11838b47b697cf1f0ed7e9de374ea37b4e4e0/uv-0.10.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/af/3b/130515418bdd4be1aec5941ca2fa53dc0281750434e835ff633e6f8cd944/uv-0.11.18-py3-none-macosx_11_0_arm64.whl
   name: uv
-  version: 0.10.9
-  sha256: 7c9d6deb30edbc22123be75479f99fb476613eaf38a8034c0e98bba24a344179
+  version: 0.11.18
+  sha256: 0571ec649f25e2cca9eb994637aa1ae27ab3db58f87c5a9b5f9776d5d7cd2298
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/89/35/684f641de4de2b20db7d2163c735b2bb211e3b3c84c241706d6448e5e868/uv-0.10.9-py3-none-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/ca/c4/8112b3c95db60a39c98db0641dd49bd4228f2fedb9d0ef5e4f3f48b52a0d/uv-0.11.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: uv
-  version: 0.10.9
-  sha256: a7a784254380552398a6baf4149faf5b31a4003275f685c28421cf8197178a08
+  version: 0.11.18
+  sha256: 9a4ee93dd0cc86046eb234ff8f3a5090c6cbb1466a825c5201aaf4ee4b45158d
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl
   name: virtualenv
-  version: 21.2.0
-  sha256: 1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f
+  version: 21.4.2
+  sha256: 854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae
   requires_dist:
   - distlib>=0.3.7,<1
   - filelock>=3.24.2,<4 ; python_full_version >= '3.10'
   - filelock>=3.16.1,<=3.19.1 ; python_full_version < '3.10'
   - importlib-metadata>=6.6 ; python_full_version < '3.8'
   - platformdirs>=3.9.1,<5
-  - python-discovery>=1
+  - python-discovery>=1.4
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ foundry = [
 submitit = [
     "submitit>=1.5.1",
 ]
+parsl = [
+    "parsl>=2024.1.1",
+]
 dev = [
     "bump-my-version",
     "hatch",
@@ -97,6 +100,7 @@ openmm = "*"
 
 [tool.pixi.pypi-dependencies]
 mdfactory = { path = ".", editable = true }
+parsl = ">=2024.1.1"
 
 [tool.pixi.tasks]
 test = "pytest -k 'not build' mdfactory"
@@ -209,3 +213,4 @@ addopts = "-m 'not foundry_live and not slow' -v --cov mdfactory --cov-report xm
 
 [tool.coverage.run]
 omit = ["mdfactory/tests/*"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ select = [
 ignore = [
     "D105", # Missing docstring in magic functions
     "D107", # Missing docstring in __init__
+    "PLC0415", # Import not at top of file (lazy imports for optional deps)
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments in function definition
     "PLR0915", # Too many statements


### PR DESCRIPTION
Closes #16 (PR 1 of 4)

Add Parsl as a Python-native workflow manager for parallel build orchestration on SLURM GPU nodes. Extends `mdfactory build` to accept CSV files directly and dispatch builds in parallel via Parsl's `@python_app` + `HighThroughputExecutor`.

## Features

| Feature | Description |
|---|---|
| **Parsl `@python_app` build dispatch** | Wraps `run_build_from_dict()` — heavy imports happen inside workers, only plain dicts cross serialization boundary |
| **`SlurmExecutorConfig`** | Pydantic model with SLURM-native field names (`gres`, `mem`, `qos`, `constraint`, `walltime`); generates `parsl.Config` with `HighThroughputExecutor` + `SlurmProvider` |
| **`ExecutorConfig`** | Local-provider alternative for testing / non-SLURM machines |
| **`build_systems()`** | Parallel dispatch with `dry_run=True` support — dry-run resolves inputs and logs the plan without importing Parsl |
| **`SlurmExecutorConfig.from_cluster()`** | 3-tier autodiscovery (explicit kwargs → config.ini → live sinfo/sacctmgr) via shared `resolve_slurm_fields()` helper from `mdfactory.performance` |
| **Walltime normalization** | `walltime` field accepts shorthand (`"2h"`, `"30m"`, `"1d"`) via `normalize_slurm_time` validator |
| **Rich live progress TUI** | Progress bar with success/fail counts, scrolling activity log, SLURM block status — scales to any campaign size |
| **Ctrl+C → `scancel`** | KeyboardInterrupt triggers explicit `scancel` of SLURM jobs + `parsl.clear()` |
| **DFK lifecycle management** | `try/finally` with `cleanup_needed` flag; DFK guard prevents double-load errors |
| **`min_blocks=0`** | Idle SLURM allocations are released — no wasted GPU-hours |
| **`--slurm` CLI flag** | Accepts a YAML path or `"tui"` for interactive setup |
| **`--slurm tui` interactive wizard** | `questionary`-based flow: discovers partitions/accounts/hardware, presents select menus with specs, supports "Custom…" escape hatch on every prompt |
| **`mdfactory config slurm`** | Same wizard but only generates a reusable YAML config (no build triggered) |
| **`--dry-run`** | Prints resolved build plan (hash, type, engine, output dir) without executing |
| **CSV → parallel builds** | `mdfactory build input.csv --slurm config.yaml` creates dirs, writes per-system YAMLs, generates summary YAML, dispatches all builds |
| **CSV → sequential builds** | `mdfactory build input.csv` (no `--slurm`) builds systems one-by-one locally |
| **Summary YAML input** | `mdfactory build summary.yaml --slurm config.yaml` dispatches previously prepared systems |
| **Single YAML unchanged** | `mdfactory build system.yaml` still works as before (backward compatible) |
| **Auto `worker_init`** | Detects pixi environment for compute node activation (tracked for improvement in issue 22) |
| **`parsl` optional dependency** | `pip install 'mdfactory[parsl]'`; importing `mdfactory` without parsl does not error |
| **SOL molecule name fix** | Forces `molecule.name = "SOL"` for water SMIRNOFF parametrization to prevent atom type naming inconsistency |

## Test Coverage

| Test file | Tests | Coverage |
|---|---|---|
| `test_orchestration_build.py` | 22 | Submission, dry-run, dict input, `_build_system_impl`, KeyboardInterrupt, SLURM cleanup, DFK guard, `wait=False` |
| `test_orchestration_cli.py` | 19 | CSV/YAML/summary-YAML dispatch, dry-run, routing, error paths, malformed input |
| `test_orchestration_config.py` | 10 | Config defaults, YAML load/roundtrip, `to_parsl_config()`, scheduler options, empty YAML guard |
| `test_orchestration_from_cluster.py` | 10 | `from_cluster()` with mocked discovery, config.ini precedence, error paths |
| `test_orchestration_tui.py` | 6 | TUI wizard with mocked questionary, manual fallback, save-to-YAML |
| `test_parametrization.py` | +1 | SOL molecule name regression test |

## New/Modified Files

| File | Change |
|---|---|
| `mdfactory/orchestration/__init__.py` | New — public API exports |
| `mdfactory/orchestration/config.py` | New — `ExecutorConfig`, `SlurmExecutorConfig` with `from_yaml()`, `from_cluster()`, `to_parsl_config()` |
| `mdfactory/orchestration/apps.py` | New — `@python_app` wrapping `run_build_from_dict` (runtime decoration) |
| `mdfactory/orchestration/build.py` | New — `build_systems()`, progress TUI, DFK lifecycle, SLURM cleanup |
| `mdfactory/orchestration/tui.py` | New — interactive SLURM config wizard |
| `mdfactory/cli.py` | Extended — CSV/YAML/summary input, `--slurm`, `--dry-run`, `config slurm` command |
| `mdfactory/performance/slurm_config.py` | Refactored — extracted `resolve_slurm_fields()` shared by both SLURM config classes |
| `mdfactory/parametrize.py` | Bugfix — SOL molecule name for water SMIRNOFF |
| `pyproject.toml` | Added `parsl` optional dependency |

Implementation plan posted as a comment below.
