### PR TITLE
fix: disable exclusive Slurm allocations by default

### DIFF
--- a/docs/content/docs/user-guide/running-on-hpc.mdx
+++ b/docs/content/docs/user-guide/running-on-hpc.mdx
@@ -132,6 +132,7 @@ stage_overrides:
 | `cpus_per_node` | CPUs per node | `12` |
 | `gres` | GPU resources (`--gres`) | — |
 | `mem` | Memory per node (`--mem`) | — |
+| `exclusive` | Whole-node allocation (`--exclusive`); `false` allocates only requested resources | `false` |
 | `max_workers_per_node` | Parallel tasks per node | `1` |
 | `max_blocks` | Max concurrent SLURM allocations | `1` |
 | `available_accelerators` | GPU count or device IDs for `CUDA_VISIBLE_DEVICES` | `0` |

--- a/examples/slurm_executor.yaml
+++ b/examples/slurm_executor.yaml
@@ -89,7 +89,7 @@ gmx_binary: auto
 # exclusive: true
 
 # Extra raw #SBATCH lines appended to the job script.
-# scheduler_options: "#SBATCH --exclusive"
+# scheduler_options: "e.g. #SBATCH --distribution=block:cyclic"
 
 # Extra flags passed to srun when launching workers.
 # launch_options: "--mpi=pmix"

--- a/examples/slurm_executor.yaml
+++ b/examples/slurm_executor.yaml
@@ -83,6 +83,11 @@ gmx_binary: auto
 # Directory where Parsl writes runinfo logs and monitoring DB.
 # run_dir: ~/.parsl/mdfactory
 
+# Reserve a whole node per allocation (adds #SBATCH --exclusive).
+# Default false: only the requested CPUs/GPUs are allocated (shared-node
+# scheduling). Set true to use a whole node.
+# exclusive: true
+
 # Extra raw #SBATCH lines appended to the job script.
 # scheduler_options: "#SBATCH --exclusive"
 

--- a/mdfactory/orchestration/config.py
+++ b/mdfactory/orchestration/config.py
@@ -243,6 +243,12 @@ class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
         Generic resource specification (``--gres``), e.g. ``"gpu:l40s:1"``.
     mem : str or None
         Memory per node (``--mem``), e.g. ``"32G"``.
+    exclusive : bool
+        Request an exclusive (whole-node) allocation. Parsl wires this to
+        ``SlurmProvider(exclusive=...)``, which adds ``#SBATCH --exclusive`` to
+        the job script when ``True``. Defaults to ``False`` so partial-node
+        requests (e.g. a few CPUs and one GPU) allocate and are billed only for
+        what was requested. Set to ``True`` to reserve the entire node.
     qos : str or None
         Quality of service (``--qos``).
     constraint : str or None
@@ -291,6 +297,7 @@ class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
     cpus_per_node: int = 12
     gres: str | None = None
     mem: str | None = None
+    exclusive: bool = False
     scheduler_options: str = ""
     launch_options: str = ""
     stage_overrides: dict[str, dict] = Field(
@@ -417,6 +424,7 @@ class SlurmExecutorConfig(ExecutorConfig, BaseSlurmConfig):
             cores_per_node=self.cpus_per_node,
             worker_init=self.environment.compose_worker_init(),
             scheduler_options=scheduler_options,
+            exclusive=self.exclusive,
             min_blocks=0,
             init_blocks=1,
             max_blocks=self.max_blocks,

--- a/mdfactory/tests/test_orchestration_config.py
+++ b/mdfactory/tests/test_orchestration_config.py
@@ -43,6 +43,7 @@ def test_slurm_executor_config_defaults():
     assert cfg.cpus_per_node == 12
     assert cfg.gres is None
     assert cfg.mem is None
+    assert cfg.exclusive is False
 
 
 def test_executor_config_from_yaml_local(tmp_path):
@@ -189,6 +190,44 @@ def test_raw_scheduler_options_appended():
     provider = result.executors[0].provider
     assert "#SBATCH --gres=gpu:1" in provider.scheduler_options
     assert "#SBATCH --exclusive" in provider.scheduler_options
+
+
+def test_slurm_exclusive_default_false():
+    """Default SlurmProvider does NOT request exclusive (whole-node) allocations.
+
+    Regression test for issue #45: Parsl's SlurmProvider defaults to
+    exclusive=True, which adds ``#SBATCH --exclusive`` and bills the entire
+    node for partial-node requests (e.g. 4 CPUs, 1 GPU). MDFactory must
+    default to shared allocations so only requested resources are used.
+    """
+    cfg = SlurmExecutorConfig(account="acc", gres="gpu:l40s:1")
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert provider.exclusive is False
+    assert "#SBATCH --exclusive" not in provider.scheduler_options
+
+
+def test_slurm_exclusive_true_opt_in():
+    """exclusive=True opts back into a whole-node allocation."""
+    cfg = SlurmExecutorConfig(account="acc", gres="gpu:1", exclusive=True)
+    result = cfg.to_parsl_config()
+
+    provider = result.executors[0].provider
+    assert provider.exclusive is True
+    assert "#SBATCH --exclusive" in provider.scheduler_options
+
+
+def test_exclusive_yaml_roundtrip(tmp_path):
+    """exclusive survives a YAML round-trip."""
+    original = SlurmExecutorConfig(account="acc", exclusive=True)
+    cfg_path = tmp_path / "exclusive.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(original.model_dump(), f)
+
+    loaded = ExecutorConfig.from_yaml(cfg_path)
+    assert isinstance(loaded, SlurmExecutorConfig)
+    assert loaded.exclusive is True
 
 
 def test_run_dir_default_and_expanduser():


### PR DESCRIPTION
Closes #45

Disable exclusive SLURM allocations by default in the Parsl executor.

MDFactory builds `SlurmProvider(...)` without passing `exclusive`, so
Parsl's default `exclusive=True` appends `#SBATCH --exclusive` to every
generated job script. Requests for only part of a node (e.g. 4 CPUs, 1 GPU)
are therefore allocated and billed for the entire node.

This change exposes `exclusive: bool = False` on `SlurmExecutorConfig` and
passes it through to `SlurmProvider(exclusive=...)`. Users who genuinely need
a whole node can opt back in with `exclusive: true` in their SLURM executor
YAML.

Implementation plan posted as a comment below.
