### PR TITLE
fix: unwrap Parsl DependencyError to surface grompp root cause

### DIFF
--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -128,12 +128,12 @@ def build_systems(
 def _describe_failure(exc: BaseException) -> tuple[str, str]:
     """Extract ``(failure_type, error_detail)`` from a future's exception.
 
-    Parsl surfaces worker errors differently across versions: modern Parsl
-    re-raises the *original* exception (via ``RemoteExceptionWrapper.reraise()``),
-    while older versions wrapped it and exposed the underlying error on
-    ``.e_value``. Unwrap defensively so callers always see the *underlying*
-    error type — letting future retry logic distinguish, e.g., a GROMACS crash
-    (``CalledProcessError``) from an infrastructure failure (OOM / preemption).
+    Parsl surfaces worker errors differently across versions and failure
+    modes: ``DependencyError`` wraps upstream failures (e.g. grompp crash
+    prevents mdrun from launching), ``RemoteExceptionWrapper`` (legacy)
+    stores the original on ``.e_value``, and modern Parsl re-raises
+    directly. Uses :func:`~mdfactory.orchestration.errors._unwrap_parsl_exception`
+    to unwrap defensively so callers always see the *underlying* error type.
 
     Parameters
     ----------
@@ -147,7 +147,9 @@ def _describe_failure(exc: BaseException) -> tuple[str, str]:
         name and its string representation.
 
     """
-    underlying = getattr(exc, "e_value", None) or exc
+    from .errors import _unwrap_parsl_exception
+
+    underlying = _unwrap_parsl_exception(exc)
     return type(underlying).__name__, str(underlying)
 
 

--- a/mdfactory/orchestration/errors.py
+++ b/mdfactory/orchestration/errors.py
@@ -36,6 +36,45 @@ _PHYSICS_PATTERNS: list[re.Pattern] = [
 ]
 
 
+def _unwrap_parsl_exception(exc: BaseException) -> BaseException:
+    """Unwrap Parsl exception wrappers to find the root cause.
+
+    Parsl surfaces worker errors differently depending on the failure mode:
+
+    1. **DependencyError** (downstream task failed because an upstream
+       dependency failed): Parsl sets ``exc.__cause__`` to the deepest
+       root-cause exception via ``_find_any_root_cause()``.
+    2. **Legacy RemoteExceptionWrapper**: stores the original exception
+       on ``exc.e_value``.
+    3. **Modern Parsl** (direct re-raise): the exception is already the
+       original — return as-is.
+
+    Uses duck-typing (``__cause__``, ``e_value``) so no Parsl import is
+    needed, and works with any future exception type that follows these
+    conventions.
+
+    Parameters
+    ----------
+    exc : BaseException
+        The exception raised by ``future.result()``.
+
+    Returns
+    -------
+    BaseException
+        The unwrapped root-cause exception.
+
+    """
+    # Case 1: DependencyError / PropagatedException sets __cause__
+    if exc.__cause__ is not None:
+        return exc.__cause__
+    # Case 2: Legacy .e_value wrapper
+    underlying = getattr(exc, "e_value", None)
+    if underlying is not None:
+        return underlying
+    # Case 3: Already the real exception
+    return exc
+
+
 class FailureType(Enum):
     """Classification of a simulation stage failure.
 
@@ -84,8 +123,8 @@ def classify_failure(
         The classified failure type.
 
     """
-    # Unwrap Parsl's exception wrapping (legacy and modern)
-    underlying = getattr(exc, "e_value", None) or exc
+    # Unwrap Parsl's exception wrapping (DependencyError, legacy, modern)
+    underlying = _unwrap_parsl_exception(exc)
     error_text = str(underlying)
 
     # Check the exception message first

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -454,6 +454,21 @@ def test_describe_failure_unwraps_legacy_e_value():
     assert detail == "real GROMACS crash"
 
 
+def test_describe_failure_unwraps_dependency_error_cause():
+    """_describe_failure unwraps DependencyError via __cause__ to show root cause."""
+    from mdfactory.orchestration.build import _describe_failure
+
+    root = ValueError("grompp fatal error: atom types not found")
+    wrapper = RuntimeError(
+        "Dependency failure for task 5. The representative cause is via task 0"
+    )
+    wrapper.__cause__ = root
+
+    failure_type, detail = _describe_failure(wrapper)
+    assert failure_type == "ValueError"
+    assert "grompp fatal error" in detail
+
+
 # --- Finding 12: completeness guard ---
 
 

--- a/mdfactory/tests/test_orchestration_errors.py
+++ b/mdfactory/tests/test_orchestration_errors.py
@@ -1,10 +1,11 @@
-# ABOUTME: Tests for GROMACS error classification
+# ABOUTME: Tests for GROMACS error classification and Parsl exception unwrapping
 # ABOUTME: Verifies physics vs infrastructure failure detection
 """Tests for mdfactory.orchestration.errors."""
 
 from mdfactory.orchestration.errors import (
     FailureType,
     _matches_physics_patterns,
+    _unwrap_parsl_exception,
     classify_failure,
 )
 
@@ -120,3 +121,68 @@ class TestClassifyFailure:
         exc = RuntimeError("Process returned non-zero exit code 1")
         result = classify_failure(exc, sim_dir=tmp_path, stage="EM")
         assert result == FailureType.PHYSICS
+
+    def test_unwraps_dependency_error_with_cause(self):
+        """DependencyError (via __cause__) is unwrapped to classify the root cause."""
+        root = RuntimeError("LINCS WARNING: bonds to H are constrained")
+        wrapper = RuntimeError("Dependency failure for task 5")
+        wrapper.__cause__ = root
+        assert classify_failure(wrapper) == FailureType.PHYSICS
+
+    def test_dependency_error_infra_from_root_cause(self):
+        """DependencyError wrapping an infrastructure failure is classified correctly."""
+        root = RuntimeError("slurmstepd: error: Detected 1 oom-kill event")
+        wrapper = RuntimeError("Dependency failure for task 3")
+        wrapper.__cause__ = root
+        assert classify_failure(wrapper) == FailureType.INFRASTRUCTURE
+
+    def test_dependency_error_unknown_root_cause(self):
+        """DependencyError wrapping an unrecognised error yields UNKNOWN."""
+        root = RuntimeError("Neither gmx nor gmx_mpi found in PATH")
+        wrapper = RuntimeError("Dependency failure for task 1")
+        wrapper.__cause__ = root
+        assert classify_failure(wrapper) == FailureType.UNKNOWN
+
+
+class TestUnwrapParslException:
+    """Tests for _unwrap_parsl_exception helper."""
+
+    def test_plain_exception_returned_as_is(self):
+        exc = RuntimeError("simple error")
+        assert _unwrap_parsl_exception(exc) is exc
+
+    def test_unwraps_cause(self):
+        root = ValueError("the real error")
+        wrapper = RuntimeError("Dependency failure for task 5")
+        wrapper.__cause__ = root
+        assert _unwrap_parsl_exception(wrapper) is root
+
+    def test_unwraps_legacy_e_value(self):
+        class LegacyWrapper(Exception):
+            pass
+
+        root = RuntimeError("LINCS WARNING in bonds")
+        wrapper = LegacyWrapper("wrapper message")
+        wrapper.e_value = root
+        assert _unwrap_parsl_exception(wrapper) is root
+
+    def test_cause_takes_precedence_over_e_value(self):
+        """If both __cause__ and .e_value exist, __cause__ wins."""
+        cause_exc = ValueError("from __cause__")
+        e_val_exc = RuntimeError("from e_value")
+        wrapper = RuntimeError("wrapper")
+        wrapper.__cause__ = cause_exc
+        wrapper.e_value = e_val_exc
+        assert _unwrap_parsl_exception(wrapper) is cause_exc
+
+    def test_chained_cause(self):
+        """Deeply nested __cause__ chain — returns the immediate __cause__."""
+        deepest = ValueError("deepest root")
+        middle = RuntimeError("middle")
+        middle.__cause__ = deepest
+        outer = RuntimeError("Dependency failure")
+        outer.__cause__ = middle
+        # Returns the immediate __cause__ (middle), not the deepest.
+        # Parsl's _find_any_root_cause already resolves __cause__ to
+        # the deepest, so this is the expected behaviour.
+        assert _unwrap_parsl_exception(outer) is middle

--- a/mdfactory/tests/test_orchestration_rescue.py
+++ b/mdfactory/tests/test_orchestration_rescue.py
@@ -171,3 +171,50 @@ class TestExecuteStageWithRescue:
         assert len(rescue_warnings) >= 1
         # Check tier info is present
         assert any("tier 1" in w for w in rescue_warnings)
+
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_dependency_error_surfaces_root_cause(self, mock_run_stage, sim_dir):
+        """A grompp DependencyError is unwrapped to classify the real root cause.
+
+        When grompp fails, mdrun receives a DependencyError with __cause__
+        pointing to the actual grompp exception. The rescue loop must
+        unwrap this to classify correctly and show an actionable message.
+        """
+        # Simulate Parsl DependencyError wrapping a grompp failure
+        root_cause = RuntimeError("Neither gmx nor gmx_mpi found in PATH")
+        dependency_error = RuntimeError(
+            "Dependency failure for task 5. The representative cause is via task 0"
+        )
+        dependency_error.__cause__ = root_cause
+
+        fail_future = MagicMock()
+        fail_future.result.side_effect = dependency_error
+        mock_run_stage.return_value = fail_future
+
+        # Should raise the original DependencyError (not retry it),
+        # since "gmx not found" is UNKNOWN, not PHYSICS.
+        with pytest.raises(RuntimeError, match="Dependency failure"):
+            execute_stage_with_rescue(
+                sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3
+            )
+        # Should NOT retry — gmx-not-found is not a physics failure
+        assert mock_run_stage.call_count == 1
+
+    @patch("mdfactory.orchestration.rescue.run_stage")
+    def test_dependency_error_with_physics_root_is_rescued(self, mock_run_stage, sim_dir):
+        """A DependencyError wrapping a physics failure IS rescued."""
+        root_cause = RuntimeError("LINCS WARNING: bonds to H are constrained")
+        dependency_error = RuntimeError("Dependency failure for task 5")
+        dependency_error.__cause__ = root_cause
+
+        fail_future = MagicMock()
+        fail_future.result.side_effect = dependency_error
+        success_future = MagicMock()
+        success_future.result.return_value = None
+        mock_run_stage.side_effect = [fail_future, success_future]
+
+        result = execute_stage_with_rescue(
+            sim_dir, "EM", None, MagicMock(), MagicMock(), max_rescue=3
+        )
+        assert result is success_future
+        assert mock_run_stage.call_count == 2

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -158,6 +158,9 @@ class TestUserCancellation:
 class TestPromptStageOverrides:
     """Tests for the per-stage override prompt helper."""
 
+    #: Default full simulation pipeline stages for test calls.
+    _ALL_STAGES = ("EM", "NVT", "NPT", "Production")
+
     @patch("mdfactory.orchestration.tui._import_questionary")
     def test_stage_overrides_declined(self, mock_iq):
         """User declines stage overrides → empty dict."""
@@ -165,7 +168,8 @@ class TestPromptStageOverrides:
         mock_q.confirm.return_value.ask.return_value = False
 
         result = _prompt_stage_overrides(
-            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=self._ALL_STAGES,
         )
         assert result == {}
 
@@ -179,7 +183,8 @@ class TestPromptStageOverrides:
         mock_q.text.return_value.ask.side_effect = ["32", "", "auto"]
 
         result = _prompt_stage_overrides(
-            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=self._ALL_STAGES,
         )
         assert "EM" in result
         assert result["EM"]["cpus_per_node"] == 32
@@ -203,7 +208,10 @@ class TestPromptStageOverrides:
             "auto",  # Production gmx
         ]
 
-        result = _prompt_stage_overrides(common_cpus=16, common_gres=None, common_gmx="auto")
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres=None, common_gmx="auto",
+            stages=self._ALL_STAGES,
+        )
         assert result["EM"] == {"cpus_per_node": 8}
         assert result["Production"] == {"cpus_per_node": 32, "gres": "gpu:a100:2"}
 
@@ -217,7 +225,8 @@ class TestPromptStageOverrides:
         mock_q.text.return_value.ask.side_effect = ["16", "gpu:a100:1", "auto"]
 
         result = _prompt_stage_overrides(
-            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=self._ALL_STAGES,
         )
         # No actual deviations → NVT not in result
         assert result == {}
@@ -230,7 +239,8 @@ class TestPromptStageOverrides:
         mock_q.checkbox.return_value.ask.return_value = []
 
         result = _prompt_stage_overrides(
-            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=self._ALL_STAGES,
         )
         assert result == {}
 
@@ -241,7 +251,10 @@ class TestPromptStageOverrides:
         mock_q.confirm.return_value.ask.return_value = None
 
         with pytest.raises(UserCancelledError):
-            _prompt_stage_overrides(common_cpus=16, common_gres=None, common_gmx="auto")
+            _prompt_stage_overrides(
+                common_cpus=16, common_gres=None, common_gmx="auto",
+                stages=self._ALL_STAGES,
+            )
 
     @patch("mdfactory.orchestration.tui._import_questionary")
     def test_stage_overrides_cancellation_at_checkbox(self, mock_iq):
@@ -251,7 +264,10 @@ class TestPromptStageOverrides:
         mock_q.checkbox.return_value.ask.return_value = None
 
         with pytest.raises(UserCancelledError):
-            _prompt_stage_overrides(common_cpus=16, common_gres=None, common_gmx="auto")
+            _prompt_stage_overrides(
+                common_cpus=16, common_gres=None, common_gmx="auto",
+                stages=self._ALL_STAGES,
+            )
 
     @patch("mdfactory.orchestration.tui._import_questionary")
     def test_stage_overrides_gmx_binary_override(self, mock_iq):
@@ -262,9 +278,26 @@ class TestPromptStageOverrides:
         mock_q.text.return_value.ask.side_effect = ["16", "gpu:a100:1", "gmx_mpi"]
 
         result = _prompt_stage_overrides(
-            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto"
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=self._ALL_STAGES,
         )
         assert result["Production"] == {"gmx_binary": "gmx_mpi"}
+
+    def test_single_stage_skips_overrides(self):
+        """A single-stage workflow skips overrides entirely — no prompt."""
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=("Production",),
+        )
+        assert result == {}
+
+    def test_empty_stages_skips_overrides(self):
+        """Empty stages (build workflow) skips overrides entirely."""
+        result = _prompt_stage_overrides(
+            common_cpus=16, common_gres="gpu:a100:1", common_gmx="auto",
+            stages=(),
+        )
+        assert result == {}
 
 
 class TestStageOverridesIntegration:


### PR DESCRIPTION
Closes #34

Unwrap Parsl's `DependencyError` so grompp failures surface with their actual error message instead of the opaque "Dependency failure for task N" wrapper.

**Target branch:** `feat/parsl-simulate`

Implementation plan posted as a comment below.
