### PR TITLE
refactor: unify duplicate Rich progress/polling infrastructure

### DIFF
--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -164,7 +164,7 @@ def _collect_results(results: list, hashes: list[str]) -> list[dict]:
     return list(results)
 
 
-from .progress import run_progress_loop  # noqa: E402
+from .progress import _make_progress, run_progress_loop  # noqa: E402
 
 
 def _is_running(future) -> bool:
@@ -243,58 +243,30 @@ def _wait_with_progress(
     result_transform=None,
     poll_interval: float = 2.0,
 ) -> list[dict]:
-    """Wait for futures with a live terminal progress display.
+    """Wait for futures with a live progress display and scrolling activity log.
 
-    Shows a progress bar with summary counts and a scrolling activity log
-    of recent completions/failures. Scales to any number of builds.
-
-    Per-future result handling is delegated to :func:`_poll_future`; SLURM
-    block status querying to :func:`_get_block_status`.  The shared
-    Live/poll/render loop is provided by :func:`run_progress_loop`.
-
-    Parameters
-    ----------
-    futures : list
-        List of Parsl AppFutures.
-    hashes : list[str], optional
-        Known hashes for each build (displayed in activity log).
-    label : str
-        Heading shown next to the progress bar.
-    result_transform : callable or None, optional
-        ``(raw_result, display_hash) -> dict`` applied to each successful
-        future's return value before it is stored.
-    poll_interval : float
-        Seconds between status polls.
-
-    Returns
-    -------
-    list[dict]
-        Result dicts for each future.
-
+    The shared Live/poll/render loop is provided by :func:`run_progress_loop`.
     """
     from rich.text import Text
 
     total = len(futures)
     results: list[dict | None] = [None] * total
     display_hashes = hashes or [f"build-{i}" for i in range(total)]
-
     succeeded = 0
     failed = 0
     max_activity = 12
     activity: list[Text] = []
-    task_id_holder: list = []
 
-    def _setup(progress):
-        tid = progress.add_task(
-            f"⚒ [bold]{label}[/]",
-            total=total,
-            succeeded=0,
-            failed=0,
-            running=0,
-        )
-        task_id_holder.append(tid)
+    progress = _make_progress()
+    task_id = progress.add_task(
+        f"⚒ [bold]{label}[/]",
+        total=total,
+        succeeded=0,
+        failed=0,
+        running=0,
+    )
 
-    def _update(progress):
+    def _update():
         nonlocal succeeded, failed
         done_count = 0
         for i, future in enumerate(futures):
@@ -310,10 +282,9 @@ def _wait_with_progress(
                 else:
                     succeeded += 1
                 done_count += 1
-
         running = sum(1 for i, f in enumerate(futures) if results[i] is None and _is_running(f))
         progress.update(
-            task_id_holder[0],
+            task_id,
             completed=succeeded + failed,
             succeeded=succeeded,
             failed=failed,
@@ -322,17 +293,14 @@ def _wait_with_progress(
         return done_count == total
 
     def _render_extras():
-        extras: list = []
-        if activity:
-            extras.append(Text(""))
-            extras.extend(activity[-max_activity:])
-        return extras
+        if not activity:
+            return []
+        return [Text(""), *activity[-max_activity:]]
 
     run_progress_loop(
-        setup=_setup,
+        progress,
         update=_update,
         render_extras=_render_extras,
         poll_interval=poll_interval,
     )
-
     return _collect_results(results, display_hashes)

--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -164,7 +164,7 @@ def _collect_results(results: list, hashes: list[str]) -> list[dict]:
     return list(results)
 
 
-from .progress import _get_block_status  # noqa: E402
+from .progress import run_progress_loop  # noqa: E402
 
 
 def _is_running(future) -> bool:
@@ -249,7 +249,8 @@ def _wait_with_progress(
     of recent completions/failures. Scales to any number of builds.
 
     Per-future result handling is delegated to :func:`_poll_future`; SLURM
-    block status querying to :func:`_get_block_status`.
+    block status querying to :func:`_get_block_status`.  The shared
+    Live/poll/render loop is provided by :func:`run_progress_loop`.
 
     Parameters
     ----------
@@ -271,83 +272,67 @@ def _wait_with_progress(
         Result dicts for each future.
 
     """
-    import time
-
-    from rich.console import Console, Group
-    from rich.live import Live
-    from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
     from rich.text import Text
 
     total = len(futures)
     results: list[dict | None] = [None] * total
     display_hashes = hashes or [f"build-{i}" for i in range(total)]
-    console = Console()
 
     succeeded = 0
     failed = 0
     max_activity = 12
     activity: list[Text] = []
+    task_id_holder: list = []
 
-    progress = Progress(
-        TextColumn(f"⚒ [bold]{label}[/]"),
-        BarColumn(bar_width=40),
-        MofNCompleteColumn(),
-        TextColumn("·"),
-        TextColumn("[green]{task.fields[succeeded]} ✓[/]"),
-        TextColumn("[red]{task.fields[failed]} ✗[/]"),
-        TextColumn("[yellow]{task.fields[running]} ●[/]"),
-        console=console,
-        transient=False,
-    )
-    task_id = progress.add_task("builds", total=total, succeeded=0, failed=0, running=0)
+    def _setup(progress):
+        tid = progress.add_task(
+            f"⚒ [bold]{label}[/]",
+            total=total,
+            succeeded=0,
+            failed=0,
+            running=0,
+        )
+        task_id_holder.append(tid)
 
-    def _render():
-        done_count = succeeded + failed
+    def _update(progress):
+        nonlocal succeeded, failed
+        done_count = 0
+        for i, future in enumerate(futures):
+            if results[i] is not None:
+                done_count += 1
+                continue
+            if future.done():
+                result, line = _poll_future(future, display_hashes[i], result_transform)
+                results[i] = result
+                activity.append(line)
+                if result.get("status") == "failed":
+                    failed += 1
+                else:
+                    succeeded += 1
+                done_count += 1
+
         running = sum(1 for i, f in enumerate(futures) if results[i] is None and _is_running(f))
         progress.update(
-            task_id,
-            completed=done_count,
+            task_id_holder[0],
+            completed=succeeded + failed,
             succeeded=succeeded,
             failed=failed,
             running=running,
         )
-        parts = [progress]
-        block_info = _get_block_status()
-        if block_info:
-            parts.append(Text.from_markup(f"  ▸ SLURM: {block_info}"))
+        return done_count == total
+
+    def _render_extras():
+        extras: list = []
         if activity:
-            parts.append(Text(""))
-            for line in activity[-max_activity:]:
-                parts.append(line)
-        return Group(*parts)
+            extras.append(Text(""))
+            extras.extend(activity[-max_activity:])
+        return extras
 
-    try:
-        with Live(_render(), console=console, refresh_per_second=2) as live:
-            while True:
-                done_count = 0
-                for i, future in enumerate(futures):
-                    if results[i] is not None:
-                        done_count += 1
-                        continue
-                    if future.done():
-                        result, line = _poll_future(future, display_hashes[i], result_transform)
-                        results[i] = result
-                        activity.append(line)
-                        if result.get("status") == "failed":
-                            failed += 1
-                        else:
-                            succeeded += 1
-                        done_count += 1
-
-                live.update(_render())
-
-                if done_count == total:
-                    break
-
-                time.sleep(poll_interval)
-
-    except KeyboardInterrupt:
-        console.print("\n[bold yellow]Interrupted[/]")
-        raise
+    run_progress_loop(
+        setup=_setup,
+        update=_update,
+        render_extras=_render_extras,
+        poll_interval=poll_interval,
+    )
 
     return _collect_results(results, display_hashes)

--- a/mdfactory/orchestration/progress.py
+++ b/mdfactory/orchestration/progress.py
@@ -203,26 +203,25 @@ def display_stage_progress(
     poll_interval: float = 2.0,
 ) -> None:
     """Poll *tracker* and render Rich progress bars until all simulations finish."""
-    total = len(tracker.sim_hashes)
-    progress = _make_progress()
-
-    task_ids = {}
+    total, progress = len(tracker.sim_hashes), _make_progress()
     max_len = max(len(s) for s in tracker.stages)
-    for stage in tracker.stages:
-        task_ids[stage] = progress.add_task(
+    task_ids = {
+        stage: progress.add_task(
             f"⚒ {stage:<{max_len}}",
             total=total,
             succeeded=0,
             failed=0,
             running=0,
         )
+        for stage in tracker.stages
+    }
 
     def _update():
         snap = tracker.snapshot()
-        for stage in tracker.stages:
+        for stage, tid in task_ids.items():
             c = snap[stage]
             progress.update(
-                task_ids[stage],
+                tid,
                 completed=c["succeeded"] + c["failed"] + c["skipped"],
                 succeeded=c["succeeded"],
                 failed=c["failed"],

--- a/mdfactory/orchestration/progress.py
+++ b/mdfactory/orchestration/progress.py
@@ -1,13 +1,6 @@
 # ABOUTME: Thread-safe progress tracking and shared Rich progress display loop
 # ABOUTME: Provides StageProgressTracker, run_progress_loop, and display_stage_progress
-"""Progress tracking and display for orchestration workflows.
-
-Provides :class:`StageProgressTracker`, a thread-safe tracker that worker
-threads report into, :func:`run_progress_loop`, a shared Rich-based
-Live/poll/render loop used by both build and simulate workflows, and
-:func:`display_stage_progress`, a convenience wrapper for simulation
-stage progress.
-"""
+"""Progress tracking and display for orchestration workflows."""
 
 from __future__ import annotations
 
@@ -16,10 +9,6 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from rich.progress import Progress
 
 
 class SimState(Enum):
@@ -152,43 +141,12 @@ def _get_block_status() -> str:
         return ""
 
 
-def run_progress_loop(
-    *,
-    setup: Callable[[Progress], None],
-    update: Callable[[Progress], bool],
-    render_extras: Callable[[], list] = lambda: [],
-    poll_interval: float = 2.0,
-) -> None:
-    """Run a Rich Live progress display with a poll loop.
-
-    Owns the shared column layout, ``Live``/``Group`` context, SLURM block
-    status rendering, and ``KeyboardInterrupt`` handling.  Callers provide
-    callbacks to set up progress bars, update state each tick, and
-    optionally render extra lines (e.g. an activity log).
-
-    Parameters
-    ----------
-    setup : callable
-        ``(progress: Progress) -> None``.  Called once to create progress
-        bar task(s) via ``progress.add_task(...)``.
-    update : callable
-        ``(progress: Progress) -> bool``.  Called each tick to refresh bar
-        state.  Must return ``True`` when the loop should exit.
-    render_extras : callable
-        ``() -> list``.  Returns additional Rich renderables (e.g.
-        ``Text`` lines) appended below the progress bars.
-    poll_interval : float
-        Seconds between ticks.
-
-    """
-    from rich.console import Console, Group
-    from rich.live import Live
+def _make_progress():
+    """Create a Rich Progress bar with the standard orchestration column layout."""
+    from rich.console import Console
     from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
-    from rich.text import Text
 
-    console = Console()
-
-    progress = Progress(
+    return Progress(
         TextColumn("{task.description}"),
         BarColumn(bar_width=40),
         MofNCompleteColumn(),
@@ -196,11 +154,27 @@ def run_progress_loop(
         TextColumn("[green]{task.fields[succeeded]} ✓[/]"),
         TextColumn("[red]{task.fields[failed]} ✗[/]"),
         TextColumn("[yellow]{task.fields[running]} ●[/]"),
-        console=console,
+        console=Console(),
         transient=False,
     )
 
-    setup(progress)
+
+def run_progress_loop(
+    progress,
+    *,
+    update: Callable[[], bool],
+    render_extras: Callable[[], list] = lambda: [],
+    poll_interval: float = 2.0,
+) -> None:
+    """Run a Live poll loop around a Progress bar until *update* returns ``True``.
+
+    Handles the SLURM block-status line and ``KeyboardInterrupt`` uniformly.
+    """
+    from rich.console import Group
+    from rich.live import Live
+    from rich.text import Text
+
+    console = progress.console
 
     def _render():
         parts: list = [progress]
@@ -213,7 +187,7 @@ def run_progress_loop(
     try:
         with Live(_render(), console=console, refresh_per_second=2) as live:
             while True:
-                done = update(progress)
+                done = update()
                 live.update(_render())
                 if done:
                     break
@@ -228,50 +202,32 @@ def display_stage_progress(
     *,
     poll_interval: float = 2.0,
 ) -> None:
-    """Poll the tracker and render Rich progress bars until all simulations finish.
-
-    Runs on the main thread.  Blocks until :meth:`StageProgressTracker.all_done`
-    returns ``True``.
-
-    Parameters
-    ----------
-    tracker : StageProgressTracker
-        Shared tracker updated by worker threads.
-    poll_interval : float
-        Seconds between display refreshes.
-
-    """
+    """Poll *tracker* and render Rich progress bars until all simulations finish."""
     total = len(tracker.sim_hashes)
-    task_ids: dict[str, object] = {}
+    progress = _make_progress()
 
-    def _setup(progress):
-        max_len = max(len(s) for s in tracker.stages)
-        for stage in tracker.stages:
-            tid = progress.add_task(
-                f"⚒ {stage:<{max_len}}",
-                total=total,
-                succeeded=0,
-                failed=0,
-                running=0,
-            )
-            task_ids[stage] = tid
+    task_ids = {}
+    max_len = max(len(s) for s in tracker.stages)
+    for stage in tracker.stages:
+        task_ids[stage] = progress.add_task(
+            f"⚒ {stage:<{max_len}}",
+            total=total,
+            succeeded=0,
+            failed=0,
+            running=0,
+        )
 
-    def _update(progress):
+    def _update():
         snap = tracker.snapshot()
         for stage in tracker.stages:
-            counts = snap[stage]
-            done = counts["succeeded"] + counts["failed"] + counts["skipped"]
+            c = snap[stage]
             progress.update(
                 task_ids[stage],
-                completed=done,
-                succeeded=counts["succeeded"],
-                failed=counts["failed"],
-                running=counts["running"],
+                completed=c["succeeded"] + c["failed"] + c["skipped"],
+                succeeded=c["succeeded"],
+                failed=c["failed"],
+                running=c["running"],
             )
         return tracker.all_done()
 
-    run_progress_loop(
-        setup=_setup,
-        update=_update,
-        poll_interval=poll_interval,
-    )
+    run_progress_loop(progress, update=_update, poll_interval=poll_interval)

--- a/mdfactory/orchestration/progress.py
+++ b/mdfactory/orchestration/progress.py
@@ -1,19 +1,25 @@
-# ABOUTME: Thread-safe progress tracking for per-stage simulation monitoring
-# ABOUTME: Provides StageProgressTracker and Rich progress display for EM/NVT/NPT/Production stages
-"""Per-stage progress tracking for simulation orchestration.
+# ABOUTME: Thread-safe progress tracking and shared Rich progress display loop
+# ABOUTME: Provides StageProgressTracker, run_progress_loop, and display_stage_progress
+"""Progress tracking and display for orchestration workflows.
 
 Provides :class:`StageProgressTracker`, a thread-safe tracker that worker
-threads report into, and :func:`display_stage_progress`, a Rich-based
-display that polls the tracker and renders one progress bar per simulation
-stage (EM, NVT, NPT, Production).
+threads report into, :func:`run_progress_loop`, a shared Rich-based
+Live/poll/render loop used by both build and simulate workflows, and
+:func:`display_stage_progress`, a convenience wrapper for simulation
+stage progress.
 """
 
 from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.progress import Progress
 
 
 class SimState(Enum):
@@ -146,6 +152,77 @@ def _get_block_status() -> str:
         return ""
 
 
+def run_progress_loop(
+    *,
+    setup: Callable[[Progress], None],
+    update: Callable[[Progress], bool],
+    render_extras: Callable[[], list] = lambda: [],
+    poll_interval: float = 2.0,
+) -> None:
+    """Run a Rich Live progress display with a poll loop.
+
+    Owns the shared column layout, ``Live``/``Group`` context, SLURM block
+    status rendering, and ``KeyboardInterrupt`` handling.  Callers provide
+    callbacks to set up progress bars, update state each tick, and
+    optionally render extra lines (e.g. an activity log).
+
+    Parameters
+    ----------
+    setup : callable
+        ``(progress: Progress) -> None``.  Called once to create progress
+        bar task(s) via ``progress.add_task(...)``.
+    update : callable
+        ``(progress: Progress) -> bool``.  Called each tick to refresh bar
+        state.  Must return ``True`` when the loop should exit.
+    render_extras : callable
+        ``() -> list``.  Returns additional Rich renderables (e.g.
+        ``Text`` lines) appended below the progress bars.
+    poll_interval : float
+        Seconds between ticks.
+
+    """
+    from rich.console import Console, Group
+    from rich.live import Live
+    from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
+    from rich.text import Text
+
+    console = Console()
+
+    progress = Progress(
+        TextColumn("{task.description}"),
+        BarColumn(bar_width=40),
+        MofNCompleteColumn(),
+        TextColumn("·"),
+        TextColumn("[green]{task.fields[succeeded]} ✓[/]"),
+        TextColumn("[red]{task.fields[failed]} ✗[/]"),
+        TextColumn("[yellow]{task.fields[running]} ●[/]"),
+        console=console,
+        transient=False,
+    )
+
+    setup(progress)
+
+    def _render():
+        parts: list = [progress]
+        block_info = _get_block_status()
+        if block_info:
+            parts.append(Text.from_markup(f"  ▸ SLURM: {block_info}"))
+        parts.extend(render_extras())
+        return Group(*parts)
+
+    try:
+        with Live(_render(), console=console, refresh_per_second=2) as live:
+            while True:
+                done = update(progress)
+                live.update(_render())
+                if done:
+                    break
+                time.sleep(poll_interval)
+    except KeyboardInterrupt:
+        console.print("\n[bold yellow]Interrupted[/]")
+        raise
+
+
 def display_stage_progress(
     tracker: StageProgressTracker,
     *,
@@ -164,39 +241,22 @@ def display_stage_progress(
         Seconds between display refreshes.
 
     """
-    from rich.console import Console, Group
-    from rich.live import Live
-    from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
-    from rich.text import Text
-
-    console = Console()
     total = len(tracker.sim_hashes)
+    task_ids: dict[str, object] = {}
 
-    progress = Progress(
-        TextColumn("{task.description}"),
-        BarColumn(bar_width=40),
-        MofNCompleteColumn(),
-        TextColumn("·"),
-        TextColumn("[green]{task.fields[succeeded]} ✓[/]"),
-        TextColumn("[red]{task.fields[failed]} ✗[/]"),
-        TextColumn("[yellow]{task.fields[running]} ●[/]"),
-        console=console,
-        transient=False,
-    )
+    def _setup(progress):
+        max_len = max(len(s) for s in tracker.stages)
+        for stage in tracker.stages:
+            tid = progress.add_task(
+                f"⚒ {stage:<{max_len}}",
+                total=total,
+                succeeded=0,
+                failed=0,
+                running=0,
+            )
+            task_ids[stage] = tid
 
-    task_ids = {}
-    max_len = max(len(s) for s in tracker.stages)
-    for stage in tracker.stages:
-        tid = progress.add_task(
-            f"⚒ {stage:<{max_len}}",
-            total=total,
-            succeeded=0,
-            failed=0,
-            running=0,
-        )
-        task_ids[stage] = tid
-
-    def _render():
+    def _update(progress):
         snap = tracker.snapshot()
         for stage in tracker.stages:
             counts = snap[stage]
@@ -208,18 +268,10 @@ def display_stage_progress(
                 failed=counts["failed"],
                 running=counts["running"],
             )
-        parts: list = [progress]
-        block_info = _get_block_status()
-        if block_info:
-            parts.append(Text.from_markup(f"  ▸ SLURM: {block_info}"))
-        return Group(*parts)
+        return tracker.all_done()
 
-    try:
-        with Live(_render(), console=console, refresh_per_second=2) as live:
-            while not tracker.all_done():
-                time.sleep(poll_interval)
-                live.update(_render())
-            live.update(_render())
-    except KeyboardInterrupt:
-        console.print("\n[bold yellow]Interrupted[/]")
-        raise
+    run_progress_loop(
+        setup=_setup,
+        update=_update,
+        poll_interval=poll_interval,
+    )

--- a/mdfactory/tests/test_orchestration_progress.py
+++ b/mdfactory/tests/test_orchestration_progress.py
@@ -1,10 +1,11 @@
-# ABOUTME: Tests for per-stage simulation progress tracking
-# ABOUTME: Covers StageProgressTracker state transitions, thread safety, and result collection
-"""Tests for the per-stage progress tracker."""
+# ABOUTME: Tests for per-stage simulation progress tracking and shared progress loop
+# ABOUTME: Covers StageProgressTracker state transitions, thread safety, and run_progress_loop
+"""Tests for the progress tracker and shared progress loop."""
 
 import threading
+from unittest.mock import MagicMock, patch
 
-from mdfactory.orchestration.progress import StageProgressTracker
+from mdfactory.orchestration.progress import StageProgressTracker, run_progress_loop
 
 
 class TestStageProgressTracker:
@@ -138,3 +139,73 @@ class TestStageProgressTracker:
         assert snap["NVT"]["failed"] == 1
         assert snap["NPT"]["skipped"] == 1
         assert snap["Production"]["skipped"] == 1
+
+
+class TestRunProgressLoop:
+    """Unit tests for the shared run_progress_loop driver."""
+
+    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
+    @patch("rich.live.Live")
+    def test_setup_called_once(self, _mock_live, _mock_block):
+        """setup callback is invoked exactly once."""
+        setup = MagicMock()
+        update = MagicMock(return_value=True)
+
+        run_progress_loop(setup=setup, update=update)
+
+        setup.assert_called_once()
+
+    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
+    @patch("rich.live.Live")
+    def test_update_polled_until_done(self, _mock_live, _mock_block):
+        """update is called repeatedly until it returns True."""
+        setup = MagicMock()
+        # Return False twice, then True on third call.
+        update = MagicMock(side_effect=[False, False, True])
+
+        run_progress_loop(setup=setup, update=update, poll_interval=0.0)
+
+        assert update.call_count == 3
+
+    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
+    @patch("rich.live.Live")
+    def test_render_extras_called_each_tick(self, _mock_live, _mock_block):
+        """render_extras is called on every render (setup + each update)."""
+        setup = MagicMock()
+        update = MagicMock(side_effect=[False, True])
+        render_extras = MagicMock(return_value=[])
+
+        run_progress_loop(
+            setup=setup, update=update, render_extras=render_extras, poll_interval=0.0
+        )
+
+        # Called during initial render + once per update tick (2 ticks)
+        assert render_extras.call_count >= 2
+
+    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
+    @patch("rich.live.Live")
+    def test_keyboard_interrupt_reraised(self, mock_live_cls, _mock_block):
+        """KeyboardInterrupt during the loop is caught, printed, and re-raised."""
+        setup = MagicMock()
+        update = MagicMock(side_effect=KeyboardInterrupt)
+
+        import pytest
+
+        with pytest.raises(KeyboardInterrupt):
+            run_progress_loop(setup=setup, update=update)
+
+    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
+    @patch("rich.live.Live")
+    def test_setup_receives_progress_object(self, _mock_live, _mock_block):
+        """setup callback receives a Progress instance with the standard columns."""
+        from rich.progress import Progress
+
+        captured = {}
+
+        def _setup(progress):
+            captured["progress"] = progress
+
+        update = MagicMock(return_value=True)
+        run_progress_loop(setup=_setup, update=update)
+
+        assert isinstance(captured["progress"], Progress)

--- a/mdfactory/tests/test_orchestration_progress.py
+++ b/mdfactory/tests/test_orchestration_progress.py
@@ -5,6 +5,8 @@
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mdfactory.orchestration.progress import StageProgressTracker, run_progress_loop
 
 
@@ -141,42 +143,30 @@ class TestStageProgressTracker:
         assert snap["Production"]["skipped"] == 1
 
 
-class TestRunProgressLoop:
-    """Unit tests for the shared run_progress_loop driver."""
+_no_block = patch("mdfactory.orchestration.progress._get_block_status", return_value="")
+_no_live = patch("rich.live.Live")
 
-    def _progress(self):
-        from mdfactory.orchestration.progress import _make_progress
 
-        return _make_progress()
+def _progress():
+    from mdfactory.orchestration.progress import _make_progress
 
-    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
-    @patch("rich.live.Live")
-    def test_update_polled_until_done(self, _mock_live, _mock_block):
-        """update is called repeatedly until it returns True."""
-        update = MagicMock(side_effect=[False, False, True])
+    return _make_progress()
 
-        run_progress_loop(self._progress(), update=update, poll_interval=0.0)
 
-        assert update.call_count == 3
+@_no_block
+@_no_live
+def test_run_progress_loop_polls_until_done(_live, _block):
+    """update is called repeatedly until it returns True; render_extras each tick."""
+    update = MagicMock(side_effect=[False, False, True])
+    extras = MagicMock(return_value=[])
+    run_progress_loop(_progress(), update=update, render_extras=extras, poll_interval=0.0)
+    assert update.call_count == 3
+    assert extras.call_count >= 2
 
-    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
-    @patch("rich.live.Live")
-    def test_render_extras_called_each_tick(self, _mock_live, _mock_block):
-        """render_extras is called on every render."""
-        update = MagicMock(side_effect=[False, True])
-        render_extras = MagicMock(return_value=[])
 
-        run_progress_loop(
-            self._progress(), update=update, render_extras=render_extras, poll_interval=0.0
-        )
-
-        assert render_extras.call_count >= 2
-
-    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
-    @patch("rich.live.Live")
-    def test_keyboard_interrupt_reraised(self, _mock_live, _mock_block):
-        """KeyboardInterrupt during the loop is caught, printed, and re-raised."""
-        import pytest
-
-        with pytest.raises(KeyboardInterrupt):
-            run_progress_loop(self._progress(), update=MagicMock(side_effect=KeyboardInterrupt))
+@_no_block
+@_no_live
+def test_run_progress_loop_keyboard_interrupt(_live, _block):
+    """KeyboardInterrupt is caught, printed, and re-raised."""
+    with pytest.raises(KeyboardInterrupt):
+        run_progress_loop(_progress(), update=MagicMock(side_effect=KeyboardInterrupt))

--- a/mdfactory/tests/test_orchestration_progress.py
+++ b/mdfactory/tests/test_orchestration_progress.py
@@ -144,68 +144,39 @@ class TestStageProgressTracker:
 class TestRunProgressLoop:
     """Unit tests for the shared run_progress_loop driver."""
 
-    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
-    @patch("rich.live.Live")
-    def test_setup_called_once(self, _mock_live, _mock_block):
-        """setup callback is invoked exactly once."""
-        setup = MagicMock()
-        update = MagicMock(return_value=True)
+    def _progress(self):
+        from mdfactory.orchestration.progress import _make_progress
 
-        run_progress_loop(setup=setup, update=update)
-
-        setup.assert_called_once()
+        return _make_progress()
 
     @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
     @patch("rich.live.Live")
     def test_update_polled_until_done(self, _mock_live, _mock_block):
         """update is called repeatedly until it returns True."""
-        setup = MagicMock()
-        # Return False twice, then True on third call.
         update = MagicMock(side_effect=[False, False, True])
 
-        run_progress_loop(setup=setup, update=update, poll_interval=0.0)
+        run_progress_loop(self._progress(), update=update, poll_interval=0.0)
 
         assert update.call_count == 3
 
     @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
     @patch("rich.live.Live")
     def test_render_extras_called_each_tick(self, _mock_live, _mock_block):
-        """render_extras is called on every render (setup + each update)."""
-        setup = MagicMock()
+        """render_extras is called on every render."""
         update = MagicMock(side_effect=[False, True])
         render_extras = MagicMock(return_value=[])
 
         run_progress_loop(
-            setup=setup, update=update, render_extras=render_extras, poll_interval=0.0
+            self._progress(), update=update, render_extras=render_extras, poll_interval=0.0
         )
 
-        # Called during initial render + once per update tick (2 ticks)
         assert render_extras.call_count >= 2
 
     @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
     @patch("rich.live.Live")
-    def test_keyboard_interrupt_reraised(self, mock_live_cls, _mock_block):
+    def test_keyboard_interrupt_reraised(self, _mock_live, _mock_block):
         """KeyboardInterrupt during the loop is caught, printed, and re-raised."""
-        setup = MagicMock()
-        update = MagicMock(side_effect=KeyboardInterrupt)
-
         import pytest
 
         with pytest.raises(KeyboardInterrupt):
-            run_progress_loop(setup=setup, update=update)
-
-    @patch("mdfactory.orchestration.progress._get_block_status", return_value="")
-    @patch("rich.live.Live")
-    def test_setup_receives_progress_object(self, _mock_live, _mock_block):
-        """setup callback receives a Progress instance with the standard columns."""
-        from rich.progress import Progress
-
-        captured = {}
-
-        def _setup(progress):
-            captured["progress"] = progress
-
-        update = MagicMock(return_value=True)
-        run_progress_loop(setup=_setup, update=update)
-
-        assert isinstance(captured["progress"], Progress)
+            run_progress_loop(self._progress(), update=MagicMock(side_effect=KeyboardInterrupt))


### PR DESCRIPTION
Closes #47

Extract a shared `run_progress_loop` from the duplicate Rich progress/polling code in `build.py` and `progress.py`.

Implementation plan posted as a comment below.
