### PR TITLE
feat: include detected GROMACS modules in default worker init for simulate

### DIFF
--- a/docs/content/docs/user-guide/running-on-hpc.mdx
+++ b/docs/content/docs/user-guide/running-on-hpc.mdx
@@ -73,6 +73,10 @@ mdfactory config slurm
 
 The wizard auto-discovers your cluster's partitions, accounts, and hardware (GPU types, memory, CPU counts) and walks through resource selection. The result is saved to a YAML file (default: `slurm_executor.yaml`).
 
+<Callout type="info" title="Automatic GROMACS module detection">
+When configuring for `simulate`, the wizard detects GROMACS modules loaded on the login node (from `$LOADEDMODULES`) and includes them in the default `worker_init` suggestion. This ensures compute nodes can find `gmx` / `gmx_mpi` without manual configuration. You can always edit the suggestion before confirming.
+</Callout>
+
 ### Manual configuration
 
 You can also write the YAML file directly. See [`examples/slurm_executor.yaml`](https://github.com/emdgroup/mdfactory/blob/main/examples/slurm_executor.yaml) for an annotated reference with all available fields.

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -11,6 +11,7 @@ that can be saved as YAML and used with Parsl-based workflows.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import yaml
@@ -66,8 +67,6 @@ def _detect_gromacs_modules() -> list[str]:
         Module names that match GROMACS, e.g. ``["gromacs/2024.3-gpu"]``.
         Empty list if no modules are loaded or the variable is unset.
     """
-    import os
-
     loaded = os.environ.get("LOADEDMODULES", "")
     if not loaded:
         return []

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -52,7 +52,33 @@ def _import_questionary():
     return questionary
 
 
-def _default_worker_init() -> str:
+def _detect_gromacs_modules() -> list[str]:
+    """Detect loaded GROMACS modules from ``$LOADEDMODULES``.
+
+    The ``LOADEDMODULES`` environment variable is a colon-separated list
+    of currently loaded modules (set by the ``module`` system on HPC
+    clusters).  This function returns module names that look like
+    GROMACS (case-insensitive prefix match on ``gromacs`` or ``gmx``).
+
+    Returns
+    -------
+    list[str]
+        Module names that match GROMACS, e.g. ``["gromacs/2024.3-gpu"]``.
+        Empty list if no modules are loaded or the variable is unset.
+    """
+    import os
+
+    loaded = os.environ.get("LOADEDMODULES", "")
+    if not loaded:
+        return []
+    return [
+        mod
+        for mod in loaded.split(":")
+        if mod.lower().startswith(("gromacs", "gmx"))
+    ]
+
+
+def _default_worker_init(*, for_simulate: bool = False) -> str:
     """Auto-detect the pixi environment and return an appropriate worker_init.
 
     On HPC clusters with a shared filesystem, workers need the same pixi
@@ -60,22 +86,43 @@ def _default_worker_init() -> str:
     project root via ``mdfactory.__file__`` and returns a pixi shell-hook
     command if the environment exists.
 
+    When *for_simulate* is ``True``, detected GROMACS modules from
+    ``$LOADEDMODULES`` are prepended so that compute nodes can find
+    ``gmx`` / ``gmx_mpi``.
+
+    Parameters
+    ----------
+    for_simulate : bool, optional
+        If ``True``, prepend ``module load`` commands for any detected
+        GROMACS modules.  Default is ``False`` (build context).
+
     Returns
     -------
     str
-        A shell command to activate the pixi environment, or ``""`` if
-        no pixi environment is detected.
+        A shell command to activate the pixi environment (and optionally
+        load GROMACS modules), or ``""`` if no pixi environment is
+        detected.
     """
+    parts: list[str] = []
+
+    if for_simulate:
+        gromacs_modules = _detect_gromacs_modules()
+        for mod in gromacs_modules:
+            parts.append(f"module load {mod}")
+
     try:
         import mdfactory as _mdf
 
         project_root = Path(_mdf.__file__).parent.parent
         pixi_env = project_root / ".pixi" / "envs" / "default"
         if pixi_env.exists():
-            return f'eval "$(pixi shell-hook --manifest-path {project_root} -e default)"'
+            parts.append(
+                f'eval "$(pixi shell-hook --manifest-path {project_root} -e default)"'
+            )
     except Exception:
         pass
-    return ""
+
+    return "; ".join(parts) if parts else ""
 
 
 class UserCancelledError(Exception):
@@ -549,7 +596,7 @@ def _configure_with_cluster(
     )
 
     # --- Worker init ---
-    default_init = _default_worker_init()
+    default_init = _default_worker_init(for_simulate=stages is None or len(stages) > 0)
     worker_init = _require(
         questionary.text(
             "Worker init script (activates environment on compute nodes):",
@@ -662,7 +709,7 @@ def _configure_manual(*, stages: tuple[str, ...] | None = None) -> SlurmExecutor
         )
     )
 
-    default_init = _default_worker_init()
+    default_init = _default_worker_init(for_simulate=stages is None or len(stages) > 0)
     worker_init = _require(
         questionary.text(
             "Worker init script (activates environment on compute nodes):",

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -10,6 +10,8 @@ import yaml
 from mdfactory.orchestration.config import SlurmExecutorConfig
 from mdfactory.orchestration.tui import (
     UserCancelledError,
+    _default_worker_init,
+    _detect_gromacs_modules,
     _prompt_stage_overrides,
     _require,
     configure_slurm_interactive,
@@ -58,6 +60,88 @@ class TestRequire:
     def test_raises_on_none(self):
         with pytest.raises(UserCancelledError):
             _require(None, "test")
+
+
+# ---------------------------------------------------------------------------
+# _detect_gromacs_modules tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectGromacsModules:
+    """Tests for GROMACS module detection from $LOADEDMODULES."""
+
+    def test_no_env_var(self, monkeypatch):
+        monkeypatch.delenv("LOADEDMODULES", raising=False)
+        assert _detect_gromacs_modules() == []
+
+    def test_empty_env_var(self, monkeypatch):
+        monkeypatch.setenv("LOADEDMODULES", "")
+        assert _detect_gromacs_modules() == []
+
+    def test_single_gromacs_module(self, monkeypatch):
+        monkeypatch.setenv("LOADEDMODULES", "cuda/12.2:gromacs/2024.3-gpu:openmpi/4.1")
+        assert _detect_gromacs_modules() == ["gromacs/2024.3-gpu"]
+
+    def test_multiple_gromacs_modules(self, monkeypatch):
+        monkeypatch.setenv("LOADEDMODULES", "gromacs/2023.1:gromacs/2024.3-gpu")
+        assert _detect_gromacs_modules() == ["gromacs/2023.1", "gromacs/2024.3-gpu"]
+
+    def test_gmx_prefix(self, monkeypatch):
+        monkeypatch.setenv("LOADEDMODULES", "gmx/2024.3:openmpi/4.1")
+        assert _detect_gromacs_modules() == ["gmx/2024.3"]
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("LOADEDMODULES", "GROMACS/2024.3:Gmx/2023.1")
+        assert _detect_gromacs_modules() == ["GROMACS/2024.3", "Gmx/2023.1"]
+
+    def test_no_gromacs_modules(self, monkeypatch):
+        monkeypatch.setenv("LOADEDMODULES", "cuda/12.2:openmpi/4.1:python/3.11")
+        assert _detect_gromacs_modules() == []
+
+
+# ---------------------------------------------------------------------------
+# _default_worker_init tests
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultWorkerInit:
+    """Tests for _default_worker_init with for_simulate flag."""
+
+    def test_without_simulate_no_modules(self, monkeypatch):
+        """Build context: no module load even if GROMACS modules present."""
+        monkeypatch.setenv("LOADEDMODULES", "gromacs/2024.3-gpu")
+        result = _default_worker_init(for_simulate=False)
+        assert "module load" not in result
+
+    def test_with_simulate_includes_modules(self, monkeypatch, tmp_path):
+        """Simulate context: module load commands are prepended."""
+        monkeypatch.setenv("LOADEDMODULES", "gromacs/2024.3-gpu")
+        # Ensure pixi env detection doesn't interfere
+        monkeypatch.setattr(
+            "mdfactory.orchestration.tui.Path",
+            lambda *a, **kw: tmp_path / "nonexistent",
+        )
+        result = _default_worker_init(for_simulate=True)
+        assert "module load gromacs/2024.3-gpu" in result
+
+    def test_with_simulate_no_modules(self, monkeypatch):
+        """Simulate context but no GROMACS modules → no module load."""
+        monkeypatch.delenv("LOADEDMODULES", raising=False)
+        result = _default_worker_init(for_simulate=True)
+        assert "module load" not in result
+
+    def test_with_simulate_multiple_modules(self, monkeypatch, tmp_path):
+        """Multiple GROMACS modules → multiple module load commands."""
+        monkeypatch.setenv("LOADEDMODULES", "gromacs/2023.1:gromacs/2024.3-gpu")
+        monkeypatch.setattr(
+            "mdfactory.orchestration.tui.Path",
+            lambda *a, **kw: tmp_path / "nonexistent",
+        )
+        result = _default_worker_init(for_simulate=True)
+        assert "module load gromacs/2023.1" in result
+        assert "module load gromacs/2024.3-gpu" in result
+        # Should be semicolon-separated
+        assert "; " in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #35.

When the TUI is invoked for `simulate` (i.e. `stages` is non-empty or `None`), `_default_worker_init()` now detects loaded GROMACS modules from `$LOADEDMODULES` and prepends `module load` commands to the default worker init suggestion.

This ensures that when a user has loaded GROMACS via `module load gromacs/...` on the login node, the same module is suggested for compute node activation — so `gmx`/`gmx_mpi` are available on workers.

### Changes

- **`_detect_gromacs_modules()`** — new helper that parses `$LOADEDMODULES` for modules with `gromacs` or `gmx` prefix (case-insensitive)
- **`_default_worker_init(for_simulate=False)`** — added `for_simulate` kwarg; when `True`, prepends detected GROMACS module loads separated by `;`
- Both call sites (`_configure_with_cluster`, `_configure_manual`) now pass `for_simulate=True` when stages indicate simulate context
- 11 new tests covering detection logic and integration with the worker init builder

### Example output

With `LOADEDMODULES=cuda/12.2:gromacs/2024.3-gpu:openmpi/4.1` and pixi environment present:

```
module load gromacs/2024.3-gpu; eval "$(pixi shell-hook --manifest-path /path/to/project -e default)"
```

For `build` context (empty stages), only the pixi shell-hook is included — no module load.