### PR TITLE
fix: handle disabled ionization and zero-ion systems

### DIFF
--- a/docs/content/docs/user-guide/system-types.mdx
+++ b/docs/content/docs/user-guide/system-types.mdx
@@ -51,7 +51,7 @@ system:
 | `species` | list of `SingleMoleculeSpecies` | — | Molecules in the system |
 | `total_count` | int \| null | null | Total molecule count (used with fractions) |
 | `target_density` | float | 1.0 | Target density in g/cm³ |
-| `ionization` | IonizationConfig | see below | Ion placement settings |
+| `ionization` | IonizationConfig \| null \| false | see below | Ion placement settings; `null` or `false` disables ionization |
 
 ### Tips
 
@@ -107,7 +107,7 @@ system:
 | `total_count` | int \| null | null | Total lipid count (used with fractions) |
 | `z_padding` | float | 20.0 | Water padding above/below bilayer in Å |
 | `monolayer` | bool | false | Build a monolayer instead of bilayer |
-| `ionization` | IonizationConfig | see below | Ion placement settings |
+| `ionization` | IonizationConfig \| null \| false | see below | Ion placement settings; `null` or `false` disables ionization |
 
 ### LipidSpecies fields
 
@@ -194,7 +194,7 @@ system:
 | `padding` | float | 25.0 | Water padding around the nanoparticle in Å |
 | `core` | CoreComposition | — | Core composition |
 | `shell` | ShellComposition | — | Shell composition |
-| `ionization` | IonizationConfig | see below | Ion placement settings |
+| `ionization` | IonizationConfig \| null \| false | see below | Ion placement settings; `null` or `false` disables ionization |
 
 ### CoreComposition fields
 
@@ -230,6 +230,11 @@ All system types support ionization configuration:
 | `concentration` | float | 0.15 | Ion concentration in mol/L |
 | `min_distance` | float | 5.0 | Minimum distance between ions in Å |
 | `seed` | int \| null | null | Random seed for ion placement |
+
+To disable ionization explicitly, set `ionization` to `null` or `false`. Both forms
+skip ion placement and are normalized to the same disabled state. Omitting the field
+keeps the default `IonizationConfig`; a configuration with zero concentration and
+`neutralize: false` also performs no ion placement.
 
 ## SingleMoleculeSpecies fields (shared)
 

--- a/docs/content/docs/user-guide/yaml-format.mdx
+++ b/docs/content/docs/user-guide/yaml-format.mdx
@@ -109,6 +109,17 @@ Defaults:
 - `min_distance: 5.0`
 - `seed: null`
 
+To disable ionization explicitly, set the field to `null` or `false`:
+
+```yaml
+system:
+  ionization: false  # `null` is equivalent
+```
+
+Both forms skip ion placement. If ionization is omitted, the defaults above are
+applied. A configured `concentration: 0.0` with `neutralize: false` likewise leaves
+the system unchanged without attempting to add zero ions.
+
 ## Full examples by simulation type
 
 These examples intentionally use compounds from the repository example inputs under `examples/` so docs stay aligned with tested/public examples.

--- a/mdfactory/build.py
+++ b/mdfactory/build.py
@@ -656,10 +656,14 @@ def ionize_solvated_system(ion_config, u_solvated, total_charge):
             f"{add_cl} Cl- ions for neutralization."
         )
 
+    c_ions = ion_config.concentration  # mol/l
+    if c_ions == 0 and add_na == 0 and add_cl == 0:
+        logger.info("No ions to add; skipping ionization.")
+        return u_solvated, []
+
     n_water = len(u_solvated.select_atoms("water").residues)
     if n_water == 0:
         raise ValueError("Cannot ionize system without water.")
-    c_ions = ion_config.concentration  # mol/l
     M_water = 55.55  # mol/l
     n_ions = np.ceil(c_ions * n_water / M_water).astype(int)
 
@@ -683,6 +687,9 @@ def ionize_solvated_system(ion_config, u_solvated, total_charge):
     u_ionized.dimensions = u_solvated.dimensions
     logger.info(f"Added {n_ions} Na+/Cl- ions.")
 
-    na_spec = SingleMoleculeSpecies(count=num_na, smiles="[Na+]", resname="NA")
-    cl_spec = SingleMoleculeSpecies(count=num_cl, smiles="[Cl-]", resname="CL")
-    return u_ionized, [na_spec, cl_spec]
+    additional_species = []
+    if num_na > 0:
+        additional_species.append(SingleMoleculeSpecies(count=num_na, smiles="[Na+]", resname="NA"))
+    if num_cl > 0:
+        additional_species.append(SingleMoleculeSpecies(count=num_cl, smiles="[Cl-]", resname="CL"))
+    return u_ionized, additional_species

--- a/mdfactory/build.py
+++ b/mdfactory/build.py
@@ -669,6 +669,10 @@ def ionize_solvated_system(ion_config, u_solvated, total_charge):
         f"Adding {num_na} Na+ and {num_cl} Cl- ions to the system for neutralization "
         f"and {c_ions} M salt concentration."
     )
+    if num_na == 0 and num_cl == 0:
+        logger.info("No ions to add; skipping ionization.")
+        return u_solvated, []
+
     u_ionized = ionize(
         u_solvated,
         num_na=num_na,

--- a/mdfactory/models/composition.py
+++ b/mdfactory/models/composition.py
@@ -2,10 +2,10 @@
 # ABOUTME: Defines species counts, ionization, and composition validation
 """Pydantic models for system composition (mixedbox, bilayer, LNP)."""
 
-from typing import Optional
+from typing import Annotated, Optional
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 
 from .species import LipidSpecies, SingleMoleculeSpecies, Species
 
@@ -65,6 +65,19 @@ class IonizationConfig(BaseModel):
     seed: Optional[int] = Field(None, description="Random seed for reproducibility.")
 
 
+def _normalize_ionization(value: object) -> object:
+    """Normalize boolean false to the disabled ionization representation."""
+    if value is False:
+        return None
+    return value
+
+
+IonizationSetting = Annotated[
+    IonizationConfig | None,
+    BeforeValidator(_normalize_ionization),
+]
+
+
 class SystemComposition(BaseModel):
     """Define a system composition as a list of species with fractional or absolute counts."""
 
@@ -116,18 +129,9 @@ class MixedBoxComposition(SystemComposition):
 
     species: list[SingleMoleculeSpecies]
     target_density: float = Field(1.0, description="Packing density of the box in g/cm^3.")
-    ionization: IonizationConfig = Field(
+    ionization: IonizationSetting = Field(
         default_factory=IonizationConfig, description="Configuration for ionization."
     )
-
-    # @field_validator("ionization")
-    # @classmethod
-    # def validate_ionization(cls, v: Any):
-    #     if v == None or v == "None":
-    #         return None
-    #     elif v == "auto":
-    #         return IonizationConfig()
-    #     return v
 
 
 class BilayerComposition(SystemComposition):
@@ -138,7 +142,7 @@ class BilayerComposition(SystemComposition):
         20.0, description="Z-direction box padding above and below the bilayer in A.", ge=0.0
     )
     monolayer: bool = Field(False, description="Whether to just build a monolayer.")
-    ionization: IonizationConfig = Field(
+    ionization: IonizationSetting = Field(
         default_factory=IonizationConfig, description="Configuration for ionization."
     )
 
@@ -312,7 +316,7 @@ class LNPComposition(BaseModel):
     core: CoreComposition
     shell: ShellComposition
     padding: float = Field(25.0, description="Solvation padding around LNP in Angstroms.", ge=0)
-    ionization: IonizationConfig = Field(
+    ionization: IonizationSetting = Field(
         default_factory=IonizationConfig, description="Configuration for ionization."
     )
 

--- a/mdfactory/models/input.py
+++ b/mdfactory/models/input.py
@@ -70,10 +70,14 @@ class BuildInput(BaseModel):
         if self.simulation_type == "bilayer":
             system_specific["z_padding"] = self.system.z_padding
             system_specific["monolayer"] = self.system.monolayer
-            system_specific["ionization"] = self.system.ionization.model_dump()
+            system_specific["ionization"] = (
+                self.system.ionization.model_dump() if self.system.ionization is not None else None
+            )
         elif self.simulation_type == "mixedbox":
             system_specific["target_density"] = self.system.target_density
-            system_specific["ionization"] = self.system.ionization.model_dump()
+            system_specific["ionization"] = (
+                self.system.ionization.model_dump() if self.system.ionization is not None else None
+            )
 
         return {
             "hash": self.hash,

--- a/mdfactory/setup/solvation.py
+++ b/mdfactory/setup/solvation.py
@@ -289,11 +289,16 @@ def ionize(u: mda.Universe, num_na: int, num_cl: int, seed: int = None, min_dist
         allatomindices - set(all_atoms_to_remove) - set(anion_indices) - set(cation_indices)
     )
     atomstokeep = u.atoms[atomstokeepindices]
-    anions = u.atoms[sorted(anion_indices)]
-    anions.residues.resids = np.arange(1, anions.n_atoms + 1)
-    cations = u.atoms[sorted(cation_indices)]
-    cations.residues.resids = np.arange(1, cations.n_atoms + 1)
-    newuniverse = mda.Merge(atomstokeep, cations, anions)
+    ion_groups = []
+    if cation_indices:
+        cations = u.atoms[sorted(cation_indices)]
+        cations.residues.resids = np.arange(1, cations.n_atoms + 1)
+        ion_groups.append(cations)
+    if anion_indices:
+        anions = u.atoms[sorted(anion_indices)]
+        anions.residues.resids = np.arange(1, anions.n_atoms + 1)
+        ion_groups.append(anions)
+    newuniverse = mda.Merge(atomstokeep, *ion_groups)
 
     n_atoms = len(newuniverse.atoms)
     n_atoms_orig = len(u.atoms)

--- a/mdfactory/tests/test_build.py
+++ b/mdfactory/tests/test_build.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import MDAnalysis as mda
+import pytest
 
 from mdfactory.build import build_bilayer, build_mixedbox, ionize_solvated_system
 from mdfactory.check import check_bilayer_buildable
@@ -66,6 +67,34 @@ def test_ionize_solvated_system_skips_zero_ions():
     assert ionized is u
     assert additional_species == []
     ionize.assert_not_called()
+
+
+def test_ionize_solvated_system_skips_water_check_when_no_ions_are_requested():
+    u = SingleMoleculeSpecies(smiles="CCO", count=1, resname="ETH").universe
+    ion_config = IonizationConfig(concentration=0.0, neutralize=False)
+
+    with patch("mdfactory.build.ionize") as ionize:
+        ionized, additional_species = ionize_solvated_system(ion_config, u, total_charge=0)
+
+    assert ionized is u
+    assert additional_species == []
+    ionize.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("total_charge", "ion_resname", "ion_count"),
+    [(2, "CL", 2), (-2, "NA", 2)],
+)
+def test_ionize_solvated_system_adds_one_sided_counterions(total_charge, ion_resname, ion_count):
+    u = mda.Universe(Path(solvation.__file__).parent / "data" / "spc216.gro")
+    ion_config = IonizationConfig(concentration=0.0, neutralize=True, seed=0)
+
+    ionized, additional_species = ionize_solvated_system(ion_config, u, total_charge)
+
+    assert len(ionized.select_atoms(f"resname {ion_resname}")) == ion_count
+    assert len(additional_species) == 1
+    assert additional_species[0].resname == ion_resname
+    assert additional_species[0].count == ion_count
 
 
 def test_build_mixedbox(tmp_path):

--- a/mdfactory/tests/test_build.py
+++ b/mdfactory/tests/test_build.py
@@ -2,13 +2,17 @@
 # ABOUTME: assembly, composition validation, and buildability checks.
 """Tests for bilayer and mixed-box system building, including structure."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import MDAnalysis as mda
 
-from mdfactory.build import build_bilayer, build_mixedbox
+from mdfactory.build import build_bilayer, build_mixedbox, ionize_solvated_system
 from mdfactory.check import check_bilayer_buildable
-from mdfactory.models.composition import BilayerComposition, MixedBoxComposition
+from mdfactory.models.composition import BilayerComposition, IonizationConfig, MixedBoxComposition
 from mdfactory.models.input import BuildInput
 from mdfactory.models.species import LipidSpecies, SingleMoleculeSpecies
+from mdfactory.setup import solvation
 from mdfactory.utils.setup_utilities import create_bilayer_from_model, create_mixed_box_universe
 from mdfactory.utils.utilities import working_directory
 
@@ -50,6 +54,18 @@ def test_create_mixedbox_universe():
     n_met = sum(1 for res in residues if res.resname == "MET")
     assert n_sol == 180
     assert n_met == 20
+
+
+def test_ionize_solvated_system_skips_zero_ions():
+    u = mda.Universe(Path(solvation.__file__).parent / "data" / "spc216.gro")
+    ion_config = IonizationConfig(concentration=0.0, neutralize=False)
+
+    with patch("mdfactory.build.ionize") as ionize:
+        ionized, additional_species = ionize_solvated_system(ion_config, u, total_charge=0)
+
+    assert ionized is u
+    assert additional_species == []
+    ionize.assert_not_called()
 
 
 def test_build_mixedbox(tmp_path):

--- a/mdfactory/tests/test_models.py
+++ b/mdfactory/tests/test_models.py
@@ -12,14 +12,13 @@ from rdkit.Chem import AllChem
 from mdfactory.models.composition import (
     BilayerComposition,
     CoreComposition,
+    IonizationConfig,
+    MixedBoxComposition,
     ShellComposition,
     SystemComposition,
     distribute_counts,
 )
-from mdfactory.models.input import (
-    BuildInput,
-    MixedBoxComposition,
-)
+from mdfactory.models.input import BuildInput
 from mdfactory.models.species import LipidSpecies, SingleMoleculeSpecies, Species
 from mdfactory.utils.utilities import working_directory
 
@@ -229,6 +228,41 @@ def test_generate_input_model_from_dict():
             simulation_type="bilayer",
             system=comp,
         )
+
+
+@pytest.mark.parametrize("disabled", [None, False])
+def test_ionization_can_be_explicitly_disabled(disabled):
+    spec = SingleMoleculeSpecies(smiles="O", count=10, resname="SOL")
+    comp = MixedBoxComposition(species=[spec], ionization=disabled)
+
+    assert comp.ionization is None
+
+
+def test_disabled_ionization_build_input_round_trip():
+    input_data = {
+        "simulation_type": "mixedbox",
+        "system": {
+            "species": [{"smiles": "O", "count": 10, "resname": "SOL"}],
+            "ionization": False,
+        },
+    }
+
+    inp = BuildInput(**input_data)
+    assert inp.system.ionization is None
+    assert inp.metadata["system_specific"]["ionization"] is None
+
+    restored = BuildInput.from_data_row(inp.to_data_row())
+    assert restored.system.ionization is None
+    assert restored == inp
+
+
+def test_ionization_defaults_when_omitted():
+    spec = SingleMoleculeSpecies(smiles="O", count=10, resname="SOL")
+    comp = MixedBoxComposition(species=[spec])
+
+    assert isinstance(comp.ionization, IonizationConfig)
+    assert comp.ionization.neutralize is True
+    assert comp.ionization.concentration == 0.15
 
 
 def test_parameter_set_dump(tmp_path):


### PR DESCRIPTION
Closes #42

Fix the zero-ion mixedbox build path and allow ionization to be explicitly disabled with null or false input.

Implementation plan posted as a comment below.
