### PR TITLE
feat: adaptive rescue retry for GROMACS physics failures

### DIFF
--- a/docs/content/docs/user-guide/cli-reference.mdx
+++ b/docs/content/docs/user-guide/cli-reference.mdx
@@ -58,6 +58,7 @@ Options:
 - `--checkpoint` — checkpoint mode: `auto` (default), `skip`, `force`
 - `--hash` — filter by hash prefix (can specify multiple)
 - `--dry-run` — preview plan without executing
+- `--max-rescue` — max rescue tiers for physics failures (default: 3; set to 0 to disable)
 
 Usage examples:
 

--- a/docs/content/docs/user-guide/running-on-hpc.mdx
+++ b/docs/content/docs/user-guide/running-on-hpc.mdx
@@ -122,7 +122,7 @@ stage_overrides:
 | `max_workers_per_node` | Parallel tasks per node | `1` |
 | `max_blocks` | Max concurrent SLURM allocations | `1` |
 | `available_accelerators` | GPU count or device IDs for `CUDA_VISIBLE_DEVICES` | `0` |
-| `retries` | Task retry count | `3` |
+| `retries` | Infrastructure retry count (OOM, timeout, preemption) | `3` |
 | `gmx_binary` | `"auto"`, `"gmx"`, or `"gmx_mpi"` | `"auto"` |
 | `worker_init` | Shell setup (module loads, etc.) | `""` |
 
@@ -137,6 +137,15 @@ mdfactory build systems.csv --output results --slurm slurm_executor.yaml
 # Run the GROMACS chain (parallel on SLURM)
 mdfactory simulate results/ --slurm slurm_executor.yaml
 ```
+
+<Callout type="info" title="Two layers of retry">
+MDFactory has two independent retry mechanisms on SLURM:
+
+- **`retries`** (executor config) — Parsl re-submits the same SLURM job on infrastructure failures (OOM, timeout, node preemption). The command is unchanged.
+- **`--max-rescue`** (CLI flag, default 3) — Automatically halves the step size and doubles `nsteps` for physics failures (LINCS errors, exploding box) in EM/NVT/NPT stages. Use `--max-rescue 0` to disable.
+
+When sizing walltime, account for potential rescue tiers — each tier roughly doubles the wall-clock cost of a rescue-eligible stage.
+</Callout>
 
 ### SLURM job wrapper
 

--- a/docs/content/docs/user-guide/troubleshooting.mdx
+++ b/docs/content/docs/user-guide/troubleshooting.mdx
@@ -109,6 +109,36 @@ mdfactory simulate output_dir/ --slurm gpu.yaml --checkpoint skip
 ```
 
 </Accordion>
+<Accordion title="Simulation fails with LINCS or constraint errors">
+
+MDFactory automatically rescues EM, NVT, and NPT stages that fail with physics errors
+(LINCS warnings, exploding box, coordinate constraint failures). On each rescue tier the
+step size is halved and `nsteps` is doubled to maintain the same elapsed simulation time,
+up to 3 tiers by default.
+
+You will see log messages like:
+
+```
+WARNING — RESCUE tier 1/3 for abc123/EM: using em_rescue_t1.mdp
+WARNING — RESCUE tier 1 for EM: emstep = 0.01 → 0.005
+```
+
+If all rescue tiers are exhausted the simulation is marked as failed. To increase or
+decrease the retry budget:
+
+```bash
+# Allow up to 5 rescue tiers
+mdfactory simulate output_dir/ --max-rescue 5
+
+# Disable rescue entirely
+mdfactory simulate output_dir/ --max-rescue 0
+```
+
+Production stages are never rescued — by that point the system should be stable.
+Infrastructure failures (OOM, SLURM timeout, preemption) are handled separately by
+Parsl's built-in retry mechanism (`retries` in the executor config).
+
+</Accordion>
 <Accordion title="Analysis SLURM submission fails immediately">
 
 `mdfactory analysis ... --slurm` requires:

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -564,6 +564,12 @@ def simulate_systems(
         bool,
         Parameter(help="Preview plan without executing"),
     ] = False,
+    max_rescue: Annotated[
+        int,
+        Parameter(
+            help="Max rescue tiers for physics failures (0 to disable)",
+        ),
+    ] = 3,
 ):
     """Run GROMACS MD simulations via Parsl.
 
@@ -627,6 +633,7 @@ def simulate_systems(
             stages=stages,
             checkpoint_mode=checkpoint,
             dry_run=dry_run,
+            max_rescue=max_rescue,
         )
     except ValueError as exc:
         logger.error(str(exc))

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -98,6 +98,16 @@ class ExecutorConfig(BaseModel):
             "the generated bash script."
         ),
     )
+    max_rescue: int = Field(
+        default=3,
+        ge=0,
+        description=(
+            "Maximum rescue tiers for physics failures (overlapping atoms, "
+            "exploding box, LINCS constraint errors) in EM/NVT/NPT stages. "
+            "Each tier halves the step size and doubles nsteps. "
+            "Set to 0 to disable rescue retry."
+        ),
+    )
 
     @field_validator("run_dir", mode="before")
     @classmethod

--- a/mdfactory/orchestration/errors.py
+++ b/mdfactory/orchestration/errors.py
@@ -1,0 +1,177 @@
+# ABOUTME: GROMACS error classification for rescue retry decisions
+# ABOUTME: Distinguishes physics failures (rescuable) from infrastructure failures
+"""GROMACS error classification for adaptive rescue retry.
+
+Classifies simulation failures as physics-driven (rescuable via parameter
+adjustment) or infrastructure-driven (handled by Parsl's built-in retry).
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from pathlib import Path
+
+from loguru import logger
+
+#: Regex patterns matching GROMACS physics-failure messages in stderr/log.
+#: Each pattern is compiled once at import time for performance.
+_PHYSICS_PATTERNS: list[re.Pattern] = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"LINCS WARNING",
+        r"the coordinate constraints could not be satisfied",
+        r"Particle .+ moved more than",
+        r"The domain decomposition cell size",
+        r"Fatal error.*blowing up",
+        r"step \d+.*: Water molecule starting at",
+        r"Too many LINCS warnings",
+        r"can not continue",
+        r"force .+ is not finite",
+        r"A]?norm(al termination|al end| of program)",
+        r"There are \d+ perturbed non-bonded pair interactions",
+        r"atoms .+ are involved in more than \d+ constraints",
+    ]
+]
+
+
+class FailureType(Enum):
+    """Classification of a simulation stage failure.
+
+    Attributes
+    ----------
+    PHYSICS
+        Failure due to simulation physics (overlapping atoms, box explosion,
+        constraint failures). Rescuable via MDP parameter adjustment.
+    INFRASTRUCTURE
+        Failure due to infrastructure (OOM, timeout, SLURM preemption,
+        filesystem errors). Handled by Parsl's built-in retry.
+    UNKNOWN
+        Failure whose cause could not be determined. Treated as
+        non-rescuable (same as INFRASTRUCTURE).
+
+    """
+
+    PHYSICS = "physics"
+    INFRASTRUCTURE = "infrastructure"
+    UNKNOWN = "unknown"
+
+
+def classify_failure(
+    exc: BaseException,
+    sim_dir: Path | None = None,
+    stage: str | None = None,
+) -> FailureType:
+    """Classify a GROMACS simulation failure.
+
+    Inspects the exception message and, optionally, the GROMACS log file
+    in the simulation directory to determine whether the failure is due
+    to physics (rescuable) or infrastructure.
+
+    Parameters
+    ----------
+    exc : BaseException
+        The exception from a failed Parsl future.
+    sim_dir : Path, optional
+        Simulation directory to check for GROMACS log files.
+    stage : str, optional
+        Stage name (used to locate the correct log file).
+
+    Returns
+    -------
+    FailureType
+        The classified failure type.
+
+    """
+    # Unwrap Parsl's exception wrapping (legacy and modern)
+    underlying = getattr(exc, "e_value", None) or exc
+    error_text = str(underlying)
+
+    # Check the exception message first
+    if _matches_physics_patterns(error_text):
+        return FailureType.PHYSICS
+
+    # Check GROMACS log file if available
+    if sim_dir is not None and stage is not None:
+        log_text = _read_stage_log(sim_dir, stage)
+        if log_text and _matches_physics_patterns(log_text):
+            return FailureType.PHYSICS
+
+    # Check for known infrastructure patterns
+    infra_keywords = [
+        "oom",
+        "out of memory",
+        "killed",
+        "timeout",
+        "time limit",
+        "cancelled",
+        "preempted",
+        "no space left",
+        "disk quota",
+        "connection reset",
+    ]
+    error_lower = error_text.lower()
+    for keyword in infra_keywords:
+        if keyword in error_lower:
+            return FailureType.INFRASTRUCTURE
+
+    logger.debug(f"Could not classify failure: {error_text[:200]}")
+    return FailureType.UNKNOWN
+
+
+def _matches_physics_patterns(text: str) -> bool:
+    """Return True if any physics-failure pattern matches the text.
+
+    Parameters
+    ----------
+    text : str
+        Error message or log content to search.
+
+    Returns
+    -------
+    bool
+
+    """
+    for pattern in _PHYSICS_PATTERNS:
+        if pattern.search(text):
+            return True
+    return False
+
+
+def _read_stage_log(sim_dir: Path, stage: str) -> str:
+    """Read the GROMACS log file for a stage, if it exists.
+
+    Parameters
+    ----------
+    sim_dir : Path
+        Simulation directory.
+    stage : str
+        Stage name.
+
+    Returns
+    -------
+    str
+        Log file content, or empty string if not found.
+
+    """
+    from .stages import STAGE_BY_NAME
+
+    spec = STAGE_BY_NAME.get(stage)
+    if spec is None:
+        return ""
+
+    log_file = sim_dir / f"{spec.deffnm}.log"
+    if not log_file.exists():
+        return ""
+
+    try:
+        # Read only the last 10KB to avoid huge logs
+        size = log_file.stat().st_size
+        with open(log_file) as f:
+            if size > 10240:
+                f.seek(size - 10240)
+                f.readline()  # Skip partial line
+            return f.read()
+    except Exception as e:
+        logger.debug(f"Could not read log file {log_file}: {e}")
+        return ""

--- a/mdfactory/orchestration/errors.py
+++ b/mdfactory/orchestration/errors.py
@@ -28,7 +28,7 @@ _PHYSICS_PATTERNS: list[re.Pattern] = [
         r"Too many LINCS warnings",
         r"can not continue",
         r"force .+ is not finite",
-        r"A]?norm(al termination|al end| of program)",
+        r"Abnorm(al termination|al end| of program)",
         r"There are \d+ perturbed non-bonded pair interactions",
         r"atoms .+ are involved in more than \d+ constraints",
     ]

--- a/mdfactory/orchestration/mdp.py
+++ b/mdfactory/orchestration/mdp.py
@@ -1,0 +1,230 @@
+# ABOUTME: MDP file parser, modifier, and writer for rescue tier parameter adjustment
+# ABOUTME: Supports binary-division rescue strategy (halving step sizes, doubling nsteps)
+"""MDP file utilities for adaptive rescue retry.
+
+Provides functions to parse GROMACS MDP parameter files, modify critical
+parameters for rescue tiers (binary division strategy), and write modified
+files back to disk preserving structure and comments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+#: Parameters modified per stage during rescue.  Each maps parameter name
+#: to the operation applied at each tier: ``"halve"`` divides by 2,
+#: ``"double"`` multiplies by 2.
+RESCUE_PARAMS: dict[str, dict[str, str]] = {
+    "EM": {"emstep": "halve", "nsteps": "double"},
+    "NVT": {"dt": "halve", "nsteps": "double"},
+    "NPT": {"dt": "halve", "nsteps": "double"},
+}
+
+#: Stages eligible for rescue retry (Production is never rescued).
+RESCUE_ELIGIBLE_STAGES: frozenset[str] = frozenset(RESCUE_PARAMS.keys())
+
+
+def parse_mdp(path: Path) -> list[tuple[str, str | None, str | None]]:
+    """Parse an MDP file preserving structure for round-trip modification.
+
+    Each line is returned as a tuple ``(raw_line, key, value)`` where
+    ``key`` and ``value`` are ``None`` for comment/blank lines.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the MDP file.
+
+    Returns
+    -------
+    list[tuple[str, str | None, str | None]]
+        List of ``(raw_line, normalized_key, value_string)`` tuples.
+        Keys are normalized to lowercase with dashes replaced by underscores.
+
+    """
+    lines: list[tuple[str, str | None, str | None]] = []
+    content = path.read_text()
+
+    for raw_line in content.splitlines():
+        # Strip comment portion (everything after ';')
+        stripped = raw_line.split(";")[0].strip()
+        if "=" not in stripped:
+            lines.append((raw_line, None, None))
+            continue
+
+        raw_key, val = stripped.split("=", 1)
+        norm_key = raw_key.strip().lower().replace("-", "_")
+        lines.append((raw_line, norm_key, val.strip()))
+
+    return lines
+
+
+def get_mdp_value(parsed: list[tuple[str, str | None, str | None]], key: str) -> str | None:
+    """Extract the value of a specific key from parsed MDP data.
+
+    Parameters
+    ----------
+    parsed : list
+        Output of :func:`parse_mdp`.
+    key : str
+        Normalized key name (lowercase, underscores).
+
+    Returns
+    -------
+    str or None
+        The value string, or ``None`` if the key is not found.
+
+    """
+    for _, k, v in parsed:
+        if k == key:
+            return v
+    return None
+
+
+def modify_mdp_value(
+    parsed: list[tuple[str, str | None, str | None]],
+    key: str,
+    new_value: str,
+) -> list[tuple[str, str | None, str | None]]:
+    """Return a copy of parsed MDP with one key's value replaced.
+
+    The raw line is reconstructed to preserve the key's original casing
+    and surrounding whitespace as much as possible.
+
+    Parameters
+    ----------
+    parsed : list
+        Output of :func:`parse_mdp`.
+    key : str
+        Normalized key to modify.
+    new_value : str
+        New value string.
+
+    Returns
+    -------
+    list
+        Modified parsed list (new copy).
+
+    """
+    result = []
+    for raw_line, k, v in parsed:
+        if k == key:
+            # Reconstruct: keep everything before '=' and any trailing comment
+            parts = raw_line.split(";", 1)
+            assignment = parts[0]
+            comment = f";{parts[1]}" if len(parts) > 1 else ""
+
+            eq_idx = assignment.index("=")
+            prefix = assignment[: eq_idx + 1]  # "key    ="
+            # Preserve spacing after '=' if possible
+            after_eq = assignment[eq_idx + 1 :]
+            leading_spaces = len(after_eq) - len(after_eq.lstrip())
+            spacing = " " * max(leading_spaces, 1)
+
+            new_raw = f"{prefix}{spacing}{new_value}"
+            if comment:
+                # Pad to roughly original width for alignment
+                new_raw = f"{new_raw:<{len(assignment)}}{comment}"
+            result.append((new_raw, k, new_value))
+        else:
+            result.append((raw_line, k, v))
+    return result
+
+
+def write_mdp(parsed: list[tuple[str, str | None, str | None]], path: Path) -> None:
+    """Write parsed (possibly modified) MDP data back to a file.
+
+    Parameters
+    ----------
+    parsed : list
+        Parsed MDP data (from :func:`parse_mdp` or :func:`modify_mdp_value`).
+    path : Path
+        Output file path.
+
+    """
+    lines = [raw_line for raw_line, _, _ in parsed]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def apply_rescue_tier(sim_dir: Path, stage: str, tier: int) -> Path:
+    """Apply rescue-tier parameter modifications to a stage's MDP file.
+
+    Reads the stage's standard MDP file, applies binary-division
+    modifications for the given tier, and writes the result to a
+    rescue-specific filename (e.g. ``em_rescue_t1.mdp``).
+
+    Parameters
+    ----------
+    sim_dir : Path
+        Simulation directory containing the MDP file.
+    stage : str
+        Stage name (``"EM"``, ``"NVT"``, ``"NPT"``).
+    tier : int
+        Rescue tier (1-based). Each tier halves/doubles parameters
+        relative to the original (not the previous tier).
+
+    Returns
+    -------
+    Path
+        Path to the written rescue MDP file.
+
+    Raises
+    ------
+    ValueError
+        If the stage is not rescue-eligible or the tier is < 1.
+    FileNotFoundError
+        If the source MDP file does not exist.
+
+    """
+    if stage not in RESCUE_PARAMS:
+        raise ValueError(f"Stage {stage!r} is not rescue-eligible. Valid: {sorted(RESCUE_PARAMS)}")
+    if tier < 1:
+        raise ValueError(f"Rescue tier must be >= 1, got {tier}")
+
+    from .stages import STAGE_BY_NAME
+
+    spec = STAGE_BY_NAME[stage]
+    source_mdp = sim_dir / spec.mdp_file
+
+    if not source_mdp.exists():
+        raise FileNotFoundError(f"Source MDP not found: {source_mdp}")
+
+    parsed = parse_mdp(source_mdp)
+    params = RESCUE_PARAMS[stage]
+
+    for param, operation in params.items():
+        current_val = get_mdp_value(parsed, param)
+        if current_val is None:
+            logger.warning(f"MDP parameter {param!r} not found in {source_mdp}, skipping")
+            continue
+
+        try:
+            numeric = float(current_val)
+        except ValueError:
+            logger.warning(f"Cannot parse {param}={current_val!r} as number, skipping")
+            continue
+
+        if operation == "halve":
+            new_val = numeric / (2**tier)
+        elif operation == "double":
+            new_val = numeric * (2**tier)
+        else:
+            raise ValueError(f"Unknown operation: {operation!r}")
+
+        # Format: use int if the result is a whole number, else float
+        if new_val == int(new_val) and "." not in current_val:
+            formatted = str(int(new_val))
+        else:
+            formatted = f"{new_val:g}"
+
+        logger.warning(f"RESCUE tier {tier} for {stage}: {param} = {current_val} → {formatted}")
+        parsed = modify_mdp_value(parsed, param, formatted)
+
+    # Write rescue MDP with tier-specific name
+    rescue_name = f"{spec.mdp_file.rsplit('.', 1)[0]}_rescue_t{tier}.mdp"
+    rescue_path = sim_dir / rescue_name
+    write_mdp(parsed, rescue_path)
+
+    return rescue_path

--- a/mdfactory/orchestration/rescue.py
+++ b/mdfactory/orchestration/rescue.py
@@ -1,0 +1,157 @@
+# ABOUTME: Rescue retry loop for GROMACS physics failures
+# ABOUTME: Retries failed stages with halved MDP parameters (binary division)
+"""Adaptive rescue retry for GROMACS simulation stages.
+
+When a stage fails due to a physics error (overlapping atoms, exploding box,
+constraint failures), the rescue loop modifies MDP parameters using binary
+division (halving step sizes, doubling nsteps) and re-submits the stage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from .errors import FailureType, classify_failure
+from .mdp import apply_rescue_tier
+from .stages import STAGE_BY_NAME, run_stage
+
+if TYPE_CHECKING:
+    from parsl import AppFuture
+
+    from .config import ExecutorConfig
+
+
+def _clean_partial_outputs(sim_dir: Path, stage: str) -> None:
+    """Remove partial outputs from a failed stage so it can be re-run cleanly.
+
+    Removes the ``.tpr``, ``.cpt``, ``.gro`` output, ``.log``, ``.edr``,
+    and trajectory files for the given stage.
+
+    Parameters
+    ----------
+    sim_dir : Path
+        Simulation directory.
+    stage : str
+        Stage name.
+
+    """
+    spec = STAGE_BY_NAME[stage]
+    candidates = [
+        spec.tpr_file,
+        spec.cpt_file,
+        spec.gro_out,
+        f"{spec.deffnm}.log",
+        f"{spec.deffnm}.edr",
+    ]
+    candidates.extend(spec.traj_files)
+
+    for fname in candidates:
+        if not fname:
+            continue
+        f = sim_dir / fname
+        if f.exists():
+            f.unlink()
+            logger.debug(f"Removed partial output: {f}")
+
+
+def execute_stage_with_rescue(
+    sim_dir: Path,
+    stage: str,
+    prev_future: "AppFuture | None",
+    grompp_app,
+    mdrun_app,
+    *,
+    max_rescue: int = 3,
+    config: "ExecutorConfig | None" = None,
+) -> "AppFuture":
+    """Execute a single stage with adaptive rescue on physics failures.
+
+    Submits the stage and waits for its result.  If the stage fails with
+    a physics error and rescue tiers remain, modifies the MDP parameters
+    (binary division), cleans partial outputs, and re-submits.
+
+    Parameters
+    ----------
+    sim_dir : Path
+        Simulation directory.
+    stage : str
+        Stage name (must be in :data:`RESCUE_ELIGIBLE_STAGES`).
+    prev_future : AppFuture or None
+        Dependency future from the preceding stage.
+    grompp_app : callable
+        Result of :func:`~mdfactory.orchestration.apps.get_grompp_app`.
+    mdrun_app : callable
+        Result of :func:`~mdfactory.orchestration.apps.get_mdrun_app`.
+    max_rescue : int
+        Maximum number of rescue tiers to attempt.
+    config : ExecutorConfig or None, optional
+        Executor configuration for per-stage resource hints.
+
+    Returns
+    -------
+    AppFuture
+        A completed future (already resolved — the result has been waited on).
+
+    Raises
+    ------
+    Exception
+        Re-raises the stage failure if rescue is exhausted or the failure
+        is not physics-related.
+
+    """
+    spec = STAGE_BY_NAME[stage]
+    stage_cfg = config.get_stage_config(stage) if hasattr(config, "get_stage_config") else None
+    cfg_kwarg: dict[str, Any] = {"stage_config": stage_cfg} if stage_cfg is not None else {}
+
+    for tier in range(max_rescue + 1):
+        mdp_override = None
+        if tier > 0:
+            # Apply rescue tier modifications
+            rescue_mdp = apply_rescue_tier(sim_dir, stage, tier)
+            mdp_override = rescue_mdp.name
+            logger.warning(
+                f"RESCUE tier {tier}/{max_rescue} for {sim_dir.name}/{stage}: using {mdp_override}"
+            )
+
+        future = run_stage(
+            spec,
+            sim_dir,
+            prev_future,
+            grompp_app,
+            mdrun_app,
+            mdp_override=mdp_override,
+            **cfg_kwarg,
+        )
+
+        try:
+            future.result()
+            if tier > 0:
+                logger.warning(f"RESCUE succeeded for {sim_dir.name}/{stage} at tier {tier}")
+            return future
+        except Exception as exc:
+            failure_type = classify_failure(exc, sim_dir, stage)
+
+            if failure_type != FailureType.PHYSICS:
+                logger.debug(
+                    f"{sim_dir.name}/{stage}: non-physics failure "
+                    f"({failure_type.value}), not rescuable"
+                )
+                raise
+
+            if tier >= max_rescue:
+                logger.error(
+                    f"RESCUE exhausted for {sim_dir.name}/{stage} after {max_rescue} tier(s)"
+                )
+                raise
+
+            logger.warning(
+                f"{sim_dir.name}/{stage}: physics failure detected, "
+                f"will attempt rescue tier {tier + 1}"
+            )
+            _clean_partial_outputs(sim_dir, stage)
+
+    # Unreachable — the loop always returns or raises
+    raise RuntimeError("Rescue loop exited unexpectedly")  # pragma: no cover

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -71,6 +71,7 @@ def run_simulations(
     wait: bool = True,
     dry_run: bool = False,
     checkpoint_mode: str = "auto",
+    max_rescue: int = 3,
 ) -> list[dict]:
     """Orchestrate GROMACS simulations via Parsl.
 
@@ -90,6 +91,10 @@ def run_simulations(
         - "auto": Skip stages with valid outputs (default)
         - "skip": Never re-run completed stages
         - "force": Overwrite all stages
+    max_rescue : int
+        Maximum number of rescue tiers for physics failures in EM/NVT/NPT
+        stages. Each tier halves the step size and doubles nsteps. Set to 0
+        to disable rescue. Default: 3.
 
     Returns
     -------
@@ -194,6 +199,7 @@ def run_simulations(
                 mdrun_app,
                 stage_restarts=item.get("stage_restarts"),
                 config=config,
+                max_rescue=max_rescue,
             )
             futures.append((item["hash"], pipeline_fut))
 
@@ -551,11 +557,16 @@ def _execute_stage_list(
     mdrun_app,
     stage_restarts: "dict[str, str] | None" = None,
     config: "ExecutorConfig | None" = None,
+    max_rescue: int = 3,
 ) -> "AppFuture | None":
     """Execute a list of stages with automatic dependency chaining.
 
     Explicitly calls stage functions based on the needed_stages list,
     validating stage ordering and chaining dependencies via inputs=[].
+
+    For rescue-eligible stages (EM, NVT, NPT) with ``max_rescue > 0``,
+    physics failures trigger automatic rescue retry with halved MDP
+    parameters.  See :mod:`mdfactory.orchestration.rescue` for details.
 
     Parameters
     ----------
@@ -577,6 +588,9 @@ def _execute_stage_list(
         provided, per-stage resource overrides are applied via
         :meth:`~mdfactory.orchestration.config.SlurmExecutorConfig.get_stage_config`
         before each stage function call.
+    max_rescue : int
+        Maximum rescue tiers for physics failures in EM/NVT/NPT stages.
+        Set to 0 to disable rescue.
 
     Returns
     -------
@@ -613,23 +627,50 @@ def _execute_stage_list(
     # becomes immediately executable here without further edits to this module.
     # prev_future=None on the first iteration is handled correctly by run_stage
     # for all stages (including non-EM checkpoint resumes).
+    #
+    # Rescue-eligible stages (EM/NVT/NPT) with max_rescue > 0 use the rescue
+    # loop which waits for each stage individually.  Non-rescue stages and
+    # stages with checkpoint restarts chain futures as before.
+    from .mdp import RESCUE_ELIGIBLE_STAGES
+
     prev_future = None
     for stage in stages:
         cpt_file = restarts.get(stage, "")
-        # Resolve per-stage resource overrides when a SlurmExecutorConfig is given.
-        # Only inject stage_config kwarg when non-None to avoid polluting mock
-        # assertions in tests that don't exercise per-stage config.
-        stage_cfg = config.get_stage_config(stage) if hasattr(config, "get_stage_config") else None
-        cfg_kwarg = {"stage_config": stage_cfg} if stage_cfg is not None else {}
-        prev_future = run_stage(
-            STAGE_BY_NAME[stage],
-            sim_dir,
-            prev_future,
-            grompp_app,
-            mdrun_app,
-            restart_from_cpt=cpt_file,
-            **cfg_kwarg,
-        )
+
+        # Use rescue loop for eligible stages without checkpoint restart
+        if (
+            max_rescue > 0
+            and stage in RESCUE_ELIGIBLE_STAGES
+            and not cpt_file
+        ):
+            from .rescue import execute_stage_with_rescue
+
+            prev_future = execute_stage_with_rescue(
+                sim_dir,
+                stage,
+                prev_future,
+                grompp_app,
+                mdrun_app,
+                max_rescue=max_rescue,
+                config=config,
+            )
+        else:
+            # Standard execution: chain futures without waiting
+            stage_cfg = (
+                config.get_stage_config(stage)
+                if hasattr(config, "get_stage_config")
+                else None
+            )
+            cfg_kwarg = {"stage_config": stage_cfg} if stage_cfg is not None else {}
+            prev_future = run_stage(
+                STAGE_BY_NAME[stage],
+                sim_dir,
+                prev_future,
+                grompp_app,
+                mdrun_app,
+                restart_from_cpt=cpt_file,
+                **cfg_kwarg,
+            )
 
     return prev_future
 

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -185,23 +185,41 @@ def run_simulations(
         mdrun_app = get_mdrun_app()
 
         # 6. Submit all pipelines (embarrassingly parallel)
+        # When rescue is active (max_rescue > 0), each simulation's
+        # pipeline may block internally while waiting for rescue-eligible
+        # stages.  Using ThreadPoolExecutor ensures cross-simulation
+        # parallelism is preserved — one simulation's rescue wait doesn't
+        # block other simulations from being submitted and executing.
+        from concurrent.futures import ThreadPoolExecutor
+
         futures = []
+        active_items = []
         for item in work_plan:
             if not item["stages"]:
                 logger.info(f"Skipping {item['hash']} (all stages complete)")
                 continue
+            active_items.append(item)
 
-            # Execute only the needed stages with explicit control
-            pipeline_fut = _execute_stage_list(
-                item["sim_dir"],
-                item["stages"],
-                grompp_app,
-                mdrun_app,
-                stage_restarts=item.get("stage_restarts"),
-                config=config,
-                max_rescue=max_rescue,
-            )
-            futures.append((item["hash"], pipeline_fut))
+        if active_items:
+
+            def _run_pipeline(item):
+                return _execute_stage_list(
+                    item["sim_dir"],
+                    item["stages"],
+                    grompp_app,
+                    mdrun_app,
+                    stage_restarts=item.get("stage_restarts"),
+                    config=config,
+                    max_rescue=max_rescue,
+                )
+
+            with ThreadPoolExecutor() as pool:
+                thread_futs = [
+                    (item["hash"], pool.submit(_run_pipeline, item))
+                    for item in active_items
+                ]
+                for h, tf in thread_futs:
+                    futures.append((h, tf.result()))
 
         logger.info(f"Submitted {len(futures)} simulation(s)")
 
@@ -632,6 +650,7 @@ def _execute_stage_list(
     # loop which waits for each stage individually.  Non-rescue stages and
     # stages with checkpoint restarts chain futures as before.
     from .mdp import RESCUE_ELIGIBLE_STAGES
+    from .rescue import execute_stage_with_rescue
 
     prev_future = None
     for stage in stages:
@@ -643,8 +662,6 @@ def _execute_stage_list(
             and stage in RESCUE_ELIGIBLE_STAGES
             and not cpt_file
         ):
-            from .rescue import execute_stage_with_rescue
-
             prev_future = execute_stage_with_rescue(
                 sim_dir,
                 stage,

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -190,6 +190,7 @@ def run_simulations(
         # stages.  Using ThreadPoolExecutor ensures cross-simulation
         # parallelism is preserved — one simulation's rescue wait doesn't
         # block other simulations from being submitted and executing.
+        from concurrent.futures import Future as StdFuture
         from concurrent.futures import ThreadPoolExecutor
 
         futures = []
@@ -219,7 +220,18 @@ def run_simulations(
                     for item in active_items
                 ]
                 for h, tf in thread_futs:
-                    futures.append((h, tf.result()))
+                    try:
+                        futures.append((h, tf.result()))
+                    except Exception as exc:
+                        # Rescue exhaustion or other pipeline-level failure.
+                        # Wrap in a pre-failed future so _wait_with_progress
+                        # handles it per-simulation (matching pre-rescue
+                        # behavior where individual failures didn't crash
+                        # the batch).
+                        logger.error(f"Pipeline failed for {h}: {exc}")
+                        failed_fut = StdFuture()
+                        failed_fut.set_exception(exc)
+                        futures.append((h, failed_fut))
 
         logger.info(f"Submitted {len(futures)} simulation(s)")
 

--- a/mdfactory/orchestration/stages.py
+++ b/mdfactory/orchestration/stages.py
@@ -198,6 +198,7 @@ def run_stage(
     mdrun_app,
     restart_from_cpt: str = "",
     stage_config: Any = None,
+    mdp_override: str | None = None,
 ) -> "AppFuture":
     """Execute a single GROMACS pipeline stage.
 
@@ -228,6 +229,10 @@ def run_stage(
     stage_config : SlurmExecutorConfig or None, optional
         Per-stage resource config.  Resource hints (thread count, GPU disable)
         are extracted and forwarded to the mdrun bash app.
+    mdp_override : str or None, optional
+        Alternative MDP filename to use instead of ``spec.mdp_file``.
+        Used by the rescue retry system to pass modified MDP files
+        (e.g. ``"em_rescue_t1.mdp"``).
 
     Returns
     -------
@@ -257,7 +262,7 @@ def run_stage(
     grompp_inputs = [prev_future] if prev_future is not None else []
 
     grompp_kwargs: dict[str, Any] = {
-        "mdp_file": spec.mdp_file,
+        "mdp_file": mdp_override if mdp_override else spec.mdp_file,
         "gro_file": spec.gro_in,
         "top_file": "topology.top",
         "tpr_file": spec.tpr_file,

--- a/mdfactory/tests/test_orchestration_errors.py
+++ b/mdfactory/tests/test_orchestration_errors.py
@@ -30,6 +30,32 @@ class TestMatchesPhysicsPatterns:
     def test_force_not_finite(self):
         assert _matches_physics_patterns("force 1.#INF is not finite")
 
+    def test_water_molecule_starting_at(self):
+        assert _matches_physics_patterns(
+            "step 1000: Water molecule starting at (1.2, 3.4, 5.6) "
+            "cannot be settled"
+        )
+
+    def test_too_many_lincs_warnings(self):
+        assert _matches_physics_patterns("Too many LINCS warnings")
+
+    def test_can_not_continue(self):
+        assert _matches_physics_patterns("can not continue")
+
+    def test_abnormal_termination(self):
+        assert _matches_physics_patterns("Abnormal termination of GROMACS")
+
+    def test_perturbed_nonbonded_pairs(self):
+        assert _matches_physics_patterns(
+            "There are 42 perturbed non-bonded pair interactions "
+            "beyond the pair-list cutoff"
+        )
+
+    def test_atoms_too_many_constraints(self):
+        assert _matches_physics_patterns(
+            "atoms 123 and 456 are involved in more than 6 constraints"
+        )
+
     def test_normal_output_no_match(self):
         assert not _matches_physics_patterns("Step 1000, time 2.0 ps")
 

--- a/mdfactory/tests/test_orchestration_errors.py
+++ b/mdfactory/tests/test_orchestration_errors.py
@@ -1,0 +1,96 @@
+# ABOUTME: Tests for GROMACS error classification
+# ABOUTME: Verifies physics vs infrastructure failure detection
+"""Tests for mdfactory.orchestration.errors."""
+
+from mdfactory.orchestration.errors import (
+    FailureType,
+    _matches_physics_patterns,
+    classify_failure,
+)
+
+
+class TestMatchesPhysicsPatterns:
+    def test_lincs_warning(self):
+        assert _matches_physics_patterns("LINCS WARNING: relative constraint deviation")
+
+    def test_coordinate_constraints(self):
+        assert _matches_physics_patterns(
+            "step 1234: the coordinate constraints could not be satisfied"
+        )
+
+    def test_particle_moved(self):
+        assert _matches_physics_patterns("Particle 42 in box 3 moved more than 5.0 nm")
+
+    def test_domain_decomposition(self):
+        assert _matches_physics_patterns("The domain decomposition cell size is too small")
+
+    def test_blowing_up(self):
+        assert _matches_physics_patterns("Fatal error: blowing up")
+
+    def test_force_not_finite(self):
+        assert _matches_physics_patterns("force 1.#INF is not finite")
+
+    def test_normal_output_no_match(self):
+        assert not _matches_physics_patterns("Step 1000, time 2.0 ps")
+
+    def test_empty_string_no_match(self):
+        assert not _matches_physics_patterns("")
+
+
+class TestClassifyFailure:
+    def test_physics_from_exception_message(self):
+        exc = RuntimeError("LINCS WARNING: bonds to H are constrained")
+        assert classify_failure(exc) == FailureType.PHYSICS
+
+    def test_physics_from_coordinate_error(self):
+        exc = RuntimeError("step 500: the coordinate constraints could not be satisfied")
+        assert classify_failure(exc) == FailureType.PHYSICS
+
+    def test_infrastructure_oom(self):
+        exc = RuntimeError("slurmstepd: error: Detected 1 oom-kill event")
+        assert classify_failure(exc) == FailureType.INFRASTRUCTURE
+
+    def test_infrastructure_timeout(self):
+        exc = RuntimeError("JOB 12345 CANCELLED AT DUE TO TIME LIMIT")
+        assert classify_failure(exc) == FailureType.INFRASTRUCTURE
+
+    def test_infrastructure_preempted(self):
+        exc = RuntimeError("Job was preempted by higher priority job")
+        assert classify_failure(exc) == FailureType.INFRASTRUCTURE
+
+    def test_unknown_for_generic_error(self):
+        exc = RuntimeError("Something went wrong")
+        assert classify_failure(exc) == FailureType.UNKNOWN
+
+    def test_unwraps_parsl_legacy_exception(self):
+        class LegacyWrapper(Exception):
+            pass
+
+        exc = LegacyWrapper("wrapper")
+        exc.e_value = RuntimeError("LINCS WARNING in bonds")
+        assert classify_failure(exc) == FailureType.PHYSICS
+
+    def test_physics_from_log_file(self, tmp_path, monkeypatch):
+        from mdfactory.orchestration.stages import StageSpec
+
+        mock_spec = StageSpec(
+            name="EM",
+            deffnm="min",
+            mdp_file="em.mdp",
+            gro_in="system.pdb",
+            gro_out="min.gro",
+            tpr_file="min.tpr",
+            cpt_file="min.cpt",
+            prereq_cpt=None,
+            traj_files=(),
+            ref_file=None,
+            maxwarn=1,
+            supports_pme_gpu=False,
+        )
+        monkeypatch.setattr("mdfactory.orchestration.stages.STAGE_BY_NAME", {"EM": mock_spec})
+        log_file = tmp_path / "min.log"
+        log_file.write_text("Step 100\nLINCS WARNING\nStep 101\n")
+
+        exc = RuntimeError("Process returned non-zero exit code 1")
+        result = classify_failure(exc, sim_dir=tmp_path, stage="EM")
+        assert result == FailureType.PHYSICS

--- a/mdfactory/tests/test_orchestration_mdp.py
+++ b/mdfactory/tests/test_orchestration_mdp.py
@@ -1,0 +1,218 @@
+# ABOUTME: Tests for MDP parser/modifier used in rescue retry
+# ABOUTME: Verifies parsing, modification, and binary-division rescue tier logic
+"""Tests for mdfactory.orchestration.mdp."""
+
+import pytest
+
+from mdfactory.orchestration.mdp import (
+    RESCUE_ELIGIBLE_STAGES,
+    RESCUE_PARAMS,
+    apply_rescue_tier,
+    get_mdp_value,
+    modify_mdp_value,
+    parse_mdp,
+    write_mdp,
+)
+
+
+@pytest.fixture
+def em_mdp(tmp_path):
+    """Create a minimal EM MDP file."""
+    content = """; minim.mdp
+integrator  = steep
+emtol       = 1000.0        ; Stop at max force < 1000
+emstep      = 0.01          ; Step size
+nsteps      = 50000         ; Max steps
+nstlist     = 1
+"""
+    p = tmp_path / "em.mdp"
+    p.write_text(content)
+    return p
+
+
+@pytest.fixture
+def nvt_mdp(tmp_path):
+    """Create a minimal NVT MDP file."""
+    content = """; NVT equilibration
+integrator  = md
+dt          = 0.002         ; 2 fs
+nsteps      = 50000         ; 100 ps
+constraints = h-bonds
+"""
+    p = tmp_path / "nvt.mdp"
+    p.write_text(content)
+    return p
+
+
+class TestParseMdp:
+    def test_parses_key_value_pairs(self, em_mdp):
+        parsed = parse_mdp(em_mdp)
+        assert get_mdp_value(parsed, "integrator") == "steep"
+        assert get_mdp_value(parsed, "emtol") == "1000.0"
+        assert get_mdp_value(parsed, "emstep") == "0.01"
+        assert get_mdp_value(parsed, "nsteps") == "50000"
+
+    def test_preserves_comment_lines(self, em_mdp):
+        parsed = parse_mdp(em_mdp)
+        assert parsed[0][1] is None
+        assert parsed[0][2] is None
+
+    def test_handles_semicolon_inline_comments(self, em_mdp):
+        parsed = parse_mdp(em_mdp)
+        assert get_mdp_value(parsed, "emtol") == "1000.0"
+
+    def test_normalizes_dashes_to_underscores(self, tmp_path):
+        p = tmp_path / "test.mdp"
+        p.write_text("lincs-iter = 2\nnstxout-compressed = 500\n")
+        parsed = parse_mdp(p)
+        assert get_mdp_value(parsed, "lincs_iter") == "2"
+        assert get_mdp_value(parsed, "nstxout_compressed") == "500"
+
+    def test_missing_key_returns_none(self, em_mdp):
+        parsed = parse_mdp(em_mdp)
+        assert get_mdp_value(parsed, "nonexistent") is None
+
+
+class TestModifyMdpValue:
+    def test_replaces_value(self, em_mdp):
+        parsed = parse_mdp(em_mdp)
+        modified = modify_mdp_value(parsed, "emstep", "0.005")
+        assert get_mdp_value(modified, "emstep") == "0.005"
+
+    def test_preserves_other_values(self, em_mdp):
+        parsed = parse_mdp(em_mdp)
+        modified = modify_mdp_value(parsed, "emstep", "0.005")
+        assert get_mdp_value(modified, "nsteps") == "50000"
+        assert get_mdp_value(modified, "emtol") == "1000.0"
+
+
+class TestWriteMdp:
+    def test_roundtrip_preserves_structure(self, em_mdp, tmp_path):
+        parsed = parse_mdp(em_mdp)
+        out = tmp_path / "out.mdp"
+        write_mdp(parsed, out)
+        reparsed = parse_mdp(out)
+        assert get_mdp_value(reparsed, "emstep") == "0.01"
+        assert get_mdp_value(reparsed, "nsteps") == "50000"
+
+    def test_modified_roundtrip(self, em_mdp, tmp_path):
+        parsed = parse_mdp(em_mdp)
+        modified = modify_mdp_value(parsed, "emstep", "0.005")
+        out = tmp_path / "modified.mdp"
+        write_mdp(modified, out)
+        reparsed = parse_mdp(out)
+        assert get_mdp_value(reparsed, "emstep") == "0.005"
+
+
+class TestApplyRescueTier:
+    def test_em_tier1_halves_emstep_doubles_nsteps(self, tmp_path, em_mdp, monkeypatch):
+        from mdfactory.orchestration.stages import StageSpec
+
+        mock_spec = StageSpec(
+            name="EM",
+            deffnm="min",
+            mdp_file="em.mdp",
+            gro_in="system.pdb",
+            gro_out="min.gro",
+            tpr_file="min.tpr",
+            cpt_file="min.cpt",
+            prereq_cpt=None,
+            traj_files=(),
+            ref_file=None,
+            maxwarn=1,
+            supports_pme_gpu=False,
+        )
+        monkeypatch.setattr("mdfactory.orchestration.stages.STAGE_BY_NAME", {"EM": mock_spec})
+        rescue_path = apply_rescue_tier(tmp_path, "EM", 1)
+        assert rescue_path.name == "em_rescue_t1.mdp"
+        assert rescue_path.exists()
+        parsed = parse_mdp(rescue_path)
+        assert get_mdp_value(parsed, "emstep") == "0.005"
+        assert get_mdp_value(parsed, "nsteps") == "100000"
+
+    def test_em_tier2_compounds(self, tmp_path, em_mdp, monkeypatch):
+        from mdfactory.orchestration.stages import StageSpec
+
+        mock_spec = StageSpec(
+            name="EM",
+            deffnm="min",
+            mdp_file="em.mdp",
+            gro_in="system.pdb",
+            gro_out="min.gro",
+            tpr_file="min.tpr",
+            cpt_file="min.cpt",
+            prereq_cpt=None,
+            traj_files=(),
+            ref_file=None,
+            maxwarn=1,
+            supports_pme_gpu=False,
+        )
+        monkeypatch.setattr("mdfactory.orchestration.stages.STAGE_BY_NAME", {"EM": mock_spec})
+        rescue_path = apply_rescue_tier(tmp_path, "EM", 2)
+        parsed = parse_mdp(rescue_path)
+        assert get_mdp_value(parsed, "emstep") == "0.0025"
+        assert get_mdp_value(parsed, "nsteps") == "200000"
+
+    def test_nvt_tier1_halves_dt_doubles_nsteps(self, tmp_path, nvt_mdp, monkeypatch):
+        from mdfactory.orchestration.stages import StageSpec
+
+        mock_spec = StageSpec(
+            name="NVT",
+            deffnm="nvt",
+            mdp_file="nvt.mdp",
+            gro_in="min.gro",
+            gro_out="nvt.gro",
+            tpr_file="nvt.tpr",
+            cpt_file="nvt.cpt",
+            prereq_cpt=None,
+            traj_files=(),
+            ref_file="min.gro",
+            maxwarn=1,
+            supports_pme_gpu=True,
+        )
+        monkeypatch.setattr("mdfactory.orchestration.stages.STAGE_BY_NAME", {"NVT": mock_spec})
+        rescue_path = apply_rescue_tier(tmp_path, "NVT", 1)
+        assert rescue_path.name == "nvt_rescue_t1.mdp"
+        parsed = parse_mdp(rescue_path)
+        assert get_mdp_value(parsed, "dt") == "0.001"
+        assert get_mdp_value(parsed, "nsteps") == "100000"
+
+    def test_invalid_stage_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="not rescue-eligible"):
+            apply_rescue_tier(tmp_path, "Production", 1)
+
+    def test_tier_zero_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="tier must be >= 1"):
+            apply_rescue_tier(tmp_path, "EM", 0)
+
+    def test_missing_mdp_raises(self, tmp_path, monkeypatch):
+        from mdfactory.orchestration.stages import StageSpec
+
+        mock_spec = StageSpec(
+            name="EM",
+            deffnm="min",
+            mdp_file="em.mdp",
+            gro_in="system.pdb",
+            gro_out="min.gro",
+            tpr_file="min.tpr",
+            cpt_file="min.cpt",
+            prereq_cpt=None,
+            traj_files=(),
+            ref_file=None,
+            maxwarn=1,
+            supports_pme_gpu=False,
+        )
+        monkeypatch.setattr("mdfactory.orchestration.stages.STAGE_BY_NAME", {"EM": mock_spec})
+        with pytest.raises(FileNotFoundError):
+            apply_rescue_tier(tmp_path, "EM", 1)
+
+
+class TestRescueConstants:
+    def test_eligible_stages(self):
+        assert RESCUE_ELIGIBLE_STAGES == {"EM", "NVT", "NPT"}
+
+    def test_production_not_eligible(self):
+        assert "Production" not in RESCUE_ELIGIBLE_STAGES
+
+    def test_rescue_params_keys_match_eligible(self):
+        assert set(RESCUE_PARAMS.keys()) == RESCUE_ELIGIBLE_STAGES

--- a/mdfactory/tests/test_orchestration_rescue.py
+++ b/mdfactory/tests/test_orchestration_rescue.py
@@ -1,0 +1,139 @@
+# ABOUTME: Tests for rescue retry loop
+# ABOUTME: Verifies rescue activation, tier progression, and failure handling
+"""Tests for mdfactory.orchestration.rescue."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mdfactory.orchestration.errors import FailureType
+from mdfactory.orchestration.rescue import (
+    _clean_partial_outputs,
+    execute_stage_with_rescue,
+)
+
+
+@pytest.fixture
+def sim_dir(tmp_path):
+    """Create a simulation directory with MDP files."""
+    (tmp_path / "em.mdp").write_text("integrator = steep\nemstep = 0.01\nnsteps = 50000\n")
+    (tmp_path / "nvt.mdp").write_text("integrator = md\ndt = 0.002\nnsteps = 50000\n")
+    (tmp_path / "system.pdb").touch()
+    (tmp_path / "topology.top").touch()
+    return tmp_path
+
+
+class TestCleanPartialOutputs:
+    def test_removes_stage_files(self, tmp_path):
+        (tmp_path / "min.tpr").touch()
+        (tmp_path / "min.cpt").touch()
+        (tmp_path / "min.gro").touch()
+        (tmp_path / "min.log").touch()
+        (tmp_path / "min.edr").touch()
+
+        _clean_partial_outputs(tmp_path, "EM")
+
+        assert not (tmp_path / "min.tpr").exists()
+        assert not (tmp_path / "min.cpt").exists()
+        assert not (tmp_path / "min.gro").exists()
+        assert not (tmp_path / "min.log").exists()
+        assert not (tmp_path / "min.edr").exists()
+
+    def test_handles_missing_files_gracefully(self, tmp_path):
+        _clean_partial_outputs(tmp_path, "EM")
+
+    def test_production_cleans_trajectory(self, tmp_path):
+        (tmp_path / "prod.xtc").touch()
+        (tmp_path / "prod.trr").touch()
+        (tmp_path / "prod.tpr").touch()
+        _clean_partial_outputs(tmp_path, "Production")
+        assert not (tmp_path / "prod.xtc").exists()
+        assert not (tmp_path / "prod.trr").exists()
+
+
+class TestExecuteStageWithRescue:
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_success_on_first_try(self, mock_run_stage, sim_dir):
+        mock_future = MagicMock()
+        mock_future.result.return_value = None
+        mock_run_stage.return_value = mock_future
+
+        result = execute_stage_with_rescue(
+            sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3
+        )
+        assert result is mock_future
+        assert mock_run_stage.call_count == 1
+
+    @patch("mdfactory.orchestration.rescue.classify_failure")
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_rescue_on_physics_failure(self, mock_run_stage, mock_classify, sim_dir):
+        fail_future = MagicMock()
+        fail_future.result.side_effect = RuntimeError("LINCS WARNING")
+        success_future = MagicMock()
+        success_future.result.return_value = None
+        mock_run_stage.side_effect = [fail_future, success_future]
+        mock_classify.return_value = FailureType.PHYSICS
+
+        result = execute_stage_with_rescue(
+            sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3
+        )
+        assert result is success_future
+        assert mock_run_stage.call_count == 2
+        assert (sim_dir / "em_rescue_t1.mdp").exists()
+
+    @patch("mdfactory.orchestration.rescue.classify_failure")
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_rescue_exhausted_raises(self, mock_run_stage, mock_classify, sim_dir):
+        fail_future = MagicMock()
+        fail_future.result.side_effect = RuntimeError("LINCS WARNING")
+        mock_run_stage.return_value = fail_future
+        mock_classify.return_value = FailureType.PHYSICS
+
+        with pytest.raises(RuntimeError, match="LINCS WARNING"):
+            execute_stage_with_rescue(sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=2)
+        # tier 0 + tier 1 + tier 2 = 3 attempts
+        assert mock_run_stage.call_count == 3
+
+    @patch("mdfactory.orchestration.rescue.classify_failure")
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_infra_failure_not_rescued(self, mock_run_stage, mock_classify, sim_dir):
+        fail_future = MagicMock()
+        fail_future.result.side_effect = RuntimeError("Out of memory")
+        mock_run_stage.return_value = fail_future
+        mock_classify.return_value = FailureType.INFRASTRUCTURE
+
+        with pytest.raises(RuntimeError, match="Out of memory"):
+            execute_stage_with_rescue(sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3)
+        assert mock_run_stage.call_count == 1
+
+    @patch("mdfactory.orchestration.rescue.classify_failure")
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_mdp_override_passed_to_run_stage(self, mock_run_stage, mock_classify, sim_dir):
+        fail_future = MagicMock()
+        fail_future.result.side_effect = RuntimeError("LINCS")
+        success_future = MagicMock()
+        success_future.result.return_value = None
+        mock_run_stage.side_effect = [fail_future, success_future]
+        mock_classify.return_value = FailureType.PHYSICS
+
+        execute_stage_with_rescue(sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3)
+
+        # First call: no mdp_override (tier 0)
+        first_call = mock_run_stage.call_args_list[0]
+        assert first_call.kwargs.get("mdp_override") is None
+
+        # Second call: has mdp_override (tier 1)
+        second_call = mock_run_stage.call_args_list[1]
+        assert second_call.kwargs.get("mdp_override") == "em_rescue_t1.mdp"
+
+    @patch("mdfactory.orchestration.rescue.classify_failure")
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_unknown_failure_not_rescued(self, mock_run_stage, mock_classify, sim_dir):
+        fail_future = MagicMock()
+        fail_future.result.side_effect = RuntimeError("mysterious error")
+        mock_run_stage.return_value = fail_future
+        mock_classify.return_value = FailureType.UNKNOWN
+
+        with pytest.raises(RuntimeError, match="mysterious error"):
+            execute_stage_with_rescue(sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3)
+        assert mock_run_stage.call_count == 1

--- a/mdfactory/tests/test_orchestration_rescue.py
+++ b/mdfactory/tests/test_orchestration_rescue.py
@@ -137,3 +137,37 @@ class TestExecuteStageWithRescue:
         with pytest.raises(RuntimeError, match="mysterious error"):
             execute_stage_with_rescue(sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3)
         assert mock_run_stage.call_count == 1
+
+    @patch("mdfactory.orchestration.rescue.classify_failure")
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_rescue_logs_warning_with_tier_and_stage(
+        self, mock_run_stage, mock_classify, sim_dir
+    ):
+        """Rescue activation emits WARNING log with tier number and stage name."""
+        from loguru import logger
+
+        fail_future = MagicMock()
+        fail_future.result.side_effect = RuntimeError("LINCS WARNING")
+        success_future = MagicMock()
+        success_future.result.return_value = None
+        mock_run_stage.side_effect = [fail_future, success_future]
+        mock_classify.return_value = FailureType.PHYSICS
+
+        warnings = []
+        handler_id = logger.add(
+            lambda msg: warnings.append(str(msg)),
+            level="WARNING",
+            format="{message}",
+        )
+        try:
+            execute_stage_with_rescue(
+                sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3
+            )
+        finally:
+            logger.remove(handler_id)
+
+        # Should have at least one warning mentioning rescue tier and stage
+        rescue_warnings = [w for w in warnings if "RESCUE" in w and "EM" in w]
+        assert len(rescue_warnings) >= 1
+        # Check tier info is present
+        assert any("tier 1" in w for w in rescue_warnings)

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -795,6 +795,44 @@ def test_execute_stage_list_partial_pipeline_from_checkpoint(mock_run_stage):
     assert result is npt_fut
 
 
+@patch("mdfactory.orchestration.rescue.execute_stage_with_rescue")
+@patch("mdfactory.orchestration.simulate.run_stage")
+def test_execute_stage_list_routes_to_rescue_when_enabled(
+    mock_run_stage, mock_rescue
+):
+    """Rescue-eligible stages dispatch to execute_stage_with_rescue when max_rescue > 0."""
+    rescue_future = MagicMock()
+    mock_rescue.return_value = rescue_future
+    sim_dir = Path("/tmp/test")
+
+    result = _execute_stage_list(
+        sim_dir, ["EM"], MagicMock(), MagicMock(), max_rescue=3
+    )
+
+    mock_rescue.assert_called_once()
+    mock_run_stage.assert_not_called()
+    assert result is rescue_future
+
+
+@patch("mdfactory.orchestration.rescue.execute_stage_with_rescue")
+@patch("mdfactory.orchestration.simulate.run_stage")
+def test_execute_stage_list_production_bypasses_rescue(
+    mock_run_stage, mock_rescue
+):
+    """Production stage uses run_stage even when max_rescue > 0."""
+    prod_future = MagicMock()
+    mock_run_stage.return_value = prod_future
+    sim_dir = Path("/tmp/test")
+
+    result = _execute_stage_list(
+        sim_dir, ["Production"], MagicMock(), MagicMock(), max_rescue=3
+    )
+
+    mock_run_stage.assert_called_once()
+    mock_rescue.assert_not_called()
+    assert result is prod_future
+
+
 @patch("mdfactory.orchestration.simulate.parsl_session")
 @patch("mdfactory.orchestration.simulate._execute_stage_list")
 def test_run_simulations_uses_execute_stage_list(mock_execute, mock_session, mock_sim_dir):

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -690,7 +690,7 @@ def test_stage_functions_no_hardcoded_nt():
 
 def test_execute_stage_list_empty():
     """Execute stage list returns None when no stages provided."""
-    result = _execute_stage_list(Path("/tmp/test"), [], None, None)
+    result = _execute_stage_list(Path("/tmp/test"), [], None, None, max_rescue=0)
     assert result is None
 
 
@@ -698,13 +698,13 @@ def test_execute_stage_list_validates_order():
     """Execute stage list validates stages are in dependency order."""
     with pytest.raises(ValueError, match="must be in dependency order"):
         # NPT before NVT is invalid
-        _execute_stage_list(Path("/tmp/test"), ["NPT", "NVT"], None, None)
+        _execute_stage_list(Path("/tmp/test"), ["NPT", "NVT"], None, None, max_rescue=0)
 
 
 def test_execute_stage_list_validates_unknown_stage():
     """Execute stage list rejects unknown stage names."""
     with pytest.raises(ValueError, match="Unknown stage.*Equilibration"):
-        _execute_stage_list(Path("/tmp/test"), ["Equilibration"], None, None)
+        _execute_stage_list(Path("/tmp/test"), ["Equilibration"], None, None, max_rescue=0)
 
 
 @patch("mdfactory.orchestration.simulate.run_stage")
@@ -713,7 +713,7 @@ def test_execute_stage_list_em_only(mock_run_stage):
     mock_future = MagicMock()
     mock_run_stage.return_value = mock_future
 
-    result = _execute_stage_list(Path("/tmp/test"), ["EM"], MagicMock(), MagicMock())
+    result = _execute_stage_list(Path("/tmp/test"), ["EM"], MagicMock(), MagicMock(), max_rescue=0)
 
     mock_run_stage.assert_called_once()
     call_args = mock_run_stage.call_args[0]
@@ -733,7 +733,7 @@ def test_execute_stage_list_em_nvt_chain(mock_run_stage):
     mdrun_app = MagicMock()
     sim_dir = Path("/tmp/test")
 
-    result = _execute_stage_list(sim_dir, ["EM", "NVT"], grompp_app, mdrun_app)
+    result = _execute_stage_list(sim_dir, ["EM", "NVT"], grompp_app, mdrun_app, max_rescue=0)
 
     assert mock_run_stage.call_count == 2
     calls = mock_run_stage.call_args_list
@@ -756,7 +756,9 @@ def test_execute_stage_list_full_pipeline(mock_run_stage):
     mdrun_app = MagicMock()
     sim_dir = Path("/tmp/test")
 
-    result = _execute_stage_list(sim_dir, ["EM", "NVT", "NPT", "Production"], grompp_app, mdrun_app)
+    result = _execute_stage_list(
+        sim_dir, ["EM", "NVT", "NPT", "Production"], grompp_app, mdrun_app, max_rescue=0
+    )
 
     assert mock_run_stage.call_count == 4
     calls = mock_run_stage.call_args_list
@@ -783,7 +785,7 @@ def test_execute_stage_list_partial_pipeline_from_checkpoint(mock_run_stage):
     mdrun_app = MagicMock()
     sim_dir = Path("/tmp/test")
 
-    result = _execute_stage_list(sim_dir, ["NVT", "NPT"], grompp_app, mdrun_app)
+    result = _execute_stage_list(sim_dir, ["NVT", "NPT"], grompp_app, mdrun_app, max_rescue=0)
 
     calls = mock_run_stage.call_args_list
     assert calls[0][0][0].name == "NVT"
@@ -1264,6 +1266,7 @@ def test_execute_stage_list_restart_only_for_matching_stage(mock_run_stage):
         MagicMock(),
         MagicMock(),
         stage_restarts={"NPT": "/sim/npt.cpt"},
+        max_rescue=0,
     )
 
     calls = mock_run_stage.call_args_list
@@ -1356,7 +1359,9 @@ def test_execute_stage_list_passes_stage_config_when_slurm(mock_run_stage):
     )
     mock_run_stage.return_value = MagicMock()
 
-    _execute_stage_list(Path("/tmp/test"), ["EM"], MagicMock(), MagicMock(), config=cfg)
+    _execute_stage_list(
+        Path("/tmp/test"), ["EM"], MagicMock(), MagicMock(), config=cfg, max_rescue=0
+    )
 
     mock_run_stage.assert_called_once()
     _, call_kwargs = mock_run_stage.call_args
@@ -1373,7 +1378,8 @@ def test_execute_stage_list_no_stage_config_for_local(mock_run_stage):
     mock_run_stage.return_value = MagicMock()
 
     _execute_stage_list(
-        Path("/tmp/test"), ["EM"], MagicMock(), MagicMock(), config=ExecutorConfig()
+        Path("/tmp/test"), ["EM"], MagicMock(), MagicMock(),
+        config=ExecutorConfig(), max_rescue=0,
     )
 
     _, call_kwargs = mock_run_stage.call_args


### PR DESCRIPTION
Closes #30

Adaptive rescue retry for GROMACS physics failures — automatically halve critical MDP parameters when simulations crash due to overlapping atoms / exploding boxes, retry up to a configurable depth.

Implementation plan posted as a comment below.
