### PR TITLE
refactor: separate EnvironmentConfig from SLURM allocation

### DIFF
--- a/docs/content/docs/user-guide/running-on-hpc.mdx
+++ b/docs/content/docs/user-guide/running-on-hpc.mdx
@@ -73,15 +73,21 @@ mdfactory config slurm
 
 The wizard auto-discovers your cluster's partitions, accounts, and hardware (GPU types, memory, CPU counts) and walks through resource selection. The result is saved to a YAML file (default: `slurm_executor.yaml`).
 
-<Callout type="info" title="Automatic GROMACS module detection">
-When configuring for `simulate`, the wizard detects GROMACS modules loaded on the login node (from `$LOADEDMODULES`) and includes them in the default `worker_init` suggestion. This ensures compute nodes can find `gmx` / `gmx_mpi` without manual configuration. You can always edit the suggestion before confirming.
+<Callout type="info" title="Three-section wizard">
+The wizard is organized into three distinct sections:
+
+1. **SLURM Allocation** — account, partition, walltime, CPUs, GPUs, memory
+2. **Execution Environment** — auto-detected pixi/conda activation, GROMACS modules
+3. **Per-Stage Tuning** — resource overrides for individual simulation stages (EM, NVT, etc.)
+
+GROMACS modules are discovered via `module avail` on the login node and offered as a selection. The pixi/conda environment is auto-detected from the filesystem.
 </Callout>
 
 ### Manual configuration
 
 You can also write the YAML file directly. See [`examples/slurm_executor.yaml`](https://github.com/emdgroup/mdfactory/blob/main/examples/slurm_executor.yaml) for an annotated reference with all available fields.
 
-A minimal GPU configuration:
+A minimal GPU configuration with the structured `environment` section:
 
 ```yaml
 provider: slurm
@@ -92,10 +98,13 @@ cpus_per_node: 16
 gres: "gpu:1"
 max_workers_per_node: 1
 max_blocks: 4
-worker_init: |
-  source ~/.bashrc
-  module load gromacs/2024
+environment:
+  modules:
+    - gromacs/2024
+  pixi_manifest: /path/to/project
 ```
+
+
 
 ### Per-stage resource overrides
 
@@ -128,7 +137,10 @@ stage_overrides:
 | `available_accelerators` | GPU count or device IDs for `CUDA_VISIBLE_DEVICES` | `0` |
 | `retries` | Infrastructure retry count (OOM, timeout, preemption) | `3` |
 | `gmx_binary` | `"auto"`, `"gmx"`, or `"gmx_mpi"` | `"auto"` |
-| `worker_init` | Shell setup (module loads, etc.) | `""` |
+| `environment.modules` | Module loads for workers (e.g. `["gromacs/2024"]`) | `[]` |
+| `environment.pixi_manifest` | Path to pixi project root | auto-detected |
+| `environment.conda_env` | Conda env name to activate | — |
+| `environment.extra_init` | Custom shell commands | `""` |
 
 ## Running simulations on SLURM
 

--- a/docs/content/docs/user-guide/workflows.mdx
+++ b/docs/content/docs/user-guide/workflows.mdx
@@ -122,8 +122,9 @@ gres: "gpu:1"
 max_workers_per_node: 1
 max_blocks: 4
 gmx_binary: auto
-worker_init: |
-  module load gromacs/2024
+environment:
+  modules:
+    - gromacs/2024
 ```
 
 ### Per-stage resource overrides

--- a/examples/slurm_executor.yaml
+++ b/examples/slurm_executor.yaml
@@ -33,6 +33,23 @@ gres: "gpu:1"
 # Memory per node (passed as --mem to sbatch). Omit to use partition default.
 # mem: "32G"
 
+# --- Execution environment ---------------------------------------------------
+# Structured environment setup for compute workers. The wizard auto-detects
+# pixi/conda/venv and GROMACS modules.
+environment:
+  # Module loads (each becomes "module load <name>")
+  modules:
+    - gromacs/2024
+
+  # Python environment activation (first match wins: pixi > conda > venv).
+  # Auto-detected by the wizard; set explicitly for manual configs.
+  pixi_manifest: /path/to/project   # generates pixi shell-hook command
+  # conda_env: gromacs_env           # alternative: conda activate
+  # venv_path: /home/user/.venvs/md  # alternative: source activate
+
+  # Extra shell commands appended after modules + activation.
+  # extra_init: "export OMP_NUM_THREADS=4"
+
 # --- Parsl tuning ------------------------------------------------------------
 # Max parallel tasks per compute node.
 max_workers_per_node: 1
@@ -50,11 +67,6 @@ retries: 3
 # --- GROMACS settings --------------------------------------------------------
 # "auto" detects gmx vs gmx_mpi at runtime. Override to force one.
 gmx_binary: auto
-
-# Shell commands run inside every worker before any task (module loads, etc.).
-worker_init: |
-  source ~/.bashrc
-  module load gromacs/2024
 
 # --- Per-stage overrides (optional) ------------------------------------------
 # Override cpus_per_node, gres, or gmx_binary for individual stages.
@@ -76,3 +88,4 @@ worker_init: |
 
 # Extra flags passed to srun when launching workers.
 # launch_options: "--mpi=pmix"
+

--- a/mdfactory/cli.py
+++ b/mdfactory/cli.py
@@ -208,8 +208,11 @@ def _load_executor_config(config: "ExecutorConfig | Path | None") -> "ExecutorCo
 
     """
     if config is None:
-        from mdfactory.orchestration import ExecutorConfig
+        from mdfactory.orchestration import EnvironmentConfig, ExecutorConfig
 
+        global_env = EnvironmentConfig.load_global()
+        if global_env is not None:
+            return ExecutorConfig(environment=global_env)
         return ExecutorConfig()
     if isinstance(config, Path):
         from mdfactory.orchestration import ExecutorConfig
@@ -2379,6 +2382,26 @@ def config_slurm():
         configure_and_save_slurm()
     except UserCancelledError:
         logger.info("SLURM configuration cancelled.")
+
+
+@config_app.command(name="environment")
+def config_environment():
+    """Interactive wizard to configure the execution environment.
+
+    Detects the current Python environment (pixi, conda, or virtualenv),
+    prompts for GROMACS modules and additional init commands, then saves
+    the result to the global config directory.
+
+    The saved environment config is automatically used by SLURM executor
+    YAMLs that don't include an ``environment:`` section, so you only
+    need to configure this once per machine.
+    """
+    from mdfactory.orchestration.tui import UserCancelledError, configure_and_save_environment
+
+    try:
+        configure_and_save_environment()
+    except UserCancelledError:
+        logger.info("Environment configuration cancelled.")
 
 
 @config_app.command(name="cluster")

--- a/mdfactory/orchestration/__init__.py
+++ b/mdfactory/orchestration/__init__.py
@@ -4,9 +4,13 @@
 
 from .build import build_systems
 from .config import ExecutorConfig, SlurmExecutorConfig
-from .environment import EnvironmentConfig
+from .environment import EnvironmentConfig, get_global_environment_path
 from .simulate import clean_simulation_outputs, find_structure_file, run_simulations
-from .tui import configure_and_save_slurm, configure_slurm_interactive
+from .tui import (
+    configure_and_save_environment,
+    configure_and_save_slurm,
+    configure_slurm_interactive,
+)
 
 __all__ = [
     "EnvironmentConfig",
@@ -14,8 +18,10 @@ __all__ = [
     "SlurmExecutorConfig",
     "build_systems",
     "clean_simulation_outputs",
-    "find_structure_file",
-    "run_simulations",
+    "configure_and_save_environment",
     "configure_and_save_slurm",
     "configure_slurm_interactive",
+    "find_structure_file",
+    "get_global_environment_path",
+    "run_simulations",
 ]

--- a/mdfactory/orchestration/__init__.py
+++ b/mdfactory/orchestration/__init__.py
@@ -4,10 +4,12 @@
 
 from .build import build_systems
 from .config import ExecutorConfig, SlurmExecutorConfig
+from .environment import EnvironmentConfig
 from .simulate import clean_simulation_outputs, find_structure_file, run_simulations
 from .tui import configure_and_save_slurm, configure_slurm_interactive
 
 __all__ = [
+    "EnvironmentConfig",
     "ExecutorConfig",
     "SlurmExecutorConfig",
     "build_systems",

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
+from mdfactory.orchestration.environment import EnvironmentConfig
 from mdfactory.performance.slurm_config import BaseSlurmConfig
 
 if TYPE_CHECKING:
@@ -47,8 +48,10 @@ class ExecutorConfig(BaseModel):
     ----------
     provider : str
         Execution provider type ("local" or "slurm").
-    worker_init : str
-        Shell commands to run before starting workers (module loads, activation).
+    environment : EnvironmentConfig
+        Structured execution-environment configuration. Defines module
+        loads, Python environment activation, and extra shell init for
+        compute workers.
     working_directory : Path or None
         Working directory for the executor.
     max_workers_per_node : int
@@ -81,7 +84,7 @@ class ExecutorConfig(BaseModel):
     """
 
     provider: Literal["local", "slurm"] = "local"
-    worker_init: str = ""
+    environment: EnvironmentConfig = Field(default_factory=EnvironmentConfig)
     working_directory: Path | None = None
     max_workers_per_node: int = 1
     max_blocks: int = 1
@@ -134,7 +137,7 @@ class ExecutorConfig(BaseModel):
         from parsl.providers import LocalProvider
 
         provider = LocalProvider(
-            worker_init=self.worker_init,
+            worker_init=self.environment.compose_worker_init(),
             min_blocks=0,
             init_blocks=1,
             max_blocks=self.max_blocks,
@@ -223,7 +226,7 @@ class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
         which Parsl uses to size the worker pool (roughly ``--ntasks`` /
         cores-per-node) — it is **not** the sbatch ``--cpus-per-task`` flag. For
         MPI+OpenMP workloads (e.g. GROMACS), OpenMP threads-per-rank must be set
-        separately via ``scheduler_options`` / ``worker_init``.
+        separately via ``scheduler_options`` / ``environment.extra_init``.
     gres : str or None
         Generic resource specification (``--gres``), e.g. ``"gpu:l40s:1"``.
     mem : str or None
@@ -258,8 +261,10 @@ class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
         gres: "gpu:l40s:1"
         max_blocks: 5
         max_workers_per_node: 1
-        worker_init: |
-          eval "$(pixi shell-hook -e default)"
+        environment:
+          modules:
+            - gromacs/2024.3-gpu
+          pixi_manifest: /path/to/project
 
     """
 
@@ -398,7 +403,7 @@ class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
             walltime=self.walltime,
             nodes_per_block=self.nodes,
             cores_per_node=self.cpus_per_node,
-            worker_init=self.worker_init,
+            worker_init=self.environment.compose_worker_init(),
             scheduler_options=scheduler_options,
             min_blocks=0,
             init_blocks=1,

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -160,6 +160,11 @@ class ExecutorConfig(BaseModel):
     def from_yaml(cls, path: Path) -> "ExecutorConfig | SlurmExecutorConfig":
         """Load executor configuration from a YAML file.
 
+        If the YAML does not contain an ``environment:`` section, the
+        global environment config (from ``mdfactory config environment``)
+        is loaded automatically.  This allows environment setup to be
+        configured once per machine and reused across SLURM configs.
+
         Parameters
         ----------
         path : Path
@@ -177,6 +182,13 @@ class ExecutorConfig(BaseModel):
             raise ValueError(
                 f"Executor config YAML is empty or invalid (expected a mapping): {path}"
             )
+
+        # Auto-load global environment when YAML has no environment section
+        if "environment" not in data:
+            global_env = EnvironmentConfig.load_global()
+            if global_env is not None:
+                data["environment"] = global_env.model_dump(exclude_none=True)
+
         provider = data.get("provider", "local")
         if provider == "slurm":
             return SlurmExecutorConfig(**data)

--- a/mdfactory/orchestration/environment.py
+++ b/mdfactory/orchestration/environment.py
@@ -10,11 +10,15 @@ are separated from SLURM allocation and per-stage tuning.
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
+import yaml
 from pydantic import BaseModel, field_serializer
+
+logger = logging.getLogger(__name__)
 
 
 class EnvironmentConfig(BaseModel):
@@ -167,3 +171,99 @@ class EnvironmentConfig(BaseModel):
         # Apply overrides last
         kwargs.update(overrides)
         return cls(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save_yaml(self, path: Path) -> None:
+        """Write this environment config to a YAML file.
+
+        Empty/default fields are omitted for cleaner output.
+
+        Parameters
+        ----------
+        path : Path
+            Destination file path.  Parent directories are created if
+            needed.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = self.model_dump(exclude_none=True)
+        if not data.get("modules"):
+            data.pop("modules", None)
+        if not data.get("extra_init"):
+            data.pop("extra_init", None)
+
+        with open(path, "w") as fh:
+            yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> EnvironmentConfig:
+        """Load environment config from a YAML file.
+
+        Parameters
+        ----------
+        path : Path
+            Path to a YAML file with environment fields.
+
+        Returns
+        -------
+        EnvironmentConfig
+            Parsed environment configuration.
+
+        Raises
+        ------
+        FileNotFoundError
+            If *path* does not exist.
+        ValueError
+            If the file is empty or not a YAML mapping.
+        """
+        path = Path(path)
+        with open(path) as fh:
+            data = yaml.safe_load(fh)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Environment config YAML is empty or invalid (expected a mapping): {path}"
+            )
+        return cls(**data)
+
+    @classmethod
+    def load_global(cls) -> EnvironmentConfig | None:
+        """Load the global environment config, if it exists.
+
+        The global config lives at
+        ``<config-dir>/environment.yaml`` (see
+        :func:`get_global_environment_path`).
+
+        Returns
+        -------
+        EnvironmentConfig or None
+            The loaded config, or ``None`` if the file does not exist
+            or cannot be parsed.
+        """
+        path = get_global_environment_path()
+        if not path.is_file():
+            return None
+        try:
+            env = cls.from_yaml(path)
+            logger.debug("Loaded global environment config from %s", path)
+            return env
+        except Exception:
+            logger.warning("Failed to load global environment config from %s", path, exc_info=True)
+            return None
+
+
+def get_global_environment_path() -> Path:
+    """Return the path to the global environment config file.
+
+    Returns
+    -------
+    Path
+        ``<user-config-dir>/environment.yaml``, where the config dir
+        is determined by :func:`~mdfactory.settings.get_config_dir`.
+    """
+    from mdfactory.settings import get_config_dir
+
+    return get_config_dir() / "environment.yaml"

--- a/mdfactory/orchestration/environment.py
+++ b/mdfactory/orchestration/environment.py
@@ -240,19 +240,21 @@ class EnvironmentConfig(BaseModel):
         Returns
         -------
         EnvironmentConfig or None
-            The loaded config, or ``None`` if the file does not exist
-            or cannot be parsed.
+            The loaded config, or ``None`` if the file does not exist.
+
+        Raises
+        ------
+        ValueError
+            If the file exists but cannot be parsed.  This fails fast
+            so a corrupt config is caught immediately rather than
+            silently submitting jobs with no environment.
         """
         path = get_global_environment_path()
         if not path.is_file():
             return None
-        try:
-            env = cls.from_yaml(path)
-            logger.debug("Loaded global environment config from %s", path)
-            return env
-        except Exception:
-            logger.warning("Failed to load global environment config from %s", path, exc_info=True)
-            return None
+        env = cls.from_yaml(path)
+        logger.debug("Loaded global environment config from %s", path)
+        return env
 
 
 def get_global_environment_path() -> Path:

--- a/mdfactory/orchestration/environment.py
+++ b/mdfactory/orchestration/environment.py
@@ -1,0 +1,169 @@
+# ABOUTME: Structured execution-environment configuration for compute workers
+# ABOUTME: Replaces the opaque worker_init string with typed fields and auto-detection
+"""Execution-environment configuration for Parsl compute workers.
+
+Defines :class:`EnvironmentConfig`, a structured replacement for the legacy
+``worker_init`` flat string on :class:`~mdfactory.orchestration.config.ExecutorConfig`.
+Environment concerns (module loads, pixi/conda activation, MPS lifecycle)
+are separated from SLURM allocation and per-stage tuning.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, field_serializer
+
+
+class EnvironmentConfig(BaseModel):
+    """Compute-node environment setup — what makes workers capable of running tasks.
+
+    This model captures the structured fields that compose the ``worker_init``
+    shell snippet passed to Parsl providers.  Instead of hand-editing a single
+    opaque string, users specify modules, activation commands, and custom
+    init separately.
+
+    Parameters
+    ----------
+    modules : list[str]
+        Environment modules to load (e.g. ``["gromacs/2024.3-gpu"]``).
+        Each entry becomes a ``module load <name>`` command.
+    pixi_manifest : Path or None
+        Path to a pixi project root (containing ``pixi.toml``).
+        When set, a ``pixi shell-hook`` activation command is emitted.
+        Auto-detected by :meth:`detect` from the filesystem or
+        ``PIXI_PROJECT_MANIFEST`` environment variable.
+    conda_env : str or None
+        Conda environment name to activate.  Ignored when
+        ``pixi_manifest`` is set (pixi takes precedence).
+    venv_path : Path or None
+        Path to a Python virtualenv.  Ignored when ``pixi_manifest``
+        or ``conda_env`` is set.
+    extra_init : str
+        Additional shell commands appended after all structured fields.
+        This is the escape hatch for anything not covered by the typed
+        fields (e.g. custom ``export`` statements, ``ulimit`` settings).
+
+    Examples
+    --------
+    >>> env = EnvironmentConfig(
+    ...     modules=["gromacs/2024.3-gpu"],
+    ...     pixi_manifest=Path("/project"),
+    ... )
+    >>> env.compose_worker_init()
+    'module load gromacs/2024.3-gpu; eval "$(pixi shell-hook --manifest-path /project -e default)"'
+
+    """
+
+    modules: list[str] = []
+    pixi_manifest: Path | None = None
+    conda_env: str | None = None
+    venv_path: Path | None = None
+    extra_init: str = ""
+
+    @field_serializer("pixi_manifest", "venv_path")
+    def _serialize_paths(self, v: Path | None) -> str | None:
+        """Serialize Path fields as plain strings for YAML compatibility."""
+        return str(v) if v is not None else None
+
+    def compose_worker_init(self) -> str:
+        """Build the shell snippet from structured fields.
+
+        Produces a semicolon-separated string of shell commands suitable
+        for Parsl's ``worker_init`` parameter.  The order is:
+
+        1. ``module load`` commands (one per entry in :attr:`modules`)
+        2. Environment activation (pixi > conda > venv, first match wins)
+        3. :attr:`extra_init` (appended verbatim)
+
+        Returns
+        -------
+        str
+            Shell snippet, or ``""`` if all fields are empty/default.
+        """
+        parts: list[str] = []
+
+        for mod in self.modules:
+            parts.append(f"module load {mod}")
+
+        if self.pixi_manifest:
+            parts.append(
+                f'eval "$(pixi shell-hook --manifest-path {self.pixi_manifest} -e default)"'
+            )
+        elif self.conda_env:
+            parts.append(f"conda activate {self.conda_env}")
+        elif self.venv_path:
+            parts.append(f"source {self.venv_path}/bin/activate")
+
+        if self.extra_init:
+            parts.append(self.extra_init)
+
+        return "; ".join(parts)
+
+    @classmethod
+    def detect(cls, **overrides: Any) -> EnvironmentConfig:
+        """Auto-detect environment from the current shell context.
+
+        Detection priority for Python environment activation:
+
+        1. **pixi** — checks ``PIXI_PROJECT_MANIFEST`` env var, then
+           falls back to the ``mdfactory`` package's own project root
+           (looks for ``.pixi/envs/default``).
+        2. **conda** — checks ``CONDA_PREFIX`` env var.
+        3. **venv** — checks ``VIRTUAL_ENV`` env var.
+
+        Only the first match is used; the rest are ignored.
+
+        GROMACS modules are **not** auto-detected here — that requires
+        subprocess calls to ``module avail`` which belong in the TUI
+        layer (see :func:`~mdfactory.orchestration.tui._detect_gromacs_modules`).
+
+        Parameters
+        ----------
+        **overrides
+            Keyword arguments forwarded to the constructor, overriding
+            any auto-detected values.
+
+        Returns
+        -------
+        EnvironmentConfig
+            Environment config with detected fields populated.
+        """
+        kwargs: dict[str, Any] = {}
+
+        # --- pixi detection ---
+        pixi_manifest_env = os.environ.get("PIXI_PROJECT_MANIFEST")
+        if pixi_manifest_env:
+            # PIXI_PROJECT_MANIFEST points to the manifest file itself
+            manifest_path = Path(pixi_manifest_env)
+            kwargs["pixi_manifest"] = manifest_path.parent
+        else:
+            # Fall back to mdfactory's own project root
+            try:
+                import mdfactory as _mdf
+
+                project_root = Path(_mdf.__file__).parent.parent
+                if (project_root / ".pixi" / "envs" / "default").exists():
+                    kwargs["pixi_manifest"] = project_root
+            except Exception:
+                pass
+
+        # --- conda detection (only if pixi not found) ---
+        if "pixi_manifest" not in kwargs:
+            conda_prefix = os.environ.get("CONDA_PREFIX")
+            if conda_prefix:
+                # Extract env name from the prefix path
+                conda_path = Path(conda_prefix)
+                kwargs["conda_env"] = conda_path.name
+
+        # --- venv detection (only if pixi and conda not found) ---
+        if "pixi_manifest" not in kwargs and "conda_env" not in kwargs:
+            venv_path = os.environ.get("VIRTUAL_ENV")
+            if venv_path:
+                kwargs["venv_path"] = Path(venv_path)
+
+        # Apply overrides last
+        kwargs.update(overrides)
+        return cls(**kwargs)

--- a/mdfactory/orchestration/progress.py
+++ b/mdfactory/orchestration/progress.py
@@ -1,0 +1,193 @@
+# ABOUTME: Thread-safe progress tracking for per-stage simulation monitoring
+# ABOUTME: Provides StageProgressTracker and Rich progress display for EM/NVT/NPT/Production stages
+"""Per-stage progress tracking for simulation orchestration.
+
+Provides :class:`StageProgressTracker`, a thread-safe tracker that worker
+threads report into, and :func:`display_stage_progress`, a Rich-based
+display that polls the tracker and renders one progress bar per simulation
+stage (EM, NVT, NPT, Production).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class SimState(Enum):
+    """State of a single simulation in a single stage."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+_TERMINAL = frozenset({SimState.SUCCEEDED, SimState.FAILED, SimState.SKIPPED})
+
+
+@dataclass
+class StageProgressTracker:
+    """Thread-safe tracker for per-stage, per-simulation progress.
+
+    Worker threads call :meth:`mark_running`, :meth:`mark_succeeded`,
+    :meth:`mark_failed`, :meth:`mark_skipped`.  The main thread calls
+    :meth:`snapshot` for counts and :meth:`all_done` for termination.
+
+    Parameters
+    ----------
+    stages : list[str]
+        Ordered stage names (e.g. ``["EM", "NVT", "NPT", "Production"]``).
+    sim_hashes : list[str]
+        Simulation directory hashes, one per simulation.
+
+    """
+
+    stages: list[str]
+    sim_hashes: list[str]
+
+    _state: dict[str, dict[str, SimState]] = field(init=False)
+    _lock: threading.Lock = field(init=False, default_factory=threading.Lock)
+    _results: dict[str, dict] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._state = {
+            stage: {h: SimState.PENDING for h in self.sim_hashes} for stage in self.stages
+        }
+        self._lock = threading.Lock()
+        self._results = {}
+
+    def mark_running(self, stage: str, sim_hash: str) -> None:
+        with self._lock:
+            self._state[stage][sim_hash] = SimState.RUNNING
+
+    def mark_succeeded(self, stage: str, sim_hash: str) -> None:
+        with self._lock:
+            self._state[stage][sim_hash] = SimState.SUCCEEDED
+
+    def mark_failed(self, stage: str, sim_hash: str) -> None:
+        with self._lock:
+            self._state[stage][sim_hash] = SimState.FAILED
+
+    def mark_skipped(self, stage: str, sim_hash: str) -> None:
+        with self._lock:
+            self._state[stage][sim_hash] = SimState.SKIPPED
+
+    def store_result(self, sim_hash: str, result: dict) -> None:
+        """Store the final result dict for a simulation."""
+        with self._lock:
+            self._results[sim_hash] = result
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        """Return per-stage counts.
+
+        Returns
+        -------
+        dict[str, dict[str, int]]
+            ``{stage: {succeeded: N, failed: N, running: N, pending: N, skipped: N}}``.
+        """
+        with self._lock:
+            out: dict[str, dict[str, int]] = {}
+            for stage in self.stages:
+                counts = {s.value: 0 for s in SimState}
+                for h in self.sim_hashes:
+                    counts[self._state[stage][h].value] += 1
+                out[stage] = counts
+            return out
+
+    def all_done(self) -> bool:
+        """Return ``True`` when every simulation's last stage is terminal."""
+        with self._lock:
+            last_stage = self.stages[-1]
+            return all(self._state[last_stage][h] in _TERMINAL for h in self.sim_hashes)
+
+    def collect_results(self) -> list[dict]:
+        """Return stored result dicts in ``sim_hashes`` order."""
+        with self._lock:
+            return [
+                self._results.get(h, {"hash": h, "status": "unknown"}) for h in self.sim_hashes
+            ]
+
+
+def display_stage_progress(
+    tracker: StageProgressTracker,
+    *,
+    poll_interval: float = 2.0,
+) -> None:
+    """Poll the tracker and render Rich progress bars until all simulations finish.
+
+    Runs on the main thread.  Blocks until :meth:`StageProgressTracker.all_done`
+    returns ``True``.
+
+    Parameters
+    ----------
+    tracker : StageProgressTracker
+        Shared tracker updated by worker threads.
+    poll_interval : float
+        Seconds between display refreshes.
+
+    """
+    from rich.console import Console, Group
+    from rich.live import Live
+    from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
+    from rich.text import Text
+
+    from .build import _get_block_status
+
+    console = Console()
+    total = len(tracker.sim_hashes)
+
+    progress = Progress(
+        TextColumn("{task.description}"),
+        BarColumn(bar_width=40),
+        MofNCompleteColumn(),
+        TextColumn("·"),
+        TextColumn("[green]{task.fields[succeeded]} ✓[/]"),
+        TextColumn("[red]{task.fields[failed]} ✗[/]"),
+        TextColumn("[yellow]{task.fields[running]} ●[/]"),
+        console=console,
+        transient=False,
+    )
+
+    task_ids = {}
+    max_len = max(len(s) for s in tracker.stages)
+    for stage in tracker.stages:
+        tid = progress.add_task(
+            f"⚒ {stage:<{max_len}}",
+            total=total,
+            succeeded=0,
+            failed=0,
+            running=0,
+        )
+        task_ids[stage] = tid
+
+    def _render():
+        snap = tracker.snapshot()
+        for stage in tracker.stages:
+            counts = snap[stage]
+            done = counts["succeeded"] + counts["failed"] + counts["skipped"]
+            progress.update(
+                task_ids[stage],
+                completed=done,
+                succeeded=counts["succeeded"],
+                failed=counts["failed"],
+                running=counts["running"],
+            )
+        parts: list = [progress]
+        block_info = _get_block_status()
+        if block_info:
+            parts.append(Text.from_markup(f"  ▸ SLURM: {block_info}"))
+        return Group(*parts)
+
+    try:
+        with Live(_render(), console=console, refresh_per_second=2) as live:
+            while not tracker.all_done():
+                time.sleep(poll_interval)
+                live.update(_render())
+            live.update(_render())
+    except KeyboardInterrupt:
+        console.print("\n[bold yellow]Interrupted — cancelling SLURM jobs...[/]")
+        raise

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from .apps import get_grompp_app, get_mdrun_app
-from .build import _wait_with_progress
 from .session import parsl_session
 from .stages import (
     STAGE_BY_NAME,
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
     from parsl import AppFuture
 
     from .config import ExecutorConfig
+    from .progress import StageProgressTracker
 
 
 def _bash_result_to_dict(raw: object, sim_hash: str) -> dict:
@@ -199,31 +199,31 @@ def run_simulations(
             # Validate first stage has required inputs
             _validate_stage_prerequisites(item["sim_dir"], item["stages"][0])
 
-    # 5. Parsl session
+    # 5. Filter active items (stages still needed)
+    active_items = []
+    for item in work_plan:
+        if not item["stages"]:
+            logger.info(f"Skipping {item['hash']} (all stages complete)")
+            continue
+        active_items.append(item)
+
+    if not active_items:
+        logger.info("All simulations already complete.")
+        return skipped_results
+
+    # 6. Parsl session
     with parsl_session(config) as session:
         grompp_app = get_grompp_app()
         mdrun_app = get_mdrun_app()
 
-        # 6. Submit all pipelines (embarrassingly parallel)
-        # When rescue is active (max_rescue > 0), each simulation's
-        # pipeline may block internally while waiting for rescue-eligible
-        # stages.  Using ThreadPoolExecutor ensures cross-simulation
-        # parallelism is preserved — one simulation's rescue wait doesn't
-        # block other simulations from being submitted and executing.
-        from concurrent.futures import Future as StdFuture
-        from concurrent.futures import ThreadPoolExecutor
+        # wait=False: legacy path returning raw futures (no progress display)
+        if not wait:
+            from concurrent.futures import Future as StdFuture
+            from concurrent.futures import ThreadPoolExecutor
 
-        futures = []
-        active_items = []
-        for item in work_plan:
-            if not item["stages"]:
-                logger.info(f"Skipping {item['hash']} (all stages complete)")
-                continue
-            active_items.append(item)
+            futures: list[tuple[str, object]] = []
 
-        if active_items:
-
-            def _run_pipeline(item):
+            def _run_pipeline_nowait(item):
                 return _execute_stage_list(
                     item["sim_dir"],
                     item["stages"],
@@ -236,25 +236,19 @@ def run_simulations(
 
             with ThreadPoolExecutor() as pool:
                 thread_futs = [
-                    (item["hash"], pool.submit(_run_pipeline, item)) for item in active_items
+                    (item["hash"], pool.submit(_run_pipeline_nowait, item))
+                    for item in active_items
                 ]
                 for h, tf in thread_futs:
                     try:
                         futures.append((h, tf.result()))
                     except Exception as exc:
-                        # Rescue exhaustion or other pipeline-level failure.
-                        # Wrap in a pre-failed future so _wait_with_progress
-                        # handles it per-simulation (matching pre-rescue
-                        # behavior where individual failures didn't crash
-                        # the batch).
                         logger.error(f"Pipeline failed for {h}: {exc}")
                         failed_fut = StdFuture()
                         failed_fut.set_exception(exc)
                         futures.append((h, failed_fut))
 
-        logger.info(f"Submitted {len(futures)} simulation(s)")
-
-        if not wait:
+            logger.info(f"Submitted {len(futures)} simulation(s)")
             logger.warning(
                 "Returning raw AppFuture objects — futures resolve to None (bash_app exit), "
                 "not status dicts.  Caller must call parsl.clear() when done."
@@ -262,16 +256,80 @@ def run_simulations(
             session.detach()
             return [fut for _, fut in futures]
 
-        # 7. Wait with progress UI (reuse from build.py)
-        hashes = [h for h, _ in futures]
-        parsl_futures = [fut for _, fut in futures]
-        run_results = _wait_with_progress(
-            parsl_futures,
-            hashes=hashes,
-            label="Simulations",
-            result_transform=_bash_result_to_dict,
-        )
-        # Prepend skipped-build entries so succeeded + failed + skipped == requested
+        # 7. wait=True: tracked execution with per-stage progress display
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+
+        from .build import _describe_failure
+        from .progress import StageProgressTracker, display_stage_progress
+
+        all_hashes = [item["hash"] for item in active_items]
+        tracker = StageProgressTracker(stages=stages, sim_hashes=all_hashes)
+
+        # Pre-mark stages already completed by checkpoint detection
+        for item in active_items:
+            for stage in stages:
+                if stage not in item["stages"]:
+                    tracker.mark_succeeded(stage, item["hash"])
+
+        def _run_pipeline(item):
+            sim_hash = item["hash"]
+            try:
+                final_future = _execute_stage_list(
+                    item["sim_dir"],
+                    item["stages"],
+                    grompp_app,
+                    mdrun_app,
+                    stage_restarts=item.get("stage_restarts"),
+                    config=config,
+                    max_rescue=max_rescue,
+                    tracker=tracker,
+                )
+                # Wait for the terminal future (Production) to collect its result
+                if final_future is not None:
+                    try:
+                        raw = final_future.result()
+                        result = _bash_result_to_dict(raw, sim_hash)
+                    except Exception as exc:
+                        failure_type, error_detail = _describe_failure(exc)
+                        result = {
+                            "hash": sim_hash,
+                            "status": "failed",
+                            "error": error_detail,
+                            "failure_type": failure_type,
+                            "error_detail": error_detail,
+                        }
+                else:
+                    result = {"hash": sim_hash, "status": "success"}
+                tracker.store_result(sim_hash, result)
+            except Exception as exc:
+                failure_type, error_detail = _describe_failure(exc)
+                tracker.store_result(sim_hash, {
+                    "hash": sim_hash,
+                    "status": "failed",
+                    "error": error_detail,
+                    "failure_type": failure_type,
+                    "error_detail": error_detail,
+                })
+
+        logger.info(f"Submitted {len(active_items)} simulation(s)")
+
+        # Launch worker threads without blocking the main thread
+        pool = ThreadPoolExecutor()
+        thread_futures = [pool.submit(_run_pipeline, item) for item in active_items]
+        pool.shutdown(wait=False)
+
+        # Main thread: display progress until all stages complete
+        display_stage_progress(tracker)
+
+        # Ensure all worker threads have finished (no-op in normal usage
+        # since display blocks until all_done, but needed for test mocks)
+        from concurrent.futures import wait as futures_wait
+
+        futures_wait(thread_futures)
+
+        # Collect results
+        run_results = tracker.collect_results()
         return skipped_results + run_results
 
 
@@ -687,6 +745,7 @@ def _execute_stage_list(
     stage_restarts: "dict[str, str] | None" = None,
     config: "ExecutorConfig | None" = None,
     max_rescue: int = 3,
+    tracker: "StageProgressTracker | None" = None,
 ) -> "AppFuture | None":
     """Execute a list of stages with automatic dependency chaining.
 
@@ -720,6 +779,10 @@ def _execute_stage_list(
     max_rescue : int
         Maximum rescue tiers for physics failures in EM/NVT/NPT stages.
         Set to 0 to disable rescue.
+    tracker : StageProgressTracker or None, optional
+        Thread-safe progress tracker.  When provided, each stage is reported
+        as running/succeeded/failed.  On failure, remaining stages are marked
+        skipped.
 
     Returns
     -------
@@ -736,6 +799,7 @@ def _execute_stage_list(
         return None
 
     restarts = stage_restarts or {}
+    sim_hash = sim_dir.name
 
     # Validate that stages are in dependency order (derived from STAGE_REGISTRY — single source)
     stage_order = [s.name for s in STAGE_REGISTRY]
@@ -751,48 +815,64 @@ def _execute_stage_list(
             raise ValueError(f"Stages must be in dependency order: {stage_order}. Got: {stages}")
         prev_idx = curr_idx
 
-    # Execute stages sequentially, chaining futures through run_stage.
-    # STAGE_REGISTRY is the single dispatch source: a new stage added there
-    # becomes immediately executable here without further edits to this module.
-    # prev_future=None on the first iteration is handled correctly by run_stage
-    # for all stages (including non-EM checkpoint resumes).
-    #
-    # Rescue-eligible stages (EM/NVT/NPT) with max_rescue > 0 use the rescue
-    # loop which waits for each stage individually.  Non-rescue stages and
-    # stages with checkpoint restarts chain futures as before.
     from .mdp import RESCUE_ELIGIBLE_STAGES
     from .rescue import execute_stage_with_rescue
 
     prev_future = None
-    for stage in stages:
+    for i, stage in enumerate(stages):
         cpt_file = restarts.get(stage, "")
 
-        # Use rescue loop for eligible stages without checkpoint restart
-        if max_rescue > 0 and stage in RESCUE_ELIGIBLE_STAGES and not cpt_file:
-            prev_future = execute_stage_with_rescue(
-                sim_dir,
-                stage,
-                prev_future,
-                grompp_app,
-                mdrun_app,
-                max_rescue=max_rescue,
-                config=config,
-            )
-        else:
-            # Standard execution: chain futures without waiting
-            stage_cfg = (
-                config.get_stage_config(stage) if hasattr(config, "get_stage_config") else None
-            )
-            cfg_kwarg = {"stage_config": stage_cfg} if stage_cfg is not None else {}
-            prev_future = run_stage(
-                STAGE_BY_NAME[stage],
-                sim_dir,
-                prev_future,
-                grompp_app,
-                mdrun_app,
-                restart_from_cpt=cpt_file,
-                **cfg_kwarg,
-            )
+        if tracker is not None:
+            tracker.mark_running(stage, sim_hash)
+
+        try:
+            if max_rescue > 0 and stage in RESCUE_ELIGIBLE_STAGES and not cpt_file:
+                prev_future = execute_stage_with_rescue(
+                    sim_dir,
+                    stage,
+                    prev_future,
+                    grompp_app,
+                    mdrun_app,
+                    max_rescue=max_rescue,
+                    config=config,
+                )
+                # Rescue stages block — if we get here, it succeeded
+                if tracker is not None:
+                    tracker.mark_succeeded(stage, sim_hash)
+            else:
+                stage_cfg = (
+                    config.get_stage_config(stage)
+                    if hasattr(config, "get_stage_config")
+                    else None
+                )
+                cfg_kwarg = {"stage_config": stage_cfg} if stage_cfg is not None else {}
+                prev_future = run_stage(
+                    STAGE_BY_NAME[stage],
+                    sim_dir,
+                    prev_future,
+                    grompp_app,
+                    mdrun_app,
+                    restart_from_cpt=cpt_file,
+                    **cfg_kwarg,
+                )
+                # Non-rescue stages return immediately — track via callback
+                if tracker is not None:
+                    _s, _h, _t = stage, sim_hash, tracker
+
+                    def _on_done(fut, s=_s, h=_h, t=_t):
+                        if fut.exception() is not None:
+                            t.mark_failed(s, h)
+                        else:
+                            t.mark_succeeded(s, h)
+
+                    prev_future.add_done_callback(_on_done)
+
+        except Exception:
+            if tracker is not None:
+                tracker.mark_failed(stage, sim_hash)
+                for skip_stage in stages[i + 1 :]:
+                    tracker.mark_skipped(skip_stage, sim_hash)
+            raise
 
     return prev_future
 

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -961,3 +961,43 @@ def configure_and_save_slurm() -> SlurmExecutorConfig:
 
     save_slurm_config_yaml(config, Path(save_path))
     return config
+
+
+def configure_and_save_environment() -> EnvironmentConfig:
+    """Run the environment wizard and save to the global config location.
+
+    Prompts for execution environment (modules, pixi/conda/venv, extra init)
+    and saves the result to ``~/.config/mdfactory/environment.yaml`` (or the
+    platform-appropriate config directory).
+
+    This global environment config is automatically loaded by
+    :meth:`~mdfactory.orchestration.config.ExecutorConfig.from_yaml` when a
+    SLURM executor YAML does not contain an ``environment:`` section.
+
+    Returns
+    -------
+    EnvironmentConfig
+        The environment config that was saved.
+
+    Raises
+    ------
+    UserCancelledError
+        If the user cancels any prompt.
+    """
+    from mdfactory.orchestration.environment import get_global_environment_path
+
+    console.print(Rule("Execution Environment", style="bold green"))
+
+    try:
+        env = _prompt_environment(stages=None)
+    except UserCancelledError:
+        console.print("Configuration cancelled.")
+        raise
+
+    save_path = get_global_environment_path()
+    env.save_yaml(save_path)
+    console.print(f"✓ Environment config written to {save_path}")
+    console.print(
+        "  This will be used automatically when SLURM configs don't include an environment section."
+    )
+    return env

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -7,18 +7,25 @@ Provides a terminal-based wizard that queries the local SLURM cluster
 the user through selecting accounts, partitions, and resource limits.
 The result is a :class:`~mdfactory.orchestration.config.SlurmExecutorConfig`
 that can be saved as YAML and used with Parsl-based workflows.
+
+The wizard is structured into three distinct sections:
+
+1. **SLURM Allocation** — cluster infrastructure (account, partition, resources)
+2. **Execution Environment** — project/tool setup (modules, pixi, extra init)
+3. **Per-Stage Tuning** — simulation-specific overrides (cpus, gres, gmx_binary)
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import yaml
 from rich.console import Console
 from rich.panel import Panel
+from rich.rule import Rule
 
 from mdfactory.orchestration.config import SlurmExecutorConfig
+from mdfactory.orchestration.environment import EnvironmentConfig
 from mdfactory.performance.cluster import ClusterInfo, Partition, discover_cluster
 
 console = Console()
@@ -54,52 +61,6 @@ def _import_questionary():
 
 
 def _detect_gromacs_modules() -> list[str]:
-    """Detect loaded GROMACS modules from ``$LOADEDMODULES``.
-
-    The ``LOADEDMODULES`` environment variable is a colon-separated list
-    of currently loaded modules (set by the ``module`` system on HPC
-    clusters).  This function returns module names that look like
-    GROMACS (case-insensitive prefix match on ``gromacs`` or ``gmx``).
-
-    Returns
-    -------
-    list[str]
-        Module names that match GROMACS, e.g. ``["gromacs/2024.3-gpu"]``.
-        Empty list if no modules are loaded or the variable is unset.
-    """
-    loaded = os.environ.get("LOADEDMODULES", "")
-    if not loaded:
-        return []
-    return [mod for mod in loaded.split(":") if mod.lower().startswith(("gromacs", "gmx"))]
-
-
-def _default_worker_init() -> str:
-    """Auto-detect the pixi environment and return an appropriate worker_init.
-
-    On HPC clusters with a shared filesystem, workers need the same pixi
-    environment as the submitting process.  This function locates the
-    project root via ``mdfactory.__file__`` and returns a pixi shell-hook
-    command if the environment exists.
-
-    Returns
-    -------
-    str
-        A shell command to activate the pixi environment, or ``""`` if
-        no pixi environment is detected.
-    """
-    try:
-        import mdfactory as _mdf
-
-        project_root = Path(_mdf.__file__).parent.parent
-        pixi_env = project_root / ".pixi" / "envs" / "default"
-        if pixi_env.exists():
-            return f'eval "$(pixi shell-hook --manifest-path {project_root} -e default)"'
-    except Exception:
-        pass
-    return ""
-
-
-def _detect_gromacs_modules() -> list[str]:
     """Discover available GROMACS modules via ``module avail``.
 
     Returns
@@ -109,13 +70,7 @@ def _detect_gromacs_modules() -> list[str]:
         or an empty list if ``module`` is not available or no GROMACS
         modules are found.
     """
-    import shutil
     import subprocess
-
-    # module is typically a shell function; invoke via bash -l
-    if shutil.which("modulecmd") is None and shutil.which("module") is None:
-        # Try invoking anyway — module is often a bash function, not a binary
-        pass
 
     try:
         # 'module avail' writes to stderr (by design)
@@ -143,23 +98,22 @@ def _detect_gromacs_modules() -> list[str]:
         return []
 
 
-def _prompt_gromacs_source() -> str:
-    """Prompt the user for how to load GROMACS on compute workers.
+def _prompt_gromacs_modules() -> list[str]:
+    """Prompt the user to select GROMACS modules for compute workers.
 
     Only prompts if ``gmx``/``gmx_mpi`` is not on the current PATH.
-    If GROMACS is already available, returns ``""``.
+    If GROMACS is already available, returns an empty list.
 
     Returns
     -------
-    str
-        A shell command to prepend to worker_init (e.g.
-        ``"module load gromacs/2024.4; "``), or ``""`` if not needed.
+    list[str]
+        Module names to load (e.g. ``["gromacs/2024.4"]``), or ``[]``.
     """
     import shutil
 
     # If gmx is already on PATH, no action needed
     if shutil.which("gmx") or shutil.which("gmx_mpi"):
-        return ""
+        return []
 
     questionary = _import_questionary()
 
@@ -169,42 +123,42 @@ def _prompt_gromacs_source() -> str:
     console.print("\n  [yellow]⚠ GROMACS (gmx/gmx_mpi) not found in current PATH.[/yellow]")
     console.print("  Compute workers need GROMACS to run simulations.\n")
 
-    _CUSTOM = "Custom command…"
-    _SKIP = "Skip (I'll include it in worker_init manually)"
+    _CUSTOM = "Custom module name…"
+    _SKIP = "Skip (I'll handle it in extra_init or PATH)"
 
     if modules:
         choices = [*modules, _CUSTOM, _SKIP]
         selected = _require(
             questionary.select(
-                "How should workers load GROMACS?",
+                "GROMACS module to load on workers:",
                 choices=choices,
                 default=modules[0],
             ).ask(),
-            "gromacs source",
+            "gromacs module",
         )
     else:
         # No modules found — offer manual entry or skip
         selected = _require(
             questionary.select(
-                "How should workers load GROMACS?",
+                "GROMACS module to load on workers:",
                 choices=[_CUSTOM, _SKIP],
             ).ask(),
-            "gromacs source",
+            "gromacs module",
         )
 
     if selected == _SKIP:
-        return ""
+        return []
     elif selected == _CUSTOM:
-        cmd = _require(
+        mod_name = _require(
             questionary.text(
-                "Command to make GROMACS available (e.g. 'module load gromacs/2024'):",
+                "Module name (e.g. 'gromacs/2024.4-gpu'):",
             ).ask(),
-            "gromacs command",
+            "gromacs module name",
         )
-        return f"{cmd.strip()}; " if cmd.strip() else ""
+        return [mod_name.strip()] if mod_name.strip() else []
     else:
-        # User selected a module
-        return f"module load {selected}; "
+        # User selected a discovered module
+        return [selected]
 
 
 class UserCancelledError(Exception):
@@ -535,6 +489,67 @@ def _prompt_stage_overrides(
 
 
 # ---------------------------------------------------------------------------
+# Environment section prompts
+# ---------------------------------------------------------------------------
+
+
+def _prompt_environment(*, stages: tuple[str, ...] | None = None) -> EnvironmentConfig:
+    """Prompt the user for execution-environment configuration.
+
+    Auto-detects pixi/conda/venv, prompts for GROMACS modules (if needed
+    for simulate workflows), and offers an extra_init escape hatch.
+
+    Parameters
+    ----------
+    stages : tuple[str, ...] or None, optional
+        The simulation stages. Pass ``()`` to skip GROMACS prompts
+        (e.g. for ``build``). ``None`` uses the full pipeline.
+
+    Returns
+    -------
+    EnvironmentConfig
+        Structured environment configuration.
+    """
+    questionary = _import_questionary()
+
+    # Start with auto-detection
+    env = EnvironmentConfig.detect()
+
+    # Show what was detected
+    if env.pixi_manifest:
+        console.print(f"  ✓ Detected pixi environment at {env.pixi_manifest}")
+    elif env.conda_env:
+        console.print(f"  ✓ Detected conda environment: {env.conda_env}")
+    elif env.venv_path:
+        console.print(f"  ✓ Detected virtualenv at {env.venv_path}")
+    else:
+        console.print("  ℹ No Python environment auto-detected.")
+
+    # GROMACS module prompts (skip for build workflows)
+    modules: list[str] = []
+    if stages != ():
+        modules = _prompt_gromacs_modules()
+
+    # Extra init commands
+    extra_init = _require(
+        questionary.text(
+            "Additional init commands (leave empty to skip):",
+            default="",
+        ).ask(),
+        "extra_init",
+    )
+
+    # Build the final config, merging auto-detected + user input
+    return EnvironmentConfig(
+        modules=modules,
+        pixi_manifest=env.pixi_manifest,
+        conda_env=env.conda_env if not env.pixi_manifest else None,
+        venv_path=env.venv_path if not env.pixi_manifest and not env.conda_env else None,
+        extra_init=extra_init.strip(),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Interactive prompts — cluster-assisted
 # ---------------------------------------------------------------------------
 
@@ -568,6 +583,10 @@ def _configure_with_cluster(
         If the user cancels any prompt.
     """
     questionary = _import_questionary()
+
+    # ━━━ Section 1: SLURM Allocation ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    console.print(Rule("SLURM Allocation", style="bold cyan"))
+
     # --- Account ---
     if cluster.accounts:
         account = _require(
@@ -678,17 +697,6 @@ def _configure_with_cluster(
         )
     )
 
-    # --- GROMACS detection + Worker init ---
-    gmx_prefix = _prompt_gromacs_source() if stages != () else ""
-    default_init = gmx_prefix + _default_worker_init()
-    worker_init = _require(
-        questionary.text(
-            "Worker init script (activates environment on compute nodes):",
-            default=default_init,
-        ).ask(),
-        "worker_init",
-    )
-
     # --- QOS ---
     qos: str | None = None
     if cluster.qos_policies:
@@ -711,7 +719,14 @@ def _configure_with_cluster(
     )
     constraint: str | None = constraint_input.strip() or None
 
-    # --- Per-stage overrides ---
+    # ━━━ Section 2: Execution Environment ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    console.print(Rule("Execution Environment", style="bold green"))
+
+    environment = _prompt_environment(stages=stages)
+
+    # ━━━ Section 3: Per-Stage Tuning ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    console.print(Rule("Per-Stage Tuning", style="bold yellow"))
+
     resolved_stages = _resolve_stages(stages)
     stage_overrides = _prompt_stage_overrides(
         common_cpus=cpus_per_node,
@@ -730,7 +745,7 @@ def _configure_with_cluster(
         qos=qos,
         constraint=constraint,
         max_blocks=max_blocks,
-        worker_init=worker_init,
+        environment=environment,
         stage_overrides=stage_overrides,
     )
 
@@ -761,6 +776,10 @@ def _configure_manual(*, stages: tuple[str, ...] | None = None) -> SlurmExecutor
         If the user cancels any prompt.
     """
     questionary = _import_questionary()
+
+    # ━━━ Section 1: SLURM Allocation ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    console.print(Rule("SLURM Allocation", style="bold cyan"))
+
     account = _require(questionary.text("SLURM account:").ask(), "account")
     partition = _require(questionary.text("SLURM partition:", default="gpu").ask(), "partition")
     walltime = _require(questionary.text("Walltime (--time):", default="2:00:00").ask(), "walltime")
@@ -793,17 +812,14 @@ def _configure_manual(*, stages: tuple[str, ...] | None = None) -> SlurmExecutor
         )
     )
 
-    gmx_prefix = _prompt_gromacs_source() if stages != () else ""
-    default_init = gmx_prefix + _default_worker_init()
-    worker_init = _require(
-        questionary.text(
-            "Worker init script (activates environment on compute nodes):",
-            default=default_init,
-        ).ask(),
-        "worker_init",
-    )
+    # ━━━ Section 2: Execution Environment ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    console.print(Rule("Execution Environment", style="bold green"))
 
-    # --- Per-stage overrides ---
+    environment = _prompt_environment(stages=stages)
+
+    # ━━━ Section 3: Per-Stage Tuning ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    console.print(Rule("Per-Stage Tuning", style="bold yellow"))
+
     resolved_stages = _resolve_stages(stages)
     stage_overrides = _prompt_stage_overrides(
         common_cpus=cpus_per_node,
@@ -821,7 +837,7 @@ def _configure_manual(*, stages: tuple[str, ...] | None = None) -> SlurmExecutor
         mem=mem,
         qos=qos,
         max_blocks=max_blocks,
-        worker_init=worker_init,
+        environment=environment,
         stage_overrides=stage_overrides,
     )
 
@@ -894,9 +910,22 @@ def save_slurm_config_yaml(config: SlurmExecutorConfig, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
     data = config.model_dump(exclude_none=True)
+
+    # Clean up empty fields in environment section
+    if "environment" in data:
+        env_data = data["environment"]
+        if not env_data.get("modules"):
+            env_data.pop("modules", None)
+        if not env_data.get("extra_init"):
+            env_data.pop("extra_init", None)
+        # Remove environment section entirely if empty after cleanup
+        if not env_data:
+            data.pop("environment")
+
     # Omit empty stage_overrides for cleaner YAML output
     if not data.get("stage_overrides"):
         data.pop("stage_overrides", None)
+
     with open(path, "w") as fh:
         yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
 

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -493,7 +493,9 @@ def _prompt_stage_overrides(
 # ---------------------------------------------------------------------------
 
 
-def _prompt_environment(*, stages: tuple[str, ...] | None = None) -> EnvironmentConfig:
+def _prompt_environment(
+    *, stages: tuple[str, ...] | None = None, ignore_global: bool = False
+) -> EnvironmentConfig:
     """Prompt the user for execution-environment configuration.
 
     If a global environment config exists (written by
@@ -507,6 +509,10 @@ def _prompt_environment(*, stages: tuple[str, ...] | None = None) -> Environment
     stages : tuple[str, ...] or None, optional
         The simulation stages. Pass ``()`` to skip GROMACS prompts
         (e.g. for ``build``). ``None`` uses the full pipeline.
+    ignore_global : bool, optional
+        If True, skip loading the global config and always run the
+        interactive wizard. Used by ``configure_and_save_environment``
+        so users can update an existing global config.
 
     Returns
     -------
@@ -515,7 +521,10 @@ def _prompt_environment(*, stages: tuple[str, ...] | None = None) -> Environment
     """
     from mdfactory.orchestration.environment import get_global_environment_path
 
-    global_env = EnvironmentConfig.load_global()
+    if not ignore_global:
+        global_env = EnvironmentConfig.load_global()
+    else:
+        global_env = None
     if global_env is not None:
         path = get_global_environment_path()
         console.print(f"  ✓ Using saved environment config from {path}")
@@ -1006,7 +1015,7 @@ def configure_and_save_environment() -> EnvironmentConfig:
     console.print(Rule("Execution Environment", style="bold green"))
 
     try:
-        env = _prompt_environment(stages=None)
+        env = _prompt_environment(stages=None, ignore_global=True)
     except UserCancelledError:
         console.print("Configuration cancelled.")
         raise

--- a/mdfactory/orchestration/tui.py
+++ b/mdfactory/orchestration/tui.py
@@ -496,8 +496,11 @@ def _prompt_stage_overrides(
 def _prompt_environment(*, stages: tuple[str, ...] | None = None) -> EnvironmentConfig:
     """Prompt the user for execution-environment configuration.
 
-    Auto-detects pixi/conda/venv, prompts for GROMACS modules (if needed
-    for simulate workflows), and offers an extra_init escape hatch.
+    If a global environment config exists (written by
+    ``mdfactory config environment``), it is used directly without
+    prompting.  Otherwise, auto-detects pixi/conda/venv, prompts for
+    GROMACS modules (if needed for simulate workflows), and offers an
+    extra_init escape hatch.
 
     Parameters
     ----------
@@ -510,6 +513,20 @@ def _prompt_environment(*, stages: tuple[str, ...] | None = None) -> Environment
     EnvironmentConfig
         Structured environment configuration.
     """
+    from mdfactory.orchestration.environment import get_global_environment_path
+
+    global_env = EnvironmentConfig.load_global()
+    if global_env is not None:
+        path = get_global_environment_path()
+        console.print(f"  ✓ Using saved environment config from {path}")
+        if global_env.modules:
+            console.print(f"    modules: {', '.join(global_env.modules)}")
+        if global_env.pixi_manifest:
+            console.print(f"    pixi: {global_env.pixi_manifest}")
+        elif global_env.conda_env:
+            console.print(f"    conda: {global_env.conda_env}")
+        return global_env
+
     questionary = _import_questionary()
 
     # Start with auto-detection

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -8,13 +8,14 @@ import yaml
 pytest.importorskip("parsl", reason="parsl not installed")
 
 from mdfactory.orchestration.config import ExecutorConfig, SlurmExecutorConfig
+from mdfactory.orchestration.environment import EnvironmentConfig
 
 
 def test_executor_config_defaults():
     """ExecutorConfig has sensible defaults."""
     cfg = ExecutorConfig()
     assert cfg.provider == "local"
-    assert cfg.worker_init == ""
+    assert cfg.environment == EnvironmentConfig()
     assert cfg.working_directory is None
     assert cfg.max_workers_per_node == 1
 
@@ -81,7 +82,8 @@ def test_executor_config_from_yaml_slurm(tmp_path):
 
 def test_executor_config_to_parsl_config():
     """to_parsl_config produces a valid Parsl Config for local provider."""
-    cfg = ExecutorConfig(max_workers_per_node=2, worker_init="module load cuda/12.0")
+    env = EnvironmentConfig(modules=["cuda/12.0"])
+    cfg = ExecutorConfig(max_workers_per_node=2, environment=env)
     result = cfg.to_parsl_config()
 
     import parsl
@@ -103,13 +105,28 @@ def test_slurm_executor_config_to_parsl_config():
     assert result.executors[0].label == "slurm"
 
 
-def test_worker_init_propagation():
-    """worker_init string is passed to the SLURM provider."""
-    cfg = SlurmExecutorConfig(account="acc", worker_init="module load cuda/12.0")
+def test_environment_propagation():
+    """environment.compose_worker_init() is passed to the SLURM provider."""
+    env = EnvironmentConfig(modules=["cuda/12.0"])
+    cfg = SlurmExecutorConfig(account="acc", environment=env)
     result = cfg.to_parsl_config()
 
     provider = result.executors[0].provider
     assert "module load cuda/12.0" in provider.worker_init
+
+
+def test_environment_combined_propagation():
+    """Multiple environment fields are composed into the provider worker_init."""
+    env = EnvironmentConfig(
+        modules=["gromacs/2024.3-gpu"],
+        pixi_manifest="/project",
+    )
+    cfg = SlurmExecutorConfig(account="acc", environment=env)
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert "module load gromacs/2024.3-gpu" in provider.worker_init
+    assert "pixi shell-hook" in provider.worker_init
 
 
 def test_gres_in_scheduler_options():
@@ -247,12 +264,13 @@ def test_launch_options_roundtrip_yaml(tmp_path):
 
 def test_config_yaml_roundtrip(tmp_path):
     """Config can be written to YAML and loaded back identically."""
+    env = EnvironmentConfig(modules=["gromacs/2024"], extra_init="source activate env")
     original = SlurmExecutorConfig(
         account="test_account",
         partition="gpu-dev",
         walltime="1:00:00",
         gres="gpu:l40s:1",
-        worker_init="source activate env",
+        environment=env,
     )
     cfg_path = tmp_path / "roundtrip.yaml"
     with open(cfg_path, "w") as f:
@@ -264,7 +282,64 @@ def test_config_yaml_roundtrip(tmp_path):
     assert loaded.partition == original.partition
     assert loaded.walltime == original.walltime
     assert loaded.gres == original.gres
-    assert loaded.worker_init == original.worker_init
+    assert loaded.environment.modules == ["gromacs/2024"]
+    assert loaded.environment.extra_init == "source activate env"
+
+
+# === EnvironmentConfig integration tests ===
+
+
+def test_environment_field_defaults_to_empty():
+    """ExecutorConfig defaults environment to an empty EnvironmentConfig."""
+    cfg = ExecutorConfig()
+    assert cfg.environment == EnvironmentConfig()
+    assert cfg.environment.compose_worker_init() == ""
+
+
+def test_to_parsl_config_uses_environment():
+    """to_parsl_config passes environment-composed string to the provider."""
+    env = EnvironmentConfig(modules=["gromacs/2024.3-gpu"])
+    cfg = ExecutorConfig(environment=env)
+    result = cfg.to_parsl_config()
+    provider = result.executors[0].provider
+    assert "module load gromacs/2024.3-gpu" in provider.worker_init
+
+
+def test_from_yaml_environment_section(tmp_path):
+    """YAML with environment section loads correctly."""
+    cfg_data = {
+        "provider": "slurm",
+        "account": "acc",
+        "environment": {
+            "modules": ["gromacs/2024.3-gpu"],
+            "pixi_manifest": "/project/root",
+            "extra_init": "ulimit -s unlimited",
+        },
+    }
+    cfg_path = tmp_path / "new.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg_data, f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert isinstance(loaded, SlurmExecutorConfig)
+    assert loaded.environment.modules == ["gromacs/2024.3-gpu"]
+    assert str(loaded.environment.pixi_manifest) == "/project/root"
+    assert loaded.environment.extra_init == "ulimit -s unlimited"
+    worker_init = loaded.environment.compose_worker_init()
+    assert "gromacs" in worker_init
+    assert "pixi shell-hook" in worker_init
+
+
+def test_from_yaml_no_environment(tmp_path):
+    """YAML without environment section gets empty EnvironmentConfig."""
+    cfg_data = {"provider": "slurm", "account": "acc"}
+    cfg_path = tmp_path / "minimal.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg_data, f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert loaded.environment == EnvironmentConfig()
+    assert loaded.environment.compose_worker_init() == ""
 
 
 # === Decision 6: Per-stage resource config tests ===

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -330,8 +330,10 @@ def test_from_yaml_environment_section(tmp_path):
     assert "pixi shell-hook" in worker_init
 
 
-def test_from_yaml_no_environment(tmp_path):
-    """YAML without environment section gets empty EnvironmentConfig."""
+def test_from_yaml_no_environment(tmp_path, monkeypatch):
+    """YAML without environment section gets empty EnvironmentConfig when no global exists."""
+    # Point config dir to an empty tmp dir so no global file is found
+    monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path / "config"))
     cfg_data = {"provider": "slurm", "account": "acc"}
     cfg_path = tmp_path / "minimal.yaml"
     with open(cfg_path, "w") as f:
@@ -340,6 +342,54 @@ def test_from_yaml_no_environment(tmp_path):
     loaded = ExecutorConfig.from_yaml(cfg_path)
     assert loaded.environment == EnvironmentConfig()
     assert loaded.environment.compose_worker_init() == ""
+
+
+def test_from_yaml_auto_loads_global_environment(tmp_path, monkeypatch):
+    """YAML without environment section auto-loads from global config."""
+    # Create a global environment config
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(config_dir))
+    global_env = EnvironmentConfig(
+        modules=["gromacs/2024"],
+        conda_env="md",
+    )
+    global_env.save_yaml(config_dir / "environment.yaml")
+
+    # Load a SLURM YAML with no environment section
+    cfg_data = {"provider": "slurm", "account": "acc"}
+    cfg_path = tmp_path / "slurm.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg_data, f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert loaded.environment.modules == ["gromacs/2024"]
+    assert loaded.environment.conda_env == "md"
+    assert "gromacs/2024" in loaded.environment.compose_worker_init()
+
+
+def test_from_yaml_explicit_environment_overrides_global(tmp_path, monkeypatch):
+    """YAML with explicit environment section ignores global config."""
+    # Create a global environment config
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(config_dir))
+    global_env = EnvironmentConfig(modules=["gromacs/2024"])
+    global_env.save_yaml(config_dir / "environment.yaml")
+
+    # Load a YAML that has its own environment section
+    cfg_data = {
+        "provider": "slurm",
+        "account": "acc",
+        "environment": {"modules": ["gromacs/2025"], "conda_env": "custom"},
+    }
+    cfg_path = tmp_path / "slurm.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg_data, f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert loaded.environment.modules == ["gromacs/2025"]
+    assert loaded.environment.conda_env == "custom"
 
 
 # === Decision 6: Per-stage resource config tests ===

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -392,6 +392,45 @@ def test_from_yaml_explicit_environment_overrides_global(tmp_path, monkeypatch):
     assert loaded.environment.conda_env == "custom"
 
 
+# === _load_executor_config tests ===
+
+
+def test_load_executor_config_none_without_global(tmp_path, monkeypatch):
+    """_load_executor_config(None) returns default ExecutorConfig when no global env exists."""
+    monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path / "no-config"))
+    from mdfactory.cli import _load_executor_config
+
+    cfg = _load_executor_config(None)
+    assert cfg.environment == EnvironmentConfig()
+    assert cfg.environment.compose_worker_init() == ""
+
+
+def test_load_executor_config_none_with_global(tmp_path, monkeypatch):
+    """_load_executor_config(None) loads global env config when it exists."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(config_dir))
+    global_env = EnvironmentConfig(modules=["gromacs/2024"], conda_env="md")
+    global_env.save_yaml(config_dir / "environment.yaml")
+    from mdfactory.cli import _load_executor_config
+
+    cfg = _load_executor_config(None)
+    assert cfg.environment.modules == ["gromacs/2024"]
+    assert cfg.environment.conda_env == "md"
+
+
+def test_load_executor_config_none_with_corrupt_global(tmp_path, monkeypatch):
+    """_load_executor_config(None) raises ValueError on corrupt global env config."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(config_dir))
+    (config_dir / "environment.yaml").write_text("- not a mapping\n")
+    from mdfactory.cli import _load_executor_config
+
+    with pytest.raises(ValueError, match="empty or invalid"):
+        _load_executor_config(None)
+
+
 # === Decision 6: Per-stage resource config tests ===
 
 
@@ -492,6 +531,26 @@ def test_get_stage_config_multiple_stages():
     assert nvt is cfg  # no override, returns self
     assert prod.cpus_per_node == 24
     assert prod.gres == "gpu:l40s:1"  # inherited
+
+
+def test_get_stage_config_rejects_unhonored_keys():
+    """Invalid override keys (e.g. walltime, mem) raise ValueError immediately."""
+    cfg = SlurmExecutorConfig(
+        account="acct",
+        stage_overrides={"EM": {"walltime": "1:00:00"}},
+    )
+    with pytest.raises(ValueError, match="walltime"):
+        cfg.get_stage_config("EM")
+
+
+def test_get_stage_config_rejects_multiple_unhonored_keys():
+    """Multiple invalid keys are all reported in the error message."""
+    cfg = SlurmExecutorConfig(
+        account="acct",
+        stage_overrides={"NVT": {"walltime": "2:00:00", "mem": "64G"}},
+    )
+    with pytest.raises(ValueError, match="walltime|mem"):
+        cfg.get_stage_config("NVT")
 
 
 # === gmx_binary field tests ===

--- a/mdfactory/tests/test_orchestration_environment.py
+++ b/mdfactory/tests/test_orchestration_environment.py
@@ -4,6 +4,7 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from mdfactory.orchestration.environment import EnvironmentConfig
@@ -290,15 +291,11 @@ class TestSaveLoadYaml:
 
     def test_from_yaml_file_not_found(self, tmp_path):
         """from_yaml raises FileNotFoundError for missing file."""
-        import pytest
-
         with pytest.raises(FileNotFoundError):
             EnvironmentConfig.from_yaml(tmp_path / "nope.yaml")
 
     def test_from_yaml_invalid_content(self, tmp_path):
         """from_yaml raises ValueError for non-mapping YAML."""
-        import pytest
-
         path = tmp_path / "bad.yaml"
         path.write_text("- item1\n- item2\n")
         with pytest.raises(ValueError, match="empty or invalid"):
@@ -327,9 +324,9 @@ class TestLoadGlobal:
         assert result.modules == ["gromacs/2024"]
         assert result.conda_env == "md"
 
-    def test_returns_none_on_corrupt_file(self, tmp_path, monkeypatch):
-        """load_global returns None if file cannot be parsed."""
+    def test_raises_on_corrupt_file(self, tmp_path, monkeypatch):
+        """load_global raises ValueError if file exists but cannot be parsed."""
         monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
         (tmp_path / "environment.yaml").write_text("- not a mapping\n")
-        result = EnvironmentConfig.load_global()
-        assert result is None
+        with pytest.raises(ValueError, match="empty or invalid"):
+            EnvironmentConfig.load_global()

--- a/mdfactory/tests/test_orchestration_environment.py
+++ b/mdfactory/tests/test_orchestration_environment.py
@@ -251,3 +251,85 @@ class TestSerialization:
         assert "pixi_manifest" not in dumped
         assert "venv_path" not in dumped
         assert "conda_env" not in dumped
+
+
+class TestSaveLoadYaml:
+    """Tests for EnvironmentConfig.save_yaml() and from_yaml()."""
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        """save_yaml then from_yaml produces equivalent config."""
+        env = EnvironmentConfig(
+            modules=["gromacs/2024.3-gpu"],
+            pixi_manifest=Path("/project"),
+            extra_init="export OMP_NUM_THREADS=4",
+        )
+        path = tmp_path / "env.yaml"
+        env.save_yaml(path)
+        loaded = EnvironmentConfig.from_yaml(path)
+        assert loaded.modules == env.modules
+        assert loaded.pixi_manifest == env.pixi_manifest
+        assert loaded.extra_init == env.extra_init
+        assert loaded.compose_worker_init() == env.compose_worker_init()
+
+    def test_save_omits_empty_fields(self, tmp_path):
+        """Empty modules and extra_init are not written to YAML."""
+        env = EnvironmentConfig(conda_env="gromacs")
+        path = tmp_path / "env.yaml"
+        env.save_yaml(path)
+        data = yaml.safe_load(path.read_text())
+        assert "modules" not in data
+        assert "extra_init" not in data
+        assert data["conda_env"] == "gromacs"
+
+    def test_save_creates_parent_directories(self, tmp_path):
+        """save_yaml creates parent directories if they don't exist."""
+        path = tmp_path / "deep" / "nested" / "env.yaml"
+        env = EnvironmentConfig(modules=["mod1"])
+        env.save_yaml(path)
+        assert path.is_file()
+
+    def test_from_yaml_file_not_found(self, tmp_path):
+        """from_yaml raises FileNotFoundError for missing file."""
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            EnvironmentConfig.from_yaml(tmp_path / "nope.yaml")
+
+    def test_from_yaml_invalid_content(self, tmp_path):
+        """from_yaml raises ValueError for non-mapping YAML."""
+        import pytest
+
+        path = tmp_path / "bad.yaml"
+        path.write_text("- item1\n- item2\n")
+        with pytest.raises(ValueError, match="empty or invalid"):
+            EnvironmentConfig.from_yaml(path)
+
+
+class TestLoadGlobal:
+    """Tests for EnvironmentConfig.load_global()."""
+
+    def test_returns_none_when_no_file(self, tmp_path, monkeypatch):
+        """load_global returns None when no global config exists."""
+        monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
+        result = EnvironmentConfig.load_global()
+        assert result is None
+
+    def test_loads_existing_global_config(self, tmp_path, monkeypatch):
+        """load_global returns config when global file exists."""
+        monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
+        env = EnvironmentConfig(
+            modules=["gromacs/2024"],
+            conda_env="md",
+        )
+        env.save_yaml(tmp_path / "environment.yaml")
+        result = EnvironmentConfig.load_global()
+        assert result is not None
+        assert result.modules == ["gromacs/2024"]
+        assert result.conda_env == "md"
+
+    def test_returns_none_on_corrupt_file(self, tmp_path, monkeypatch):
+        """load_global returns None if file cannot be parsed."""
+        monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
+        (tmp_path / "environment.yaml").write_text("- not a mapping\n")
+        result = EnvironmentConfig.load_global()
+        assert result is None

--- a/mdfactory/tests/test_orchestration_environment.py
+++ b/mdfactory/tests/test_orchestration_environment.py
@@ -1,0 +1,253 @@
+# ABOUTME: Tests for EnvironmentConfig model
+# ABOUTME: Validates compose_worker_init(), detect(), and YAML serialization
+"""Tests for the EnvironmentConfig structured environment model."""
+
+from pathlib import Path
+
+import yaml
+
+from mdfactory.orchestration.environment import EnvironmentConfig
+
+
+class TestComposeWorkerInit:
+    """Tests for EnvironmentConfig.compose_worker_init()."""
+
+    def test_empty_produces_empty_string(self):
+        """All defaults produce an empty worker_init string."""
+        env = EnvironmentConfig()
+        assert env.compose_worker_init() == ""
+
+    def test_modules_only(self):
+        """Module list produces 'module load' commands."""
+        env = EnvironmentConfig(modules=["gromacs/2024.3-gpu"])
+        assert env.compose_worker_init() == "module load gromacs/2024.3-gpu"
+
+    def test_multiple_modules(self):
+        """Multiple modules are joined with semicolons."""
+        env = EnvironmentConfig(modules=["cuda/12.2", "gromacs/2024.3-gpu"])
+        result = env.compose_worker_init()
+        assert result == "module load cuda/12.2; module load gromacs/2024.3-gpu"
+
+    def test_pixi_manifest(self):
+        """pixi_manifest produces a pixi shell-hook command."""
+        env = EnvironmentConfig(pixi_manifest=Path("/project/root"))
+        result = env.compose_worker_init()
+        assert result == 'eval "$(pixi shell-hook --manifest-path /project/root -e default)"'
+
+    def test_conda_env(self):
+        """conda_env produces a conda activate command."""
+        env = EnvironmentConfig(conda_env="myenv")
+        assert env.compose_worker_init() == "conda activate myenv"
+
+    def test_venv_path(self):
+        """venv_path produces a source activate command."""
+        env = EnvironmentConfig(venv_path=Path("/home/user/.venvs/md"))
+        assert env.compose_worker_init() == "source /home/user/.venvs/md/bin/activate"
+
+    def test_pixi_takes_precedence_over_conda(self):
+        """When pixi_manifest and conda_env are both set, pixi wins."""
+        env = EnvironmentConfig(
+            pixi_manifest=Path("/project"),
+            conda_env="myenv",
+        )
+        result = env.compose_worker_init()
+        assert "pixi shell-hook" in result
+        assert "conda" not in result
+
+    def test_pixi_takes_precedence_over_venv(self):
+        """When pixi_manifest and venv_path are both set, pixi wins."""
+        env = EnvironmentConfig(
+            pixi_manifest=Path("/project"),
+            venv_path=Path("/venv"),
+        )
+        result = env.compose_worker_init()
+        assert "pixi shell-hook" in result
+        assert "source" not in result
+
+    def test_conda_takes_precedence_over_venv(self):
+        """When conda_env and venv_path are both set, conda wins."""
+        env = EnvironmentConfig(
+            conda_env="myenv",
+            venv_path=Path("/venv"),
+        )
+        result = env.compose_worker_init()
+        assert "conda activate myenv" in result
+        assert "source" not in result
+
+    def test_extra_init_only(self):
+        """extra_init alone is returned verbatim."""
+        env = EnvironmentConfig(extra_init="export OMP_NUM_THREADS=4")
+        assert env.compose_worker_init() == "export OMP_NUM_THREADS=4"
+
+    def test_combined_modules_pixi_extra(self):
+        """All components are joined with semicolons in correct order."""
+        env = EnvironmentConfig(
+            modules=["gromacs/2024.3-gpu"],
+            pixi_manifest=Path("/project"),
+            extra_init="export OMP_NUM_THREADS=4",
+        )
+        result = env.compose_worker_init()
+        parts = result.split("; ")
+        assert parts[0] == "module load gromacs/2024.3-gpu"
+        assert "pixi shell-hook" in parts[1]
+        assert parts[2] == "export OMP_NUM_THREADS=4"
+
+    def test_combined_modules_conda(self):
+        """Modules + conda are correctly combined."""
+        env = EnvironmentConfig(
+            modules=["cuda/12.2"],
+            conda_env="gromacs_env",
+        )
+        result = env.compose_worker_init()
+        assert result == "module load cuda/12.2; conda activate gromacs_env"
+
+
+class TestDetect:
+    """Tests for EnvironmentConfig.detect() auto-detection."""
+
+    def test_detect_pixi_from_env_var(self, monkeypatch, tmp_path):
+        """PIXI_PROJECT_MANIFEST env var is detected."""
+        manifest = tmp_path / "pixi.toml"
+        manifest.touch()
+        monkeypatch.setenv("PIXI_PROJECT_MANIFEST", str(manifest))
+        monkeypatch.delenv("CONDA_PREFIX", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        env = EnvironmentConfig.detect()
+        assert env.pixi_manifest == tmp_path
+        assert env.conda_env is None
+        assert env.venv_path is None
+
+    def test_detect_pixi_from_filesystem(self, monkeypatch, tmp_path):
+        """Pixi is detected from mdfactory's project root .pixi/ dir."""
+        monkeypatch.delenv("PIXI_PROJECT_MANIFEST", raising=False)
+        monkeypatch.delenv("CONDA_PREFIX", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        # Create a fake mdfactory package structure
+        fake_pkg = tmp_path / "mdfactory"
+        fake_pkg.mkdir()
+        (fake_pkg / "__init__.py").write_text("__file__ = __file__\n")
+        pixi_env = tmp_path / ".pixi" / "envs" / "default"
+        pixi_env.mkdir(parents=True)
+
+        # Patch mdfactory.__file__ to point to our fake
+        import mdfactory
+
+        monkeypatch.setattr(mdfactory, "__file__", str(fake_pkg / "__init__.py"))
+
+        env = EnvironmentConfig.detect()
+        assert env.pixi_manifest == tmp_path
+
+    def test_detect_conda_from_env(self, monkeypatch):
+        """CONDA_PREFIX env var is detected when pixi is absent."""
+        monkeypatch.delenv("PIXI_PROJECT_MANIFEST", raising=False)
+        monkeypatch.setenv("CONDA_PREFIX", "/opt/conda/envs/gromacs")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        # Ensure pixi filesystem detection also fails
+        import mdfactory
+
+        monkeypatch.setattr(mdfactory, "__file__", "/nonexistent/mdfactory/__init__.py")
+
+        env = EnvironmentConfig.detect()
+        assert env.pixi_manifest is None
+        assert env.conda_env == "gromacs"
+        assert env.venv_path is None
+
+    def test_detect_venv_from_env(self, monkeypatch):
+        """VIRTUAL_ENV env var is detected when pixi and conda are absent."""
+        monkeypatch.delenv("PIXI_PROJECT_MANIFEST", raising=False)
+        monkeypatch.delenv("CONDA_PREFIX", raising=False)
+        monkeypatch.setenv("VIRTUAL_ENV", "/home/user/.venvs/md")
+
+        import mdfactory
+
+        monkeypatch.setattr(mdfactory, "__file__", "/nonexistent/mdfactory/__init__.py")
+
+        env = EnvironmentConfig.detect()
+        assert env.pixi_manifest is None
+        assert env.conda_env is None
+        assert env.venv_path == Path("/home/user/.venvs/md")
+
+    def test_detect_nothing(self, monkeypatch):
+        """Clean environment produces empty EnvironmentConfig."""
+        monkeypatch.delenv("PIXI_PROJECT_MANIFEST", raising=False)
+        monkeypatch.delenv("CONDA_PREFIX", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        import mdfactory
+
+        monkeypatch.setattr(mdfactory, "__file__", "/nonexistent/mdfactory/__init__.py")
+
+        env = EnvironmentConfig.detect()
+        assert env.pixi_manifest is None
+        assert env.conda_env is None
+        assert env.venv_path is None
+        assert env.modules == []
+        assert env.extra_init == ""
+        assert env.compose_worker_init() == ""
+
+    def test_detect_pixi_takes_precedence_over_conda(self, monkeypatch, tmp_path):
+        """When both PIXI_PROJECT_MANIFEST and CONDA_PREFIX are set, pixi wins."""
+        manifest = tmp_path / "pixi.toml"
+        manifest.touch()
+        monkeypatch.setenv("PIXI_PROJECT_MANIFEST", str(manifest))
+        monkeypatch.setenv("CONDA_PREFIX", "/opt/conda/envs/other")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        env = EnvironmentConfig.detect()
+        assert env.pixi_manifest == tmp_path
+        assert env.conda_env is None
+
+    def test_detect_with_overrides(self, monkeypatch, tmp_path):
+        """Keyword overrides take precedence over auto-detection."""
+        manifest = tmp_path / "pixi.toml"
+        manifest.touch()
+        monkeypatch.setenv("PIXI_PROJECT_MANIFEST", str(manifest))
+        monkeypatch.delenv("CONDA_PREFIX", raising=False)
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        env = EnvironmentConfig.detect(modules=["gromacs/2024"], extra_init="ulimit -s unlimited")
+        assert env.pixi_manifest == tmp_path
+        assert env.modules == ["gromacs/2024"]
+        assert env.extra_init == "ulimit -s unlimited"
+
+
+class TestSerialization:
+    """Tests for EnvironmentConfig YAML serialization."""
+
+    def test_paths_serialize_as_strings(self):
+        """Path fields serialize as plain strings for YAML compatibility."""
+        env = EnvironmentConfig(
+            pixi_manifest=Path("/project/root"),
+            venv_path=Path("/home/user/.venvs/md"),
+        )
+        dumped = env.model_dump()
+        assert isinstance(dumped["pixi_manifest"], str)
+        assert isinstance(dumped["venv_path"], str)
+        # Round-trips through yaml without RepresenterError
+        yaml.safe_dump(dumped)
+
+    def test_yaml_roundtrip(self):
+        """EnvironmentConfig survives YAML round-trip."""
+        env = EnvironmentConfig(
+            modules=["gromacs/2024.3-gpu", "cuda/12.2"],
+            pixi_manifest=Path("/project"),
+            extra_init="export OMP_NUM_THREADS=4",
+        )
+        dumped = yaml.safe_dump(env.model_dump())
+        loaded = yaml.safe_load(dumped)
+        restored = EnvironmentConfig(**loaded)
+        assert restored.modules == env.modules
+        assert restored.pixi_manifest == env.pixi_manifest
+        assert restored.extra_init == env.extra_init
+        assert restored.compose_worker_init() == env.compose_worker_init()
+
+    def test_none_paths_excluded_with_exclude_none(self):
+        """None-valued path fields are excluded with exclude_none=True."""
+        env = EnvironmentConfig(modules=["gromacs/2024"])
+        dumped = env.model_dump(exclude_none=True)
+        assert "pixi_manifest" not in dumped
+        assert "venv_path" not in dumped
+        assert "conda_env" not in dumped

--- a/mdfactory/tests/test_orchestration_progress.py
+++ b/mdfactory/tests/test_orchestration_progress.py
@@ -1,0 +1,142 @@
+# ABOUTME: Tests for per-stage simulation progress tracking
+# ABOUTME: Covers StageProgressTracker state transitions, thread safety, and result collection
+"""Tests for the per-stage progress tracker."""
+
+import threading
+
+import pytest
+
+from mdfactory.orchestration.progress import SimState, StageProgressTracker
+
+
+class TestStageProgressTracker:
+    """Unit tests for StageProgressTracker."""
+
+    def _make_tracker(self):
+        return StageProgressTracker(
+            stages=["EM", "NVT", "NPT", "Production"],
+            sim_hashes=["aaa", "bbb", "ccc"],
+        )
+
+    def test_initial_state_all_pending(self):
+        tracker = self._make_tracker()
+        snap = tracker.snapshot()
+        for stage in ["EM", "NVT", "NPT", "Production"]:
+            assert snap[stage]["pending"] == 3
+            assert snap[stage]["running"] == 0
+
+    def test_mark_running(self):
+        tracker = self._make_tracker()
+        tracker.mark_running("EM", "aaa")
+        snap = tracker.snapshot()
+        assert snap["EM"]["running"] == 1
+        assert snap["EM"]["pending"] == 2
+
+    def test_mark_succeeded(self):
+        tracker = self._make_tracker()
+        tracker.mark_running("EM", "aaa")
+        tracker.mark_succeeded("EM", "aaa")
+        snap = tracker.snapshot()
+        assert snap["EM"]["succeeded"] == 1
+        assert snap["EM"]["running"] == 0
+
+    def test_mark_failed(self):
+        tracker = self._make_tracker()
+        tracker.mark_running("NVT", "bbb")
+        tracker.mark_failed("NVT", "bbb")
+        snap = tracker.snapshot()
+        assert snap["NVT"]["failed"] == 1
+
+    def test_mark_skipped(self):
+        tracker = self._make_tracker()
+        tracker.mark_skipped("NPT", "ccc")
+        snap = tracker.snapshot()
+        assert snap["NPT"]["skipped"] == 1
+
+    def test_all_done_false_initially(self):
+        tracker = self._make_tracker()
+        assert not tracker.all_done()
+
+    def test_all_done_true_when_last_stage_terminal(self):
+        tracker = self._make_tracker()
+        tracker.mark_succeeded("Production", "aaa")
+        tracker.mark_failed("Production", "bbb")
+        tracker.mark_skipped("Production", "ccc")
+        assert tracker.all_done()
+
+    def test_all_done_false_with_running_last_stage(self):
+        tracker = self._make_tracker()
+        tracker.mark_succeeded("Production", "aaa")
+        tracker.mark_succeeded("Production", "bbb")
+        tracker.mark_running("Production", "ccc")
+        assert not tracker.all_done()
+
+    def test_store_and_collect_results(self):
+        tracker = self._make_tracker()
+        tracker.store_result("bbb", {"hash": "bbb", "status": "success"})
+        tracker.store_result("aaa", {"hash": "aaa", "status": "failed"})
+        tracker.store_result("ccc", {"hash": "ccc", "status": "success"})
+
+        results = tracker.collect_results()
+        assert len(results) == 3
+        assert results[0]["hash"] == "aaa"
+        assert results[1]["hash"] == "bbb"
+        assert results[2]["hash"] == "ccc"
+
+    def test_collect_results_missing_returns_unknown(self):
+        tracker = self._make_tracker()
+        tracker.store_result("aaa", {"hash": "aaa", "status": "success"})
+        results = tracker.collect_results()
+        assert results[1] == {"hash": "bbb", "status": "unknown"}
+
+    def test_thread_safety(self):
+        """Concurrent mark calls from multiple threads don't crash."""
+        tracker = StageProgressTracker(
+            stages=["EM", "Production"],
+            sim_hashes=[f"sim{i}" for i in range(20)],
+        )
+        errors = []
+
+        def _worker(i):
+            try:
+                h = f"sim{i}"
+                tracker.mark_running("EM", h)
+                tracker.mark_succeeded("EM", h)
+                tracker.mark_running("Production", h)
+                tracker.mark_succeeded("Production", h)
+                tracker.store_result(h, {"hash": h, "status": "success"})
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert tracker.all_done()
+        snap = tracker.snapshot()
+        assert snap["EM"]["succeeded"] == 20
+        assert snap["Production"]["succeeded"] == 20
+
+    def test_failure_cascade_pattern(self):
+        """Simulates a pipeline failing at NVT — remaining stages skipped."""
+        tracker = self._make_tracker()
+        tracker.mark_running("EM", "aaa")
+        tracker.mark_succeeded("EM", "aaa")
+        tracker.mark_running("NVT", "aaa")
+        tracker.mark_failed("NVT", "aaa")
+        tracker.mark_skipped("NPT", "aaa")
+        tracker.mark_skipped("Production", "aaa")
+
+        # Other sims succeed
+        for h in ["bbb", "ccc"]:
+            for s in ["EM", "NVT", "NPT", "Production"]:
+                tracker.mark_succeeded(s, h)
+
+        assert tracker.all_done()
+        snap = tracker.snapshot()
+        assert snap["NVT"]["failed"] == 1
+        assert snap["NPT"]["skipped"] == 1
+        assert snap["Production"]["skipped"] == 1

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -228,9 +228,10 @@ def test_log_dry_run_plan_format(mock_sim_dir):
     assert result == work_plan
 
 
+@patch("mdfactory.orchestration.progress.display_stage_progress")
 @patch("mdfactory.orchestration.simulate.parsl_session")
 @patch("mdfactory.orchestration.simulate._execute_stage_list")
-def test_parallel_submission(mock_execute, mock_session, tmp_path):
+def test_parallel_submission(mock_execute, mock_session, mock_display, tmp_path):
     """Multiple simulations submit in parallel."""
     # Create 10 mock simulations
     sim_dirs = []
@@ -825,9 +826,10 @@ def test_execute_stage_list_production_bypasses_rescue(mock_run_stage, mock_resc
     assert result is prod_future
 
 
+@patch("mdfactory.orchestration.progress.display_stage_progress")
 @patch("mdfactory.orchestration.simulate.parsl_session")
 @patch("mdfactory.orchestration.simulate._execute_stage_list")
-def test_run_simulations_uses_execute_stage_list(mock_execute, mock_session, mock_sim_dir):
+def test_run_simulations_uses_execute_stage_list(mock_execute, mock_session, mock_display, mock_sim_dir):
     """run_simulations dispatcher now uses _execute_stage_list."""
     mock_future = MagicMock()
     mock_future.done.return_value = True
@@ -2075,10 +2077,11 @@ def test_detect_stage_state_structure_partial_cpt_unchanged(tmp_path):
 # --- run_simulations clean integration tests ---
 
 
+@patch("mdfactory.orchestration.progress.display_stage_progress")
 @patch("mdfactory.orchestration.simulate.parsl_session")
 @patch("mdfactory.orchestration.simulate._execute_stage_list")
 def test_run_simulations_clean_deletes_before_checkpoint_detection(
-    mock_execute, mock_session, tmp_path
+    mock_execute, mock_session, mock_display, tmp_path
 ):
     """run_simulations(clean=True) deletes outputs then detects all stages needed."""
     sim_dir = tmp_path / "sim"

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -11,6 +11,7 @@ from mdfactory.orchestration.config import SlurmExecutorConfig
 from mdfactory.orchestration.tui import (
     UserCancelledError,
     _detect_gromacs_modules,
+    _prompt_environment,
     _prompt_stage_overrides,
     _require,
     configure_slurm_interactive,
@@ -455,6 +456,68 @@ class TestStageOverridesIntegration:
         assert cfg.stage_overrides == {
             "EM": {"cpus_per_node": 32, "gres": None},
         }
+
+
+# ---------------------------------------------------------------------------
+# _prompt_environment tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptEnvironment:
+    """Tests for the _prompt_environment helper."""
+
+    @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stages_empty_skips_gromacs_prompts(self, mock_iq, mock_detect, mock_gmx):
+        """build workflow (stages=()) skips GROMACS module prompts."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        mock_detect.return_value = EnvironmentConfig()
+        mock_q = mock_iq.return_value
+        # extra_init prompt
+        mock_q.text.return_value.ask.return_value = ""
+
+        result = _prompt_environment(stages=())
+
+        mock_gmx.assert_not_called()
+        assert result.modules == []
+
+    @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_stages_none_calls_gromacs_prompts(self, mock_iq, mock_detect, mock_gmx):
+        """simulate workflow (stages=None) does prompt for GROMACS modules."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        mock_detect.return_value = EnvironmentConfig()
+        mock_gmx.return_value = ["gromacs/2024.4"]
+        mock_q = mock_iq.return_value
+        # extra_init prompt
+        mock_q.text.return_value.ask.return_value = ""
+
+        result = _prompt_environment(stages=None)
+
+        mock_gmx.assert_called_once()
+        assert result.modules == ["gromacs/2024.4"]
+
+    @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_detected_pixi_flows_through(self, mock_iq, mock_detect, mock_gmx):
+        """Auto-detected pixi_manifest is preserved in returned config."""
+        from pathlib import Path
+
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        mock_detect.return_value = EnvironmentConfig(pixi_manifest=Path("/project"))
+        mock_gmx.return_value = []
+        mock_q = mock_iq.return_value
+        mock_q.text.return_value.ask.return_value = ""
+
+        result = _prompt_environment(stages=None)
+
+        assert result.pixi_manifest == Path("/project")
 
 
 # ---------------------------------------------------------------------------

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -466,10 +466,13 @@ class TestStageOverridesIntegration:
 class TestPromptEnvironment:
     """Tests for the _prompt_environment helper."""
 
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.load_global", return_value=None)
     @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
     @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_stages_empty_skips_gromacs_prompts(self, mock_iq, mock_detect, mock_gmx):
+    def test_stages_empty_skips_gromacs_prompts(
+        self, mock_iq, mock_detect, mock_gmx, _load_global
+    ):
         """build workflow (stages=()) skips GROMACS module prompts."""
         from mdfactory.orchestration.environment import EnvironmentConfig
 
@@ -483,10 +486,13 @@ class TestPromptEnvironment:
         mock_gmx.assert_not_called()
         assert result.modules == []
 
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.load_global", return_value=None)
     @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
     @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_stages_none_calls_gromacs_prompts(self, mock_iq, mock_detect, mock_gmx):
+    def test_stages_none_calls_gromacs_prompts(
+        self, mock_iq, mock_detect, mock_gmx, _load_global
+    ):
         """simulate workflow (stages=None) does prompt for GROMACS modules."""
         from mdfactory.orchestration.environment import EnvironmentConfig
 
@@ -501,10 +507,11 @@ class TestPromptEnvironment:
         mock_gmx.assert_called_once()
         assert result.modules == ["gromacs/2024.4"]
 
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.load_global", return_value=None)
     @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
     @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_detected_pixi_flows_through(self, mock_iq, mock_detect, mock_gmx):
+    def test_detected_pixi_flows_through(self, mock_iq, mock_detect, mock_gmx, _load_global):
         """Auto-detected pixi_manifest is preserved in returned config."""
         from pathlib import Path
 
@@ -517,6 +524,25 @@ class TestPromptEnvironment:
 
         result = _prompt_environment(stages=None)
 
+        assert result.pixi_manifest == Path("/project")
+
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.load_global")
+    def test_global_config_skips_prompts(self, mock_load_global):
+        """When global environment.yaml exists, prompts are skipped entirely."""
+        from pathlib import Path
+
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        saved_env = EnvironmentConfig(
+            modules=["gromacs/2024.3-gpu"],
+            pixi_manifest=Path("/project"),
+        )
+        mock_load_global.return_value = saved_env
+
+        result = _prompt_environment(stages=None)
+
+        assert result is saved_env
+        assert result.modules == ["gromacs/2024.3-gpu"]
         assert result.pixi_manifest == Path("/project")
 
 

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -107,6 +107,7 @@ class TestDetectGromacsModules:
             "subprocess.run",
             lambda *a, **kw: type("R", (), {"stdout": fake_output, "stderr": ""})(),
         )
+        assert _detect_gromacs_modules() == []
 
 
 # ---------------------------------------------------------------------------
@@ -117,15 +118,19 @@ class TestDetectGromacsModules:
 class TestConfigureManualFallback:
     """When discover_cluster returns None, wizard uses manual entry."""
 
-    @patch("mdfactory.orchestration.tui._prompt_gromacs_source", return_value="")
+    @patch("mdfactory.orchestration.tui._prompt_environment")
     @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_configure_manual_fallback(self, mock_iq, _discover, _gmx):
+    def test_configure_manual_fallback(self, mock_iq, _discover, mock_prompt_env):
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
         mock_q = mock_iq.return_value
+        mock_prompt_env.return_value = EnvironmentConfig()
+
         # confirm prompts: proceed with manual? → True, stage overrides? → False
         mock_q.confirm.return_value.ask.side_effect = [True, False]
         # text prompts in order: account, partition, walltime, cpus,
-        # gres, mem, qos, max_blocks, worker_init
+        # gres, mem, qos, max_blocks
         mock_q.text.return_value.ask.side_effect = [
             "manual_acc",
             "gpu",
@@ -135,7 +140,6 @@ class TestConfigureManualFallback:
             "64G",
             "",
             "4",
-            "",
         ]
 
         cfg = configure_slurm_interactive()
@@ -145,18 +149,22 @@ class TestConfigureManualFallback:
         assert cfg.cpus_per_node == 24
         assert cfg.gres == "gpu:a100:1"
         assert cfg.mem == "64G"
+        assert cfg.environment is not None
         assert cfg.stage_overrides == {}
 
 
 class TestConfigureWithCluster:
     """When cluster is discovered, wizard uses select menus."""
 
-    @patch("mdfactory.orchestration.tui._prompt_gromacs_source", return_value="")
+    @patch("mdfactory.orchestration.tui._prompt_environment")
     @patch("mdfactory.orchestration.tui.discover_cluster")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_configure_with_cluster(self, mock_iq, mock_discover, _gmx):
+    def test_configure_with_cluster(self, mock_iq, mock_discover, mock_prompt_env):
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
         mock_q = mock_iq.return_value
         mock_discover.return_value = _make_cluster()
+        mock_prompt_env.return_value = EnvironmentConfig(modules=["gromacs/2024.4"])
 
         # select prompts: account, partition, walltime, cpus, mem, max_blocks
         mock_q.select.return_value.ask.side_effect = [
@@ -167,10 +175,9 @@ class TestConfigureWithCluster:
             "50G",
             "4",
         ]
-        # text prompts: gres, worker_init, constraint
+        # text prompts: gres, constraint
         mock_q.text.return_value.ask.side_effect = [
             "gpu:a100:1",
-            "",
             "a100",
         ]
         # confirm: QOS → False, stage overrides → False
@@ -184,6 +191,8 @@ class TestConfigureWithCluster:
         assert cfg.mem == "50G"
         assert cfg.max_blocks == 4
         assert cfg.constraint == "a100"
+        assert cfg.environment is not None
+        assert cfg.environment.modules == ["gromacs/2024.4"]
         assert cfg.stage_overrides == {}
 
 
@@ -374,16 +383,20 @@ class TestPromptStageOverrides:
 class TestStageOverridesIntegration:
     """Tests that stage overrides flow through the full wizard paths."""
 
-    @patch("mdfactory.orchestration.tui._prompt_gromacs_source", return_value="")
+    @patch("mdfactory.orchestration.tui._prompt_environment")
     @patch("mdfactory.orchestration.tui.discover_cluster", return_value=None)
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_stage_overrides_manual_path(self, mock_iq, _discover, _gmx):
+    def test_stage_overrides_manual_path(self, mock_iq, _discover, mock_prompt_env):
         """Manual fallback path produces config with stage overrides."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
         mock_q = mock_iq.return_value
+        mock_prompt_env.return_value = EnvironmentConfig()
+
         # confirm: proceed with manual → True, stage overrides → True
         mock_q.confirm.return_value.ask.side_effect = [True, True]
         # text prompts: account, partition, walltime, cpus, gres, mem, qos,
-        # max_blocks, worker_init, then stage override prompts for EM
+        # max_blocks, then stage override prompts for EM
         mock_q.text.return_value.ask.side_effect = [
             "acc",
             "gpu",
@@ -393,7 +406,6 @@ class TestStageOverridesIntegration:
             "32G",
             "",
             "4",
-            "",
             # EM stage prompts: cpus, gres, gmx
             "32",
             "",
@@ -406,13 +418,16 @@ class TestStageOverridesIntegration:
             "EM": {"cpus_per_node": 32, "gres": None},
         }
 
-    @patch("mdfactory.orchestration.tui._prompt_gromacs_source", return_value="")
+    @patch("mdfactory.orchestration.tui._prompt_environment")
     @patch("mdfactory.orchestration.tui.discover_cluster")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_stage_overrides_cluster_path(self, mock_iq, mock_discover, _gmx):
+    def test_stage_overrides_cluster_path(self, mock_iq, mock_discover, mock_prompt_env):
         """Cluster-assisted path produces config with stage overrides."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
         mock_q = mock_iq.return_value
         mock_discover.return_value = _make_cluster()
+        mock_prompt_env.return_value = EnvironmentConfig()
 
         # select prompts: account, partition, walltime, cpus, mem, max_blocks
         mock_q.select.return_value.ask.side_effect = [
@@ -423,10 +438,9 @@ class TestStageOverridesIntegration:
             "50G",
             "4",
         ]
-        # text prompts: gres, worker_init, constraint, then stage prompts
+        # text prompts: gres, constraint, then stage prompts
         mock_q.text.return_value.ask.side_effect = [
             "gpu:a100:1",
-            "",
             "",
             # EM stage prompts: cpus, gres, gmx
             "32",
@@ -505,3 +519,33 @@ class TestSaveYaml:
         assert data["stage_overrides"]["EM"]["cpus_per_node"] == 32
         assert data["stage_overrides"]["EM"]["gres"] is None
         assert data["stage_overrides"]["Production"]["cpus_per_node"] == 64
+
+    def test_save_yaml_with_environment(self, tmp_path):
+        """Environment section is written to YAML."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        env = EnvironmentConfig(
+            modules=["gromacs/2024.3-gpu"],
+            pixi_manifest="/project/root",
+        )
+        cfg = SlurmExecutorConfig(account="acc", environment=env)
+        out = tmp_path / "slurm.yaml"
+        save_slurm_config_yaml(cfg, out)
+
+        data = yaml.safe_load(out.read_text())
+        assert "environment" in data
+        assert data["environment"]["modules"] == ["gromacs/2024.3-gpu"]
+        assert data["environment"]["pixi_manifest"] == "/project/root"
+
+    def test_save_yaml_empty_environment_excluded(self, tmp_path):
+        """Empty EnvironmentConfig (all defaults) is excluded from YAML."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        env = EnvironmentConfig()
+        cfg = SlurmExecutorConfig(account="acc", environment=env)
+        out = tmp_path / "slurm.yaml"
+        save_slurm_config_yaml(cfg, out)
+
+        data = yaml.safe_load(out.read_text())
+        # An empty environment section should be cleaned up
+        assert "environment" not in data

--- a/mdfactory/tests/test_orchestration_tui.py
+++ b/mdfactory/tests/test_orchestration_tui.py
@@ -14,6 +14,7 @@ from mdfactory.orchestration.tui import (
     _prompt_environment,
     _prompt_stage_overrides,
     _require,
+    configure_and_save_environment,
     configure_slurm_interactive,
     save_slurm_config_yaml,
 )
@@ -470,9 +471,7 @@ class TestPromptEnvironment:
     @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
     @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_stages_empty_skips_gromacs_prompts(
-        self, mock_iq, mock_detect, mock_gmx, _load_global
-    ):
+    def test_stages_empty_skips_gromacs_prompts(self, mock_iq, mock_detect, mock_gmx, _load_global):
         """build workflow (stages=()) skips GROMACS module prompts."""
         from mdfactory.orchestration.environment import EnvironmentConfig
 
@@ -490,9 +489,7 @@ class TestPromptEnvironment:
     @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
     @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
     @patch("mdfactory.orchestration.tui._import_questionary")
-    def test_stages_none_calls_gromacs_prompts(
-        self, mock_iq, mock_detect, mock_gmx, _load_global
-    ):
+    def test_stages_none_calls_gromacs_prompts(self, mock_iq, mock_detect, mock_gmx, _load_global):
         """simulate workflow (stages=None) does prompt for GROMACS modules."""
         from mdfactory.orchestration.environment import EnvironmentConfig
 
@@ -638,3 +635,71 @@ class TestSaveYaml:
         data = yaml.safe_load(out.read_text())
         # An empty environment section should be cleaned up
         assert "environment" not in data
+
+
+# ---------------------------------------------------------------------------
+# configure_and_save_environment tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureAndSaveEnvironment:
+    """Tests for configure_and_save_environment."""
+
+    @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_saves_environment_to_global_path(
+        self, mock_iq, mock_detect, mock_gmx, tmp_path, monkeypatch
+    ):
+        """configure_and_save_environment runs wizard and saves result."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
+        mock_detect.return_value = EnvironmentConfig()
+        mock_gmx.return_value = ["gromacs/2024.3-gpu"]
+        mock_q = mock_iq.return_value
+        mock_q.text.return_value.ask.return_value = ""
+
+        env = configure_and_save_environment()
+
+        assert env.modules == ["gromacs/2024.3-gpu"]
+        saved_path = tmp_path / "environment.yaml"
+        assert saved_path.is_file()
+        loaded = EnvironmentConfig.from_yaml(saved_path)
+        assert loaded.modules == ["gromacs/2024.3-gpu"]
+
+    @patch("mdfactory.orchestration.tui._prompt_gromacs_modules")
+    @patch("mdfactory.orchestration.tui.EnvironmentConfig.detect")
+    @patch("mdfactory.orchestration.tui._import_questionary")
+    def test_ignores_existing_global_config(
+        self, mock_iq, mock_detect, mock_gmx, tmp_path, monkeypatch
+    ):
+        """configure_and_save_environment always runs wizard even if global exists."""
+        from mdfactory.orchestration.environment import EnvironmentConfig
+
+        monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
+        # Write an existing global config
+        old_env = EnvironmentConfig(modules=["old/module"])
+        old_env.save_yaml(tmp_path / "environment.yaml")
+
+        # The wizard should run (ignore_global=True) and produce new config
+        mock_detect.return_value = EnvironmentConfig()
+        mock_gmx.return_value = ["new/module"]
+        mock_q = mock_iq.return_value
+        mock_q.text.return_value.ask.return_value = ""
+
+        env = configure_and_save_environment()
+
+        assert env.modules == ["new/module"]
+        loaded = EnvironmentConfig.from_yaml(tmp_path / "environment.yaml")
+        assert loaded.modules == ["new/module"]
+
+    def test_cancellation_raises(self, tmp_path, monkeypatch):
+        """configure_and_save_environment propagates UserCancelledError."""
+        monkeypatch.setenv("MDFACTORY_CONFIG_DIR", str(tmp_path))
+        with patch(
+            "mdfactory.orchestration.tui._prompt_environment",
+            side_effect=UserCancelledError("cancelled"),
+        ):
+            with pytest.raises(UserCancelledError):
+                configure_and_save_environment()


### PR DESCRIPTION
Closes #40

Separate `EnvironmentConfig` from SLURM allocation in executor config — structured model replacing the opaque `worker_init` string, with backward compatibility and TUI refactoring into three visual sections.

Implementation plan posted as a comment below.
