### PR TITLE
feat: add per-stage override prompts to SLURM config wizard

### DIFF
--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import yaml
 from rich.console import Console
+from rich.panel import Panel
 
 from mdfactory.orchestration.config import SlurmExecutorConfig
 from mdfactory.performance.cluster import ClusterInfo, Partition, discover_cluster
@@ -245,6 +246,138 @@ def _select_with_custom(
 
 
 # ---------------------------------------------------------------------------
+# Stage override prompts
+# ---------------------------------------------------------------------------
+
+#: Simulation stages that support per-stage resource overrides.
+_STAGES = ("EM", "NVT", "NPT", "Production")
+
+
+def _prompt_stage_overrides(
+    common_cpus: int,
+    common_gres: str | None,
+    common_gmx: str,
+) -> dict[str, dict]:
+    """Prompt the user for per-stage resource overrides.
+
+    When the common configuration includes a GPU (``gres`` is set), an
+    informational panel is displayed explaining that GROMACS energy
+    minimisation cannot use GPU acceleration.
+
+    Parameters
+    ----------
+    common_cpus : int
+        The ``cpus_per_node`` value from the common configuration.
+    common_gres : str or None
+        The ``gres`` value from the common configuration.
+    common_gmx : str
+        The ``gmx_binary`` value from the common configuration.
+
+    Returns
+    -------
+    dict[str, dict]
+        Stage overrides dict ready for ``SlurmExecutorConfig``.
+        Empty dict if the user declines or no deviations are entered.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels any prompt.
+    """
+    questionary = _import_questionary()
+    has_gpu = common_gres is not None
+
+    # --- EM/GPU information panel ---
+    if has_gpu:
+        console.print(
+            Panel(
+                "[bold]GROMACS energy minimisation (EM) does not support GPU acceleration.[/bold]\n"
+                "EM uses steepest-descent/conjugate-gradient integrators which have no GPU\n"
+                "code path. Consider configuring a CPU-only override for the EM stage with\n"
+                "more CPU cores to compensate.",
+                title="ℹ  Stage hint",
+                border_style="blue",
+            )
+        )
+
+    # --- Ask whether to configure overrides ---
+    default_configure = has_gpu
+    configure = questionary.confirm(
+        "Configure per-stage resource overrides?",
+        default=default_configure,
+    ).ask()
+    if configure is None:
+        raise UserCancelledError("Prompt cancelled at: stage overrides confirm")
+    if not configure:
+        return {}
+
+    # --- Select stages to override ---
+    stage_choices = [
+        questionary.Choice(title=stage, value=stage, checked=(stage == "EM" and has_gpu))
+        for stage in _STAGES
+    ]
+    selected_stages = questionary.checkbox(
+        "Select stages to customise:",
+        choices=stage_choices,
+    ).ask()
+    if selected_stages is None:
+        raise UserCancelledError("Prompt cancelled at: stage selection")
+    if not selected_stages:
+        return {}
+
+    # --- Prompt for each selected stage ---
+    stage_overrides: dict[str, dict] = {}
+    for stage in selected_stages:
+        console.print(f"\n  [bold]Configure {stage} stage:[/bold]")
+
+        # Suggest higher CPU count for EM when GPU is the common config
+        em_cpu_default = str(common_cpus * 2) if (stage == "EM" and has_gpu) else str(common_cpus)
+        # Suggest empty gres for EM when GPU is common
+        em_gres_default = "" if (stage == "EM" and has_gpu) else (common_gres or "")
+
+        cpus_input = _require(
+            questionary.text(
+                f"  {stage} — CPUs per node:",
+                default=em_cpu_default,
+            ).ask(),
+            f"{stage} cpus_per_node",
+        )
+        cpus_val = int(cpus_input)
+
+        gres_input = _require(
+            questionary.text(
+                f"  {stage} — GRES (leave empty for CPU-only):",
+                default=em_gres_default,
+            ).ask(),
+            f"{stage} gres",
+        )
+        gres_val: str | None = gres_input.strip() or None
+
+        gmx_input = _require(
+            questionary.text(
+                f"  {stage} — gmx_binary:",
+                default=common_gmx,
+            ).ask(),
+            f"{stage} gmx_binary",
+        )
+        gmx_val = gmx_input.strip()
+
+        # Only store fields that differ from common values
+        overrides: dict = {}
+        if cpus_val != common_cpus:
+            overrides["cpus_per_node"] = cpus_val
+        if gres_val != common_gres:
+            overrides["gres"] = gres_val
+        if gmx_val != common_gmx:
+            overrides["gmx_binary"] = gmx_val
+
+        if overrides:
+            stage_overrides[stage] = overrides
+
+    return stage_overrides
+
+
+# ---------------------------------------------------------------------------
 # Interactive prompts — cluster-assisted
 # ---------------------------------------------------------------------------
 
@@ -410,6 +543,13 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
     )
     constraint: str | None = constraint_input.strip() or None
 
+    # --- Per-stage overrides ---
+    stage_overrides = _prompt_stage_overrides(
+        common_cpus=cpus_per_node,
+        common_gres=gres,
+        common_gmx="auto",
+    )
+
     return SlurmExecutorConfig(
         account=account,
         partition=partition_name,
@@ -421,6 +561,7 @@ def _configure_with_cluster(cluster: ClusterInfo) -> SlurmExecutorConfig:
         constraint=constraint,
         max_blocks=max_blocks,
         worker_init=worker_init,
+        stage_overrides=stage_overrides,
     )
 
 
@@ -484,6 +625,13 @@ def _configure_manual() -> SlurmExecutorConfig:
         "worker_init",
     )
 
+    # --- Per-stage overrides ---
+    stage_overrides = _prompt_stage_overrides(
+        common_cpus=cpus_per_node,
+        common_gres=gres,
+        common_gmx="auto",
+    )
+
     return SlurmExecutorConfig(
         account=account,
         partition=partition,
@@ -494,6 +642,7 @@ def _configure_manual() -> SlurmExecutorConfig:
         qos=qos,
         max_blocks=max_blocks,
         worker_init=worker_init,
+        stage_overrides=stage_overrides,
     )
 
 
@@ -552,6 +701,9 @@ def save_slurm_config_yaml(config: SlurmExecutorConfig, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
     data = config.model_dump(exclude_none=True)
+    # Omit empty stage_overrides for cleaner YAML output
+    if not data.get("stage_overrides"):
+        data.pop("stage_overrides", None)
     with open(path, "w") as fh:
         yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
 

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -10,6 +10,7 @@ import yaml
 from mdfactory.orchestration.config import SlurmExecutorConfig
 from mdfactory.orchestration.tui import (
     UserCancelledError,
+    _prompt_stage_overrides,
     _require,
     configure_slurm_interactive,
     save_slurm_config_yaml,
@@ -71,8 +72,8 @@ class TestConfigureManualFallback:
     @patch("mdfactory.orchestration.tui._import_questionary")
     def test_configure_manual_fallback(self, mock_iq, _discover):
         mock_q = mock_iq.return_value
-        # confirm → proceed with manual config
-        mock_q.confirm.return_value.ask.return_value = True
+        # confirm prompts: proceed with manual? → True, stage overrides? → False
+        mock_q.confirm.return_value.ask.side_effect = [True, False]
         # text prompts in order: account, partition, walltime, cpus,
         # gres, mem, qos, max_blocks, worker_init
         mock_q.text.return_value.ask.side_effect = [
@@ -94,6 +95,7 @@ class TestConfigureManualFallback:
         assert cfg.cpus_per_node == 24
         assert cfg.gres == "gpu:a100:1"
         assert cfg.mem == "64G"
+        assert cfg.stage_overrides == {}
 
 
 class TestConfigureWithCluster:
@@ -120,8 +122,8 @@ class TestConfigureWithCluster:
             "",
             "a100",
         ]
-        # confirm for QOS
-        mock_q.confirm.return_value.ask.return_value = False
+        # confirm: QOS → False, stage overrides → False
+        mock_q.confirm.return_value.ask.side_effect = [False, False]
 
         cfg = configure_slurm_interactive()
         assert cfg.account == "hpc_chem"
@@ -131,6 +133,7 @@ class TestConfigureWithCluster:
         assert cfg.mem == "50G"
         assert cfg.max_blocks == 4
         assert cfg.constraint == "a100"
+        assert cfg.stage_overrides == {}
 
 
 class TestUserCancellation:
@@ -145,6 +148,193 @@ class TestUserCancellation:
 
         with pytest.raises(UserCancelledError):
             configure_slurm_interactive()
+
+
+# ---------------------------------------------------------------------------
+# _prompt_stage_overrides tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptStageOverrides:
+    """Tests for the per-stage override prompt helper."""
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_declined(self, mock_iq):
+        """User declines stage overrides → empty dict."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = False
+
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+        )
+        assert result == {}
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_em_cpu_only(self, mock_iq):
+        """GPU config + accept + EM → gres=None and higher cpus."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.checkbox.return_value.ask.return_value = ["EM"]
+        # text prompts for EM: cpus (default 32=16*2), gres (default ""), gmx_binary
+        mock_q.text.return_value.ask.side_effect = ["32", "", "auto"]
+
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+        )
+        assert "EM" in result
+        assert result["EM"]["cpus_per_node"] == 32
+        assert result["EM"]["gres"] is None
+        # gmx_binary same as common → not stored
+        assert "gmx_binary" not in result["EM"]
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_multiple_stages(self, mock_iq):
+        """Multiple stages selected → each gets correct overrides."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.checkbox.return_value.ask.return_value = ["EM", "Production"]
+        # text prompts: EM(cpus, gres, gmx), Production(cpus, gres, gmx)
+        mock_q.text.return_value.ask.side_effect = [
+            "8",  # EM cpus
+            "",  # EM gres (empty → None, differs from common None → no diff)
+            "auto",  # EM gmx
+            "32",  # Production cpus
+            "gpu:a100:2",  # Production gres
+            "auto",  # Production gmx
+        ]
+
+        result = _prompt_stage_overrides(common_cpus=16, common_gres=None, common_gmx="auto")
+        assert result["EM"] == {"cpus_per_node": 8}
+        assert result["Production"] == {"cpus_per_node": 32, "gres": "gpu:a100:2"}
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_no_diff_excluded(self, mock_iq):
+        """Override values same as common → not stored in overrides."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.checkbox.return_value.ask.return_value = ["NVT"]
+        # text prompts: all same as common values
+        mock_q.text.return_value.ask.side_effect = ["16", "gpu:a100:1", "auto"]
+
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+        )
+        # No actual deviations → NVT not in result
+        assert result == {}
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_empty_selection(self, mock_iq):
+        """User confirms but selects no stages → empty dict."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.checkbox.return_value.ask.return_value = []
+
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+        )
+        assert result == {}
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_cancellation_at_confirm(self, mock_iq):
+        """User cancels at confirm prompt → raises UserCancelledError."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = None
+
+        with pytest.raises(UserCancelledError):
+            _prompt_stage_overrides(common_cpus=16, common_gres=None, common_gmx="auto")
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_cancellation_at_checkbox(self, mock_iq):
+        """User cancels at stage selection → raises UserCancelledError."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.checkbox.return_value.ask.return_value = None
+
+        with pytest.raises(UserCancelledError):
+            _prompt_stage_overrides(common_cpus=16, common_gres=None, common_gmx="auto")
+
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_gmx_binary_override(self, mock_iq):
+        """Override gmx_binary for a stage → stored in overrides."""
+        mock_q = mock_iq.return_value
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.checkbox.return_value.ask.return_value = ["Production"]
+        mock_q.text.return_value.ask.side_effect = ["16", "gpu:a100:1", "gmx_mpi"]
+
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+        )
+        assert result["Production"] == {"gmx_binary": "gmx_mpi"}
+
+
+class TestStageOverridesIntegration:
+    """Tests that stage overrides flow through the full wizard paths."""
+
+    @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_manual_path(self, mock_iq, _discover):
+        """Manual fallback path produces config with stage overrides."""
+        mock_q = mock_iq.return_value
+        # confirm: proceed with manual → True, stage overrides → True
+        mock_q.confirm.return_value.ask.side_effect = [True, True]
+        # text prompts: account, partition, walltime, cpus, gres, mem, qos,
+        # max_blocks, worker_init, then stage override prompts for EM
+        mock_q.text.return_value.ask.side_effect = [
+            "acc",
+            "gpu",
+            "2:00:00",
+            "16",
+            "gpu:a100:1",
+            "32G",
+            "",
+            "4",
+            "",
+            # EM stage prompts: cpus, gres, gmx
+            "32",
+            "",
+            "auto",
+        ]
+        mock_q.checkbox.return_value.ask.return_value = ["EM"]
+
+        cfg = configure_slurm_interactive()
+        assert cfg.stage_overrides == {
+            "EM": {"cpus_per_node": 32, "gres": None},
+        }
+
+    @patch("mdfactory.orchestration.tui.discover_cluster")
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stage_overrides_cluster_path(self, mock_iq, mock_discover):
+        """Cluster-assisted path produces config with stage overrides."""
+        mock_q = mock_iq.return_value
+        mock_discover.return_value = _make_cluster()
+
+        # select prompts: account, partition, walltime, cpus, mem, max_blocks
+        mock_q.select.return_value.ask.side_effect = [
+            "hpc_chem",
+            "gpu",
+            "2h",
+            "16",
+            "50G",
+            "4",
+        ]
+        # text prompts: gres, worker_init, constraint, then stage prompts
+        mock_q.text.return_value.ask.side_effect = [
+            "gpu:a100:1",
+            "",
+            "",
+            # EM stage prompts: cpus, gres, gmx
+            "32",
+            "",
+            "auto",
+        ]
+        # confirm: QOS → False, stage overrides → True
+        mock_q.confirm.return_value.ask.side_effect = [False, True]
+        mock_q.checkbox.return_value.ask.return_value = ["EM"]
+
+        cfg = configure_slurm_interactive()
+        assert cfg.stage_overrides == {
+            "EM": {"cpus_per_node": 32, "gres": None},
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -173,3 +363,39 @@ class TestSaveYaml:
         assert data["gres"] == "gpu:v100:1"
         assert data["max_blocks"] == 3
         assert data["provider"] == "slurm"
+
+    def test_save_yaml_excludes_empty_overrides(self, tmp_path):
+        """Empty stage_overrides should not appear in the YAML output."""
+        cfg = SlurmExecutorConfig(
+            account="acc",
+            partition="cpu",
+            walltime="1h",
+            cpus_per_node=8,
+        )
+        out = tmp_path / "slurm.yaml"
+        save_slurm_config_yaml(cfg, out)
+
+        data = yaml.safe_load(out.read_text())
+        assert "stage_overrides" not in data
+
+    def test_save_yaml_includes_populated_overrides(self, tmp_path):
+        """Non-empty stage_overrides should be written to the YAML output."""
+        cfg = SlurmExecutorConfig(
+            account="acc",
+            partition="gpu",
+            walltime="2h",
+            cpus_per_node=16,
+            gres="gpu:a100:1",
+            stage_overrides={
+                "EM": {"cpus_per_node": 32, "gres": None},
+                "Production": {"cpus_per_node": 64},
+            },
+        )
+        out = tmp_path / "slurm.yaml"
+        save_slurm_config_yaml(cfg, out)
+
+        data = yaml.safe_load(out.read_text())
+        assert "stage_overrides" in data
+        assert data["stage_overrides"]["EM"]["cpus_per_node"] == 32
+        assert data["stage_overrides"]["EM"]["gres"] is None
+        assert data["stage_overrides"]["Production"]["cpus_per_node"] == 64


### PR DESCRIPTION
Closes #32

Add per-stage resource override prompts to the interactive SLURM configuration wizard, including a smart EM/GPU hint that informs users GROMACS energy minimisation cannot use GPU acceleration.

Base branch: feat/parsl-simulate

Implementation plan posted as a comment below.
