### PR TITLE
fix: skip ionization when no ions would be added

### DIFF
--- a/mdfactory/build.py
+++ b/mdfactory/build.py
@@ -665,6 +665,9 @@ def ionize_solvated_system(ion_config, u_solvated, total_charge):
 
     num_na = n_ions + add_na
     num_cl = n_ions + add_cl
+    if num_na == 0 and num_cl == 0:
+        logger.info("No ions to add - skipping ionization.")
+        return u_solvated, []
     logger.info(
         f"Adding {num_na} Na+ and {num_cl} Cl- ions to the system for neutralization "
         f"and {c_ions} M salt concentration."

--- a/mdfactory/tests/test_solvation.py
+++ b/mdfactory/tests/test_solvation.py
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 from MDAnalysis.analysis import distances
 
+from mdfactory.build import ionize_solvated_system
+from mdfactory.models.composition import IonizationConfig
 from mdfactory.models.species import SingleMoleculeSpecies
 from mdfactory.setup import solvation
 
@@ -136,3 +138,17 @@ def test_remove_clashes():
             )
             clashes_no_pbc.add(tuple(sorted(um.atoms.residues.resids)))
     assert len(clashes_no_pbc) == 0
+
+
+def test_ionize_solvated_system_skips_when_no_ions():
+    """Skip ionization when no ions should be added."""
+    u = mda.Universe(Path(solvation.__file__).parent / "data" / "spc216.gro")
+    n_atoms_before = len(u.atoms)
+
+    ion_config = IonizationConfig(concentration=0.0, neutralize=False)
+    u_out, additional_species = ionize_solvated_system(ion_config, u, total_charge=0)
+
+    assert additional_species == []
+    assert len(u_out.atoms) == n_atoms_before
+    assert len(u_out.select_atoms("resname NA")) == 0
+    assert len(u_out.select_atoms("resname CL")) == 0


### PR DESCRIPTION
## Summary

`ionize_solvated_system` called `ionize()` even when `concentration=0.0` and `neutralize=False`, so both ion counts were zero. MDAnalysis then tried to merge empty cation/anion AtomGroups and raised `ValueError: cannot merge empty AtomGroup`.

Return the solvated universe unchanged (and an empty species list) when no ions would be added — same outcome as `ion_config is None`.

## Test plan

- [x] `pytest mdfactory/tests/test_solvation.py::test_ionize_solvated_system_skips_when_no_ions --no-cov`
- [x] `pytest mdfactory/tests/test_solvation.py --no-cov` (4 passed)

Fixes #42