### PR TITLE
refactor: split simulate.py into focused modules (SRP)

### DIFF
--- a/mdfactory/orchestration/__init__.py
+++ b/mdfactory/orchestration/__init__.py
@@ -5,7 +5,8 @@
 from .build import build_systems
 from .config import ExecutorConfig, SlurmExecutorConfig
 from .environment import EnvironmentConfig, get_global_environment_path
-from .simulate import clean_simulation_outputs, find_structure_file, run_simulations
+from .simulate import clean_simulation_outputs, run_simulations
+from .trajectory import find_structure_file
 from .tui import (
     configure_and_save_environment,
     configure_and_save_slurm,

--- a/mdfactory/orchestration/checkpoint.py
+++ b/mdfactory/orchestration/checkpoint.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TypedDict
 
-from loguru import logger
-
 from .stages import STAGE_BY_NAME, StageSpec
 from .trajectory import _extract_expected_frames_from_mdp, _validate_trajectory_complete
 
@@ -146,26 +144,8 @@ def _detect_needed_stages_with_restart_info(
     needed = []
     for stage in stages:
         state = _detect_stage_state(sim_dir, stage, mode)
-
         if state["status"] == "complete":
-            continue  # Skip completed stages
-        elif state["status"] == "partial" and state["restart"]:
-            # Can resume from checkpoint
-            needed.append(
-                {
-                    "stage": stage,
-                    "restart": True,
-                    "cpt_file": state["cpt_file"],
-                }
-            )
-        else:
-            # Not started or can't restart - run from beginning
-            needed.append(
-                {
-                    "stage": stage,
-                    "restart": False,
-                    "cpt_file": None,
-                }
-            )
+            continue
+        needed.append({"stage": stage, "restart": state["restart"], "cpt_file": state["cpt_file"]})
 
     return needed

--- a/mdfactory/orchestration/checkpoint.py
+++ b/mdfactory/orchestration/checkpoint.py
@@ -1,0 +1,171 @@
+# ABOUTME: Checkpoint detection logic for GROMACS simulation stage progression
+# ABOUTME: Determines which stages need to run based on mode (auto/skip/force) and existing outputs
+"""Checkpoint detection for simulation stage progression.
+
+Determines which pipeline stages still need to run based on the checkpoint
+*mode* (``auto`` / ``skip`` / ``force``) and existing output files.  The
+core entry point is :func:`_detect_needed_stages_with_restart_info`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+from loguru import logger
+
+from .stages import STAGE_BY_NAME, StageSpec
+from .trajectory import _extract_expected_frames_from_mdp, _validate_trajectory_complete
+
+
+class _StageState(TypedDict):
+    """Checkpoint detection result for a single stage."""
+
+    status: str  # "complete" | "partial" | "not_started"
+    cpt_file: "Path | None"
+    restart: bool
+
+
+def _has_restart_pair(cpt_file: Path, tpr_file: Path) -> bool:
+    """Return True if both checkpoint and TPR files exist (restartable state)."""
+    return cpt_file.exists() and tpr_file.exists()
+
+
+def _detect_skip_mode_state(output_file: Path, cpt_file: Path, tpr_file: Path) -> _StageState:
+    """Return stage state for 'skip' mode: complete if output exists, partial if cpt+tpr exist."""
+    if output_file.exists():
+        return {"status": "complete", "cpt_file": None, "restart": False}
+    if _has_restart_pair(cpt_file, tpr_file):
+        return {"status": "partial", "cpt_file": cpt_file, "restart": True}
+    return {"status": "not_started", "cpt_file": None, "restart": False}
+
+
+def _detect_production_output_state(
+    sim_dir: Path,
+    cpt_file: Path,
+    tpr_file: Path,
+    traj_files: "tuple[str, ...]",
+) -> _StageState:
+    """Check Production trajectory completeness; restart from cpt if incomplete."""
+    expected_frames = _extract_expected_frames_from_mdp(sim_dir, "Production")
+    for traj_file in traj_files:
+        if _validate_trajectory_complete(sim_dir, traj_file, expected_frames):
+            return {"status": "complete", "cpt_file": None, "restart": False}
+    if _has_restart_pair(cpt_file, tpr_file):
+        return {"status": "partial", "cpt_file": cpt_file, "restart": True}
+    # All trajectory files incomplete and no checkpoint to restart from
+    return {"status": "partial", "cpt_file": None, "restart": False}
+
+
+def _detect_skip_stage_state(
+    sim_dir: Path,
+    spec: "StageSpec",
+    cpt_file: Path,
+    tpr_file: Path,
+) -> _StageState:
+    """Return stage state for 'skip' mode: file-existence only, no integrity checks."""
+    if spec.traj_files:
+        # Mirror auto mode: complete if ANY trajectory file exists (XTC or TRR).
+        if any((sim_dir / tf).exists() for tf in spec.traj_files):
+            return {"status": "complete", "cpt_file": None, "restart": False}
+        if _has_restart_pair(cpt_file, tpr_file):
+            return {"status": "partial", "cpt_file": cpt_file, "restart": True}
+        return {"status": "not_started", "cpt_file": None, "restart": False}
+    return _detect_skip_mode_state(sim_dir / spec.gro_out, cpt_file, tpr_file)
+
+
+def _detect_auto_output_state(
+    sim_dir: Path,
+    stage: str,
+    spec: "StageSpec",
+    cpt_file: Path,
+    tpr_file: Path,
+    prereq_cpt: "Path | None",
+) -> _StageState:
+    """Return stage state for 'auto' mode; validates prerequisite integrity before accepting."""
+    # Workflow integrity: prerequisite checkpoint must exist for the output to
+    # be trustworthy (e.g. npt.gro is only valid if nvt.cpt is present).
+    if prereq_cpt and not prereq_cpt.exists():
+        return {"status": "not_started", "cpt_file": None, "restart": False}
+    if stage == "Production":
+        return _detect_production_output_state(sim_dir, cpt_file, tpr_file, spec.traj_files)
+    return {"status": "complete", "cpt_file": None, "restart": False}
+
+
+def _detect_stage_state(sim_dir: Path, stage: str, mode: str = "auto") -> _StageState:
+    """Detect completion or partial progress of a stage given checkpoint *mode*."""
+    spec = STAGE_BY_NAME[stage]
+    cpt_file = sim_dir / spec.cpt_file
+    tpr_file = sim_dir / spec.tpr_file
+
+    if mode == "skip":
+        return _detect_skip_stage_state(sim_dir, spec, cpt_file, tpr_file)
+
+    # For trajectory stages (Production) any accepted file counts as output.
+    # For structure stages (EM/NVT/NPT) the single gro_out is the output.
+    if spec.traj_files:
+        output_exists = any(
+            (sim_dir / tf).exists() and (sim_dir / tf).stat().st_size > 0 for tf in spec.traj_files
+        )
+    else:
+        gro_out_file = sim_dir / spec.gro_out
+        output_exists = gro_out_file.exists() and gro_out_file.stat().st_size > 0
+
+    # Prerequisite checkpoint (for validating workflow integrity in auto mode)
+    prereq_cpt = sim_dir / spec.prereq_cpt if spec.prereq_cpt else None
+
+    if output_exists:
+        return _detect_auto_output_state(sim_dir, stage, spec, cpt_file, tpr_file, prereq_cpt)
+
+    # Check partial progress (checkpoint exists, output doesn't).
+    if _has_restart_pair(cpt_file, tpr_file):
+        if spec.traj_files:
+            # Trajectory stage (Production): stale checkpoint without a
+            # trajectory file cannot use -append — GROMACS would crash.
+            # Treat as not_started so grompp+mdrun run from scratch.
+            return {"status": "not_started", "cpt_file": None, "restart": False}
+        return {"status": "partial", "cpt_file": cpt_file, "restart": True}
+
+    return {"status": "not_started", "cpt_file": None, "restart": False}
+
+
+def _detect_needed_stages(sim_dir: Path, stages: list[str], mode: str) -> list[str]:
+    """Return stage names that still need to run (discards restart metadata)."""
+    return [
+        item["stage"] for item in _detect_needed_stages_with_restart_info(sim_dir, stages, mode)
+    ]
+
+
+def _detect_needed_stages_with_restart_info(
+    sim_dir: Path, stages: list[str], mode: str
+) -> list[dict]:
+    """Return stage work items ``[{"stage", "restart", "cpt_file"}, ...]`` for incomplete stages."""
+    if mode == "force":
+        return [{"stage": s, "restart": False, "cpt_file": None} for s in stages]
+
+    needed = []
+    for stage in stages:
+        state = _detect_stage_state(sim_dir, stage, mode)
+
+        if state["status"] == "complete":
+            continue  # Skip completed stages
+        elif state["status"] == "partial" and state["restart"]:
+            # Can resume from checkpoint
+            needed.append(
+                {
+                    "stage": stage,
+                    "restart": True,
+                    "cpt_file": state["cpt_file"],
+                }
+            )
+        else:
+            # Not started or can't restart - run from beginning
+            needed.append(
+                {
+                    "stage": stage,
+                    "restart": False,
+                    "cpt_file": None,
+                }
+            )
+
+    return needed

--- a/mdfactory/orchestration/execution.py
+++ b/mdfactory/orchestration/execution.py
@@ -1,0 +1,133 @@
+# ABOUTME: Stage execution mechanics for GROMACS simulation pipelines
+# ABOUTME: Chains stages in dependency order with rescue retry and progress tracking
+"""Stage execution for simulation pipelines.
+
+Provides :func:`_execute_stage_list` (stage chaining with rescue retry
+and progress tracking) and :func:`_validate_stage_prerequisites`
+(fail-fast prerequisite check before Parsl submission).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .config import get_stage_config_or_none
+from .stages import STAGE_BY_NAME, STAGE_REGISTRY, run_stage
+
+if TYPE_CHECKING:
+    from parsl import AppFuture
+
+    from .config import ExecutorConfig
+    from .progress import StageProgressTracker
+
+
+def _execute_stage_list(
+    sim_dir: Path,
+    stages: list[str],
+    grompp_app,
+    mdrun_app,
+    stage_restarts: "dict[str, str] | None" = None,
+    config: "ExecutorConfig | None" = None,
+    max_rescue: int = 3,
+    tracker: "StageProgressTracker | None" = None,
+) -> "AppFuture | None":
+    """Chain and submit stages in dependency order, with rescue retry and progress tracking."""
+    if not stages:
+        return None
+
+    restarts = stage_restarts or {}
+    sim_hash = sim_dir.name
+
+    # Validate that stages are in dependency order (derived from STAGE_REGISTRY — single source)
+    stage_order = [s.name for s in STAGE_REGISTRY]
+    stage_indices = {name: idx for idx, name in enumerate(stage_order)}
+
+    prev_idx = -1
+    for stage in stages:
+        if stage not in stage_indices:
+            raise ValueError(f"Unknown stage: {stage}. Valid: {stage_order}")
+
+        curr_idx = stage_indices[stage]
+        if curr_idx <= prev_idx:
+            raise ValueError(f"Stages must be in dependency order: {stage_order}. Got: {stages}")
+        prev_idx = curr_idx
+
+    from .mdp import RESCUE_ELIGIBLE_STAGES
+    from .rescue import execute_stage_with_rescue
+
+    prev_future = None
+    for i, stage in enumerate(stages):
+        cpt_file = restarts.get(stage, "")
+
+        if tracker is not None:
+            tracker.mark_running(stage, sim_hash)
+
+        try:
+            if max_rescue > 0 and stage in RESCUE_ELIGIBLE_STAGES and not cpt_file:
+                prev_future = execute_stage_with_rescue(
+                    sim_dir,
+                    stage,
+                    prev_future,
+                    grompp_app,
+                    mdrun_app,
+                    max_rescue=max_rescue,
+                    config=config,
+                )
+                # Rescue stages block — if we get here, it succeeded
+                if tracker is not None:
+                    tracker.mark_succeeded(stage, sim_hash)
+            else:
+                stage_cfg = get_stage_config_or_none(config, stage)
+                cfg_kwarg = {"stage_config": stage_cfg} if stage_cfg is not None else {}
+                prev_future = run_stage(
+                    STAGE_BY_NAME[stage],
+                    sim_dir,
+                    prev_future,
+                    grompp_app,
+                    mdrun_app,
+                    restart_from_cpt=cpt_file,
+                    **cfg_kwarg,
+                )
+                # Non-rescue stages return immediately — track via callback
+                if tracker is not None:
+                    _s, _h, _t = stage, sim_hash, tracker
+
+                    def _on_done(fut, s=_s, h=_h, t=_t):
+                        if fut.exception() is not None:
+                            t.mark_failed(s, h)
+                        else:
+                            t.mark_succeeded(s, h)
+
+                    prev_future.add_done_callback(_on_done)
+
+        except Exception:
+            if tracker is not None:
+                tracker.mark_failed(stage, sim_hash)
+                for skip_stage in stages[i + 1 :]:
+                    tracker.mark_skipped(skip_stage, sim_hash)
+            raise
+
+    return prev_future
+
+
+def _validate_stage_prerequisites(sim_dir: Path, first_stage: str) -> None:
+    """Fail fast if prerequisite files for *first_stage* are missing."""
+    spec = STAGE_BY_NAME[first_stage]
+    required: list[Path] = []
+    if spec.gro_in and spec.gro_in != "system.pdb":
+        required.append(sim_dir / spec.gro_in)
+    if spec.prereq_cpt:
+        required.append(sim_dir / spec.prereq_cpt)
+    missing = [f.name for f in required if not f.exists()]
+
+    if missing:
+        raise FileNotFoundError(
+            f"Cannot start {first_stage} in {sim_dir.name}: "
+            f"missing prerequisite files: {missing}\n\n"
+            f"Resolution:\n"
+            f"  1. Run earlier stages first:\n"
+            f"     mdfactory simulate {sim_dir} --stages EM NVT\n"
+            f"  2. Or force overwrite all:\n"
+            f"     mdfactory simulate {sim_dir} --checkpoint force"
+        )

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -18,18 +18,12 @@ from loguru import logger
 from .apps import get_grompp_app, get_mdrun_app
 from .checkpoint import _detect_needed_stages_with_restart_info
 from .config import get_stage_config_or_none
+from .execution import _execute_stage_list, _validate_stage_prerequisites
 from .session import parsl_session
-from .stages import (
-    STAGE_BY_NAME,
-    STAGE_REGISTRY,
-    run_stage,
-)
+from .stages import STAGE_BY_NAME, STAGE_REGISTRY
 
 if TYPE_CHECKING:
-    from parsl import AppFuture
-
     from .config import ExecutorConfig
-    from .progress import StageProgressTracker
 
 
 def _bash_result_to_dict(raw: object, sim_hash: str) -> dict:
@@ -389,120 +383,6 @@ def clean_simulation_outputs(
             logger.info(f"Cleaned {len(existing)} file(s) from {sim_dir.name}")
 
     return existing
-
-
-def _execute_stage_list(
-    sim_dir: Path,
-    stages: list[str],
-    grompp_app,
-    mdrun_app,
-    stage_restarts: "dict[str, str] | None" = None,
-    config: "ExecutorConfig | None" = None,
-    max_rescue: int = 3,
-    tracker: "StageProgressTracker | None" = None,
-) -> "AppFuture | None":
-    """Chain and submit stages in dependency order, with rescue retry and progress tracking."""
-    if not stages:
-        return None
-
-    restarts = stage_restarts or {}
-    sim_hash = sim_dir.name
-
-    # Validate that stages are in dependency order (derived from STAGE_REGISTRY — single source)
-    stage_order = [s.name for s in STAGE_REGISTRY]
-    stage_indices = {name: idx for idx, name in enumerate(stage_order)}
-
-    prev_idx = -1
-    for stage in stages:
-        if stage not in stage_indices:
-            raise ValueError(f"Unknown stage: {stage}. Valid: {stage_order}")
-
-        curr_idx = stage_indices[stage]
-        if curr_idx <= prev_idx:
-            raise ValueError(f"Stages must be in dependency order: {stage_order}. Got: {stages}")
-        prev_idx = curr_idx
-
-    from .mdp import RESCUE_ELIGIBLE_STAGES
-    from .rescue import execute_stage_with_rescue
-
-    prev_future = None
-    for i, stage in enumerate(stages):
-        cpt_file = restarts.get(stage, "")
-
-        if tracker is not None:
-            tracker.mark_running(stage, sim_hash)
-
-        try:
-            if max_rescue > 0 and stage in RESCUE_ELIGIBLE_STAGES and not cpt_file:
-                prev_future = execute_stage_with_rescue(
-                    sim_dir,
-                    stage,
-                    prev_future,
-                    grompp_app,
-                    mdrun_app,
-                    max_rescue=max_rescue,
-                    config=config,
-                )
-                # Rescue stages block — if we get here, it succeeded
-                if tracker is not None:
-                    tracker.mark_succeeded(stage, sim_hash)
-            else:
-                stage_cfg = get_stage_config_or_none(config, stage)
-                cfg_kwarg = {"stage_config": stage_cfg} if stage_cfg is not None else {}
-                prev_future = run_stage(
-                    STAGE_BY_NAME[stage],
-                    sim_dir,
-                    prev_future,
-                    grompp_app,
-                    mdrun_app,
-                    restart_from_cpt=cpt_file,
-                    **cfg_kwarg,
-                )
-                # Non-rescue stages return immediately — track via callback
-                if tracker is not None:
-                    _s, _h, _t = stage, sim_hash, tracker
-
-                    def _on_done(fut, s=_s, h=_h, t=_t):
-                        if fut.exception() is not None:
-                            t.mark_failed(s, h)
-                        else:
-                            t.mark_succeeded(s, h)
-
-                    prev_future.add_done_callback(_on_done)
-
-        except Exception:
-            if tracker is not None:
-                tracker.mark_failed(stage, sim_hash)
-                for skip_stage in stages[i + 1 :]:
-                    tracker.mark_skipped(skip_stage, sim_hash)
-            raise
-
-    return prev_future
-
-
-def _validate_stage_prerequisites(sim_dir: Path, first_stage: str) -> None:
-    """Fail fast if prerequisite files for *first_stage* are missing."""
-    # Prerequisites: files needed BEFORE this stage can start.
-    # Derived from StageSpec: the input .gro file and, when present, the
-    # prerequisite checkpoint (which is also the grompp -t velocity input).
-    spec = STAGE_BY_NAME[first_stage]
-    required: list[Path] = []
-    if spec.gro_in and spec.gro_in != "system.pdb":
-        required.append(sim_dir / spec.gro_in)
-    if spec.prereq_cpt:
-        required.append(sim_dir / spec.prereq_cpt)
-    missing = [f.name for f in required if not f.exists()]
-
-    if missing:
-        raise FileNotFoundError(
-            f"Cannot start {first_stage} in {sim_dir.name}: "
-            f"missing prerequisite files: {missing}\n\n"
-            f"Resolution:\n"
-            f"  1. Run earlier stages first:\n"
-            f"     mdfactory simulate {sim_dir} --stages EM NVT\n"
-            f"  2. Or force overwrite all:\n"
-            f"     mdfactory simulate {sim_dir} --checkpoint force"
-        )
 
 
 def _log_dry_run_plan(work_plan: list[dict], config: "ExecutorConfig") -> list[dict]:

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -1,53 +1,35 @@
 # ABOUTME: Main dispatcher for Parsl-based GROMACS simulation orchestration
-# ABOUTME: Handles checkpoint detection, dry-run, and progress monitoring
+# ABOUTME: Handles dry-run logging, stage execution, and progress monitoring
 """GROMACS simulation orchestration via Parsl.
 
 Provides :func:`run_simulations`, the main entry point for orchestrating
-GROMACS MD simulations via Parsl. Handles checkpoint detection, dry-run mode,
-and progress monitoring.
+GROMACS MD simulations via Parsl. Handles stage execution, dry-run mode,
+and progress monitoring.  Checkpoint detection lives in
+:mod:`.checkpoint`; trajectory validation in :mod:`.trajectory`.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from .apps import get_grompp_app, get_mdrun_app
+from .checkpoint import _detect_needed_stages_with_restart_info
 from .config import get_stage_config_or_none
 from .session import parsl_session
 from .stages import (
     STAGE_BY_NAME,
     STAGE_REGISTRY,
-    StageSpec,
     run_stage,
 )
-
-# Import MDAnalysis at module level for testability
-try:
-    import MDAnalysis as mda
-except ImportError:
-    mda = None
 
 if TYPE_CHECKING:
     from parsl import AppFuture
 
     from .config import ExecutorConfig
     from .progress import StageProgressTracker
-
-
-class _StageState(TypedDict):
-    """Checkpoint detection result for a single stage."""
-
-    status: str  # "complete" | "partial" | "not_started"
-    cpt_file: "Path | None"
-    restart: bool
-
-
-def _has_restart_pair(cpt_file: Path, tpr_file: Path) -> bool:
-    """Return True if both checkpoint and TPR files exist (restartable state)."""
-    return cpt_file.exists() and tpr_file.exists()
 
 
 def _bash_result_to_dict(raw: object, sim_hash: str) -> dict:
@@ -409,146 +391,6 @@ def clean_simulation_outputs(
     return existing
 
 
-def _detect_skip_mode_state(output_file: Path, cpt_file: Path, tpr_file: Path) -> _StageState:
-    """Return stage state for 'skip' mode: complete if output exists, partial if cpt+tpr exist."""
-    if output_file.exists():
-        return {"status": "complete", "cpt_file": None, "restart": False}
-    if _has_restart_pair(cpt_file, tpr_file):
-        return {"status": "partial", "cpt_file": cpt_file, "restart": True}
-    return {"status": "not_started", "cpt_file": None, "restart": False}
-
-
-def _detect_production_output_state(
-    sim_dir: Path,
-    cpt_file: Path,
-    tpr_file: Path,
-    traj_files: "tuple[str, ...]",
-) -> _StageState:
-    """Check Production trajectory completeness; restart from cpt if incomplete."""
-    expected_frames = _extract_expected_frames_from_mdp(sim_dir, "Production")
-    for traj_file in traj_files:
-        if _validate_trajectory_complete(sim_dir, traj_file, expected_frames):
-            return {"status": "complete", "cpt_file": None, "restart": False}
-    if _has_restart_pair(cpt_file, tpr_file):
-        return {"status": "partial", "cpt_file": cpt_file, "restart": True}
-    # All trajectory files incomplete and no checkpoint to restart from
-    return {"status": "partial", "cpt_file": None, "restart": False}
-
-
-def _detect_skip_stage_state(
-    sim_dir: Path,
-    spec: "StageSpec",
-    cpt_file: Path,
-    tpr_file: Path,
-) -> _StageState:
-    """Return stage state for 'skip' mode: file-existence only, no integrity checks."""
-    if spec.traj_files:
-        # Mirror auto mode: complete if ANY trajectory file exists (XTC or TRR).
-        if any((sim_dir / tf).exists() for tf in spec.traj_files):
-            return {"status": "complete", "cpt_file": None, "restart": False}
-        if _has_restart_pair(cpt_file, tpr_file):
-            return {"status": "partial", "cpt_file": cpt_file, "restart": True}
-        return {"status": "not_started", "cpt_file": None, "restart": False}
-    return _detect_skip_mode_state(sim_dir / spec.gro_out, cpt_file, tpr_file)
-
-
-def _detect_auto_output_state(
-    sim_dir: Path,
-    stage: str,
-    spec: "StageSpec",
-    cpt_file: Path,
-    tpr_file: Path,
-    prereq_cpt: "Path | None",
-) -> _StageState:
-    """Return stage state for 'auto' mode; validates prerequisite integrity before accepting."""
-    # Workflow integrity: prerequisite checkpoint must exist for the output to
-    # be trustworthy (e.g. npt.gro is only valid if nvt.cpt is present).
-    if prereq_cpt and not prereq_cpt.exists():
-        return {"status": "not_started", "cpt_file": None, "restart": False}
-    if stage == "Production":
-        return _detect_production_output_state(sim_dir, cpt_file, tpr_file, spec.traj_files)
-    return {"status": "complete", "cpt_file": None, "restart": False}
-
-
-def _detect_stage_state(sim_dir: Path, stage: str, mode: str = "auto") -> _StageState:
-    """Detect completion or partial progress of a stage given checkpoint *mode*."""
-    spec = STAGE_BY_NAME[stage]
-    cpt_file = sim_dir / spec.cpt_file
-    tpr_file = sim_dir / spec.tpr_file
-
-    if mode == "skip":
-        return _detect_skip_stage_state(sim_dir, spec, cpt_file, tpr_file)
-
-    # For trajectory stages (Production) any accepted file counts as output.
-    # For structure stages (EM/NVT/NPT) the single gro_out is the output.
-    if spec.traj_files:
-        output_exists = any(
-            (sim_dir / tf).exists() and (sim_dir / tf).stat().st_size > 0 for tf in spec.traj_files
-        )
-    else:
-        gro_out_file = sim_dir / spec.gro_out
-        output_exists = gro_out_file.exists() and gro_out_file.stat().st_size > 0
-
-    # Prerequisite checkpoint (for validating workflow integrity in auto mode)
-    prereq_cpt = sim_dir / spec.prereq_cpt if spec.prereq_cpt else None
-
-    if output_exists:
-        return _detect_auto_output_state(sim_dir, stage, spec, cpt_file, tpr_file, prereq_cpt)
-
-    # Check partial progress (checkpoint exists, output doesn't).
-    if _has_restart_pair(cpt_file, tpr_file):
-        if spec.traj_files:
-            # Trajectory stage (Production): stale checkpoint without a
-            # trajectory file cannot use -append — GROMACS would crash.
-            # Treat as not_started so grompp+mdrun run from scratch.
-            return {"status": "not_started", "cpt_file": None, "restart": False}
-        return {"status": "partial", "cpt_file": cpt_file, "restart": True}
-
-    return {"status": "not_started", "cpt_file": None, "restart": False}
-
-
-def _detect_needed_stages(sim_dir: Path, stages: list[str], mode: str) -> list[str]:
-    """Return stage names that still need to run (discards restart metadata)."""
-    return [
-        item["stage"] for item in _detect_needed_stages_with_restart_info(sim_dir, stages, mode)
-    ]
-
-
-def _detect_needed_stages_with_restart_info(
-    sim_dir: Path, stages: list[str], mode: str
-) -> list[dict]:
-    """Return stage work items ``[{"stage", "restart", "cpt_file"}, ...]`` for incomplete stages."""
-    if mode == "force":
-        return [{"stage": s, "restart": False, "cpt_file": None} for s in stages]
-
-    needed = []
-    for stage in stages:
-        state = _detect_stage_state(sim_dir, stage, mode)
-
-        if state["status"] == "complete":
-            continue  # Skip completed stages
-        elif state["status"] == "partial" and state["restart"]:
-            # Can resume from checkpoint
-            needed.append(
-                {
-                    "stage": stage,
-                    "restart": True,
-                    "cpt_file": state["cpt_file"],
-                }
-            )
-        else:
-            # Not started or can't restart - run from beginning
-            needed.append(
-                {
-                    "stage": stage,
-                    "restart": False,
-                    "cpt_file": None,
-                }
-            )
-
-    return needed
-
-
 def _execute_stage_list(
     sim_dir: Path,
     stages: list[str],
@@ -661,127 +503,6 @@ def _validate_stage_prerequisites(sim_dir: Path, first_stage: str) -> None:
             f"  2. Or force overwrite all:\n"
             f"     mdfactory simulate {sim_dir} --checkpoint force"
         )
-
-
-def _validate_trajectory_complete(
-    sim_dir: Path, traj_file: str, expected_frames: int | None = None
-) -> bool:
-    """Return True if *traj_file* exists, is readable via MDAnalysis, and has enough frames."""
-    traj_path = sim_dir / traj_file
-
-    if not traj_path.exists():
-        return False
-
-    # Quick check: empty file
-    if traj_path.stat().st_size == 0:
-        return False
-
-    # Try to read with MDAnalysis
-    try:
-        if mda is None:
-            raise ImportError("MDAnalysis not available")
-
-        # Find structure file for topology
-        structure_file = find_structure_file(sim_dir)
-        if not structure_file:
-            logger.warning(f"No structure file found in {sim_dir}, skipping frame check")
-            # Cannot validate frames without a topology — treat as incomplete so
-            # the caller can decide (partial restart will regenerate if needed).
-            return False
-
-        # Load trajectory and count frames
-        u = mda.Universe(str(structure_file), str(traj_path))
-        num_frames = len(u.trajectory)
-
-        logger.debug(f"{traj_file}: {num_frames} frames")
-
-        if expected_frames is not None:
-            return num_frames >= expected_frames
-        else:
-            # If no expectation, just check it's readable and non-trivial
-            return num_frames > 0
-
-    except Exception as e:
-        logger.warning(f"Trajectory validation failed for {traj_file}: {e}")
-        # A parse failure means the file is corrupt or truncated — not complete.
-        # Return False so the caller triggers a partial restart rather than
-        # silently skipping the stage on a bad trajectory.
-        return False
-
-
-#: Candidate structure files checked by :func:`find_structure_file` in
-#: priority order (most-equilibrated first), followed by the raw input.
-#: Derived from :data:`~mdfactory.orchestration.stages.STAGE_REGISTRY` at
-#: import time — add a new stage to the registry and this list stays in sync
-#: automatically without any further edits to this module.
-_STRUCTURE_CANDIDATES: list[str] = [
-    spec.gro_out for spec in reversed(STAGE_REGISTRY) if spec.gro_out
-] + ["system.pdb"]
-
-
-def find_structure_file(sim_dir: Path) -> Path | None:
-    """Find the best available structure file in a simulation directory.
-
-    Checks candidates in GROMACS output priority order so that the most
-    equilibrated coordinates are used when available.  This is the canonical
-    priority list shared by trajectory validation (this module) and benchmark
-    pre-processing (:mod:`mdfactory.performance.benchmark`).
-
-    The candidate list is derived from
-    :data:`~mdfactory.orchestration.stages.STAGE_REGISTRY` at import time
-    (see :data:`_STRUCTURE_CANDIDATES`), so adding a new stage with a
-    ``gro_out`` field automatically extends the search without modifying this
-    function.
-
-    Parameters
-    ----------
-    sim_dir : Path
-        Simulation directory.
-
-    Returns
-    -------
-    Path or None
-        Path to the first existing structure file, or ``None`` if none of the
-        candidates are found.
-
-    Notes
-    -----
-    Priority order (highest to lowest):
-
-    1. Most-recently-added stage's ``.gro`` (most equilibrated)
-    2. …earlier stages in reverse registry order…
-    3. ``system.pdb`` — raw starting structure
-
-    """
-    for candidate in _STRUCTURE_CANDIDATES:
-        path = sim_dir / candidate
-        if path.exists():
-            return path
-    return None
-
-
-def _extract_expected_frames_from_mdp(sim_dir: Path, stage: str) -> int | None:
-    """Extract expected frame count from MDP file (nsteps / output_frequency)."""
-    from .mdp import get_mdp_value, parse_mdp
-
-    mdp_path = sim_dir / STAGE_BY_NAME.get(stage, STAGE_BY_NAME["Production"]).mdp_file
-    if not mdp_path.exists():
-        return None
-    try:
-        parsed = parse_mdp(mdp_path)
-        nsteps_val = get_mdp_value(parsed, "nsteps")
-        # XTC frequency preferred; fall back to TRR
-        nstxout_val = get_mdp_value(parsed, "nstxout_compressed") or get_mdp_value(
-            parsed, "nstxout"
-        )
-        if nsteps_val and nstxout_val:
-            nsteps = int(nsteps_val)
-            nstxout = int(nstxout_val)
-            if nstxout > 0:
-                return nsteps // nstxout
-    except Exception as e:
-        logger.debug(f"Could not parse MDP file: {e}")
-    return None
 
 
 def _log_dry_run_plan(work_plan: list[dict], config: "ExecutorConfig") -> list[dict]:

--- a/mdfactory/orchestration/simulate.py
+++ b/mdfactory/orchestration/simulate.py
@@ -38,7 +38,6 @@ def run_simulations(
     config: "ExecutorConfig",
     *,
     stages: list[str] | None = None,
-    wait: bool = True,
     dry_run: bool = False,
     clean: bool = False,
     checkpoint_mode: str = "auto",
@@ -54,8 +53,6 @@ def run_simulations(
         Parsl executor configuration (local or SLURM).
     stages : list[str], optional
         Stages to run. Default: ["EM", "NVT", "NPT", "Production"].
-    wait : bool
-        Wait for completion (default: True).
     dry_run : bool
         Preview plan without executing (default: False).
     clean : bool
@@ -75,7 +72,7 @@ def run_simulations(
     Returns
     -------
     list[dict]
-        Results with status, errors, timing (or futures if wait=False).
+        Results with status, errors, and timing per simulation.
 
     """
     valid_stages = [s.name for s in STAGE_REGISTRY]
@@ -181,55 +178,15 @@ def run_simulations(
         logger.info("All simulations already complete.")
         return skipped_results
 
-    # 6. Parsl session
-    with parsl_session(config) as session:
+    # 6. Parsl session: tracked execution with per-stage progress display
+    import threading
+
+    from .errors import _describe_failure
+    from .progress import StageProgressTracker, display_stage_progress
+
+    with parsl_session(config):
         grompp_app = get_grompp_app()
         mdrun_app = get_mdrun_app()
-
-        # wait=False: legacy path returning raw futures (no progress display)
-        if not wait:
-            from concurrent.futures import Future as StdFuture
-            from concurrent.futures import ThreadPoolExecutor
-
-            futures: list[tuple[str, object]] = []
-
-            def _run_pipeline_nowait(item):
-                return _execute_stage_list(
-                    item["sim_dir"],
-                    item["stages"],
-                    grompp_app,
-                    mdrun_app,
-                    stage_restarts=item.get("stage_restarts"),
-                    config=config,
-                    max_rescue=max_rescue,
-                )
-
-            with ThreadPoolExecutor() as pool:
-                thread_futs = [
-                    (item["hash"], pool.submit(_run_pipeline_nowait, item)) for item in active_items
-                ]
-                for h, tf in thread_futs:
-                    try:
-                        futures.append((h, tf.result()))
-                    except Exception as exc:
-                        logger.error(f"Pipeline failed for {h}: {exc}")
-                        failed_fut = StdFuture()
-                        failed_fut.set_exception(exc)
-                        futures.append((h, failed_fut))
-
-            logger.info(f"Submitted {len(futures)} simulation(s)")
-            logger.warning(
-                "Returning raw AppFuture objects — futures resolve to None (bash_app exit), "
-                "not status dicts.  Caller must call parsl.clear() when done."
-            )
-            session.detach()
-            return [fut for _, fut in futures]
-
-        # 7. wait=True: tracked execution with per-stage progress display
-        import threading
-
-        from .errors import _describe_failure
-        from .progress import StageProgressTracker, display_stage_progress
 
         all_hashes = [item["hash"] for item in active_items]
         tracker = StageProgressTracker(stages=stages, sim_hashes=all_hashes)

--- a/mdfactory/orchestration/trajectory.py
+++ b/mdfactory/orchestration/trajectory.py
@@ -1,0 +1,143 @@
+# ABOUTME: Trajectory validation and structure file discovery for GROMACS simulations
+# ABOUTME: Checks frame counts via MDAnalysis and locates best-available structure files
+"""Trajectory validation and structure file discovery.
+
+Provides :func:`find_structure_file` (shared utility for locating the best
+available structure file) and trajectory completeness checking used by the
+checkpoint detection layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from .stages import STAGE_BY_NAME, STAGE_REGISTRY
+
+# Import MDAnalysis at module level for testability
+try:
+    import MDAnalysis as mda
+except ImportError:
+    mda = None
+
+
+#: Candidate structure files checked by :func:`find_structure_file` in
+#: priority order (most-equilibrated first), followed by the raw input.
+#: Derived from :data:`~mdfactory.orchestration.stages.STAGE_REGISTRY` at
+#: import time — add a new stage to the registry and this list stays in sync
+#: automatically without any further edits to this module.
+_STRUCTURE_CANDIDATES: list[str] = [
+    spec.gro_out for spec in reversed(STAGE_REGISTRY) if spec.gro_out
+] + ["system.pdb"]
+
+
+def find_structure_file(sim_dir: Path) -> Path | None:
+    """Find the best available structure file in a simulation directory.
+
+    Checks candidates in GROMACS output priority order so that the most
+    equilibrated coordinates are used when available.  This is the canonical
+    priority list shared by trajectory validation (this module) and benchmark
+    pre-processing (:mod:`mdfactory.performance.benchmark`).
+
+    The candidate list is derived from
+    :data:`~mdfactory.orchestration.stages.STAGE_REGISTRY` at import time
+    (see :data:`_STRUCTURE_CANDIDATES`), so adding a new stage with a
+    ``gro_out`` field automatically extends the search without modifying this
+    function.
+
+    Parameters
+    ----------
+    sim_dir : Path
+        Simulation directory.
+
+    Returns
+    -------
+    Path or None
+        Path to the first existing structure file, or ``None`` if none of the
+        candidates are found.
+
+    Notes
+    -----
+    Priority order (highest to lowest):
+
+    1. Most-recently-added stage's ``.gro`` (most equilibrated)
+    2. …earlier stages in reverse registry order…
+    3. ``system.pdb`` — raw starting structure
+
+    """
+    for candidate in _STRUCTURE_CANDIDATES:
+        path = sim_dir / candidate
+        if path.exists():
+            return path
+    return None
+
+
+def _validate_trajectory_complete(
+    sim_dir: Path, traj_file: str, expected_frames: int | None = None
+) -> bool:
+    """Return True if *traj_file* exists, is readable via MDAnalysis, and has enough frames."""
+    traj_path = sim_dir / traj_file
+
+    if not traj_path.exists():
+        return False
+
+    # Quick check: empty file
+    if traj_path.stat().st_size == 0:
+        return False
+
+    # Try to read with MDAnalysis
+    try:
+        if mda is None:
+            raise ImportError("MDAnalysis not available")
+
+        # Find structure file for topology
+        structure_file = find_structure_file(sim_dir)
+        if not structure_file:
+            logger.warning(f"No structure file found in {sim_dir}, skipping frame check")
+            # Cannot validate frames without a topology — treat as incomplete so
+            # the caller can decide (partial restart will regenerate if needed).
+            return False
+
+        # Load trajectory and count frames
+        u = mda.Universe(str(structure_file), str(traj_path))
+        num_frames = len(u.trajectory)
+
+        logger.debug(f"{traj_file}: {num_frames} frames")
+
+        if expected_frames is not None:
+            return num_frames >= expected_frames
+        else:
+            # If no expectation, just check it's readable and non-trivial
+            return num_frames > 0
+
+    except Exception as e:
+        logger.warning(f"Trajectory validation failed for {traj_file}: {e}")
+        # A parse failure means the file is corrupt or truncated — not complete.
+        # Return False so the caller triggers a partial restart rather than
+        # silently skipping the stage on a bad trajectory.
+        return False
+
+
+def _extract_expected_frames_from_mdp(sim_dir: Path, stage: str) -> int | None:
+    """Extract expected frame count from MDP file (nsteps / output_frequency)."""
+    from .mdp import get_mdp_value, parse_mdp
+
+    mdp_path = sim_dir / STAGE_BY_NAME.get(stage, STAGE_BY_NAME["Production"]).mdp_file
+    if not mdp_path.exists():
+        return None
+    try:
+        parsed = parse_mdp(mdp_path)
+        nsteps_val = get_mdp_value(parsed, "nsteps")
+        # XTC frequency preferred; fall back to TRR
+        nstxout_val = get_mdp_value(parsed, "nstxout_compressed") or get_mdp_value(
+            parsed, "nstxout"
+        )
+        if nsteps_val and nstxout_val:
+            nsteps = int(nsteps_val)
+            nstxout = int(nstxout_val)
+            if nstxout > 0:
+                return nsteps // nstxout
+    except Exception as e:
+        logger.debug(f"Could not parse MDP file: {e}")
+    return None

--- a/mdfactory/orchestration/trajectory.py
+++ b/mdfactory/orchestration/trajectory.py
@@ -82,41 +82,34 @@ def _validate_trajectory_complete(
     if not traj_path.exists():
         return False
 
-    # Quick check: empty file
     if traj_path.stat().st_size == 0:
         return False
 
-    # Try to read with MDAnalysis
+    if mda is None:
+        logger.warning(f"Trajectory validation skipped for {traj_file}: MDAnalysis not available")
+        return False
+
+    structure_file = find_structure_file(sim_dir)
+    if not structure_file:
+        # Cannot validate frames without a topology — treat as incomplete so
+        # the caller can decide (partial restart will regenerate if needed).
+        logger.warning(f"No structure file found in {sim_dir}, skipping frame check")
+        return False
+
     try:
-        if mda is None:
-            raise ImportError("MDAnalysis not available")
-
-        # Find structure file for topology
-        structure_file = find_structure_file(sim_dir)
-        if not structure_file:
-            logger.warning(f"No structure file found in {sim_dir}, skipping frame check")
-            # Cannot validate frames without a topology — treat as incomplete so
-            # the caller can decide (partial restart will regenerate if needed).
-            return False
-
-        # Load trajectory and count frames
         u = mda.Universe(str(structure_file), str(traj_path))
         num_frames = len(u.trajectory)
-
-        logger.debug(f"{traj_file}: {num_frames} frames")
-
-        if expected_frames is not None:
-            return num_frames >= expected_frames
-        else:
-            # If no expectation, just check it's readable and non-trivial
-            return num_frames > 0
-
     except Exception as e:
+        # Corrupt or truncated trajectory — trigger partial restart rather than
+        # silently skipping the stage.
         logger.warning(f"Trajectory validation failed for {traj_file}: {e}")
-        # A parse failure means the file is corrupt or truncated — not complete.
-        # Return False so the caller triggers a partial restart rather than
-        # silently skipping the stage on a bad trajectory.
         return False
+
+    logger.debug(f"{traj_file}: {num_frames} frames")
+
+    if expected_frames is not None:
+        return num_frames >= expected_frames
+    return num_frames > 0
 
 
 def _extract_expected_frames_from_mdp(sim_dir: Path, stage: str) -> int | None:

--- a/mdfactory/orchestration/trajectory.py
+++ b/mdfactory/orchestration/trajectory.py
@@ -79,10 +79,7 @@ def _validate_trajectory_complete(
     """Return True if *traj_file* exists, is readable via MDAnalysis, and has enough frames."""
     traj_path = sim_dir / traj_file
 
-    if not traj_path.exists():
-        return False
-
-    if traj_path.stat().st_size == 0:
+    if not traj_path.exists() or traj_path.stat().st_size == 0:
         return False
 
     if mda is None:

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -319,41 +319,6 @@ def test_stage_order_preservation(mock_sim_dir):
     assert needed == ["Production", "NPT", "EM", "NVT"]
 
 
-@patch("mdfactory.orchestration.simulate.parsl_session")
-@patch("mdfactory.orchestration.simulate._execute_stage_list")
-def test_wait_false_returns_futures(mock_execute, mock_session, mock_sim_dir):
-    """When wait=False, returns raw futures."""
-    mock_future = MagicMock()
-    mock_execute.return_value = mock_future
-
-    mock_session_obj = MagicMock()
-    mock_session.return_value.__enter__.return_value = mock_session_obj
-
-    results = run_simulations([mock_sim_dir], ExecutorConfig(), wait=False)
-
-    # Should return futures, not results
-    assert results == [mock_future]
-    # Session should be detached
-    mock_session_obj.detach.assert_called_once()
-
-
-@patch("mdfactory.orchestration.simulate.parsl_session")
-@patch("mdfactory.orchestration.simulate._execute_stage_list")
-def test_wait_false_emits_warning(mock_execute, mock_session, mock_sim_dir):
-    """wait=False logs a warning that raw futures resolve to None, not dicts."""
-    mock_execute.return_value = MagicMock()
-    mock_session.return_value.__enter__.return_value = MagicMock()
-
-    with patch("mdfactory.orchestration.simulate.logger") as mock_logger:
-        run_simulations([mock_sim_dir], ExecutorConfig(), wait=False)
-
-    # Warning must be emitted and mention the None / parsl.clear() contract
-    mock_logger.warning.assert_called()
-    warning_text = " ".join(str(a) for call in mock_logger.warning.call_args_list for a in call[0])
-    assert "None" in warning_text or "raw" in warning_text
-    assert "parsl.clear()" in warning_text
-
-
 def test_empty_sim_list():
     """Handle empty simulation list gracefully."""
     results = run_simulations([], ExecutorConfig(), dry_run=True)
@@ -1564,9 +1529,12 @@ def test_detect_needed_stages_with_restart_info_partial(tmp_path):
     assert items[0]["cpt_file"] == sim_dir / "nvt.cpt"
 
 
+@patch("mdfactory.orchestration.progress.display_stage_progress")
 @patch("mdfactory.orchestration.simulate.parsl_session")
 @patch("mdfactory.orchestration.simulate._execute_stage_list")
-def test_run_simulations_propagates_stage_restarts(mock_execute, mock_session, tmp_path):
+def test_run_simulations_propagates_stage_restarts(
+    mock_execute, mock_session, mock_display, tmp_path
+):
     """stage_restarts dict assembled from checkpoint detection is passed to _execute_stage_list."""
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -1584,7 +1552,7 @@ def test_run_simulations_propagates_stage_restarts(mock_execute, mock_session, t
 
     from mdfactory.orchestration.config import ExecutorConfig
 
-    run_simulations([sim_dir], ExecutorConfig(), wait=False)
+    run_simulations([sim_dir], ExecutorConfig())
 
     # _execute_stage_list must be called; assert stage_restarts contains NVT entry
     assert mock_execute.called

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -17,8 +17,8 @@ from mdfactory.orchestration.apps import (
     _resolve_thread_count_expr,
     _resolve_thread_flags,
 )
-from mdfactory.orchestration.config import ExecutorConfig
 from mdfactory.orchestration.checkpoint import _detect_needed_stages
+from mdfactory.orchestration.config import ExecutorConfig
 from mdfactory.orchestration.execution import _execute_stage_list, _validate_stage_prerequisites
 from mdfactory.orchestration.simulate import (
     _log_dry_run_plan,
@@ -291,7 +291,9 @@ def test_multiple_simulations_mixed_states(tmp_path):
     (sim3 / "prod.xtc").write_text("FAKE")  # Trajectory present
 
     # Mock trajectory validation so fake XTC counts as complete
-    with patch("mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True):
+    with patch(
+        "mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True
+    ):
         results = run_simulations([sim1, sim2, sim3], ExecutorConfig(), dry_run=True)
 
     assert len(results) == 3
@@ -1041,8 +1043,8 @@ def test_find_structure_file_returns_none_if_missing(tmp_path):
 
 def test_find_structure_file_candidates_derived_from_registry():
     """_STRUCTURE_CANDIDATES matches the current STAGE_REGISTRY gro_out fields."""
-    from mdfactory.orchestration.trajectory import _STRUCTURE_CANDIDATES
     from mdfactory.orchestration.stages import STAGE_REGISTRY
+    from mdfactory.orchestration.trajectory import _STRUCTURE_CANDIDATES
 
     expected = [spec.gro_out for spec in reversed(STAGE_REGISTRY) if spec.gro_out] + ["system.pdb"]
     assert _STRUCTURE_CANDIDATES == expected

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -19,11 +19,10 @@ from mdfactory.orchestration.apps import (
 )
 from mdfactory.orchestration.config import ExecutorConfig
 from mdfactory.orchestration.checkpoint import _detect_needed_stages
+from mdfactory.orchestration.execution import _execute_stage_list, _validate_stage_prerequisites
 from mdfactory.orchestration.simulate import (
-    _execute_stage_list,
     _log_dry_run_plan,
     _missing_build_files,
-    _validate_stage_prerequisites,
     run_simulations,
 )
 from mdfactory.orchestration.trajectory import _validate_trajectory_complete
@@ -681,7 +680,7 @@ def test_execute_stage_list_validates_unknown_stage():
         _execute_stage_list(Path("/tmp/test"), ["Equilibration"], None, None, max_rescue=0)
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_em_only(mock_run_stage):
     """Execute stage list dispatches EM via run_stage with correct spec and no prev_future."""
     mock_future = MagicMock()
@@ -696,7 +695,7 @@ def test_execute_stage_list_em_only(mock_run_stage):
     assert result == mock_future
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_em_nvt_chain(mock_run_stage):
     """Execute stage list chains EM → NVT: NVT receives EM's future as prev_future."""
     em_future = MagicMock()
@@ -720,7 +719,7 @@ def test_execute_stage_list_em_nvt_chain(mock_run_stage):
     assert result == nvt_future
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_full_pipeline(mock_run_stage):
     """Execute stage list chains all 4 stages via run_stage with correct futures."""
     stage_futures = [MagicMock() for _ in range(4)]
@@ -748,7 +747,7 @@ def test_execute_stage_list_full_pipeline(mock_run_stage):
     assert result is stage_futures[3]
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_partial_pipeline_from_checkpoint(mock_run_stage):
     """Checkpoint resume: first stage is not EM; prev_future starts as None."""
     nvt_fut = MagicMock()
@@ -770,7 +769,7 @@ def test_execute_stage_list_partial_pipeline_from_checkpoint(mock_run_stage):
 
 
 @patch("mdfactory.orchestration.rescue.execute_stage_with_rescue")
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_routes_to_rescue_when_enabled(mock_run_stage, mock_rescue):
     """Rescue-eligible stages dispatch to execute_stage_with_rescue when max_rescue > 0."""
     rescue_future = MagicMock()
@@ -785,7 +784,7 @@ def test_execute_stage_list_routes_to_rescue_when_enabled(mock_run_stage, mock_r
 
 
 @patch("mdfactory.orchestration.rescue.execute_stage_with_rescue")
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_production_bypasses_rescue(mock_run_stage, mock_rescue):
     """Production stage uses run_stage even when max_rescue > 0."""
     prod_future = MagicMock()
@@ -1241,7 +1240,7 @@ def test_get_gromacs_detect_script_prefers_gmx_over_gmx_mpi():
 # === Decision 7: Restart wiring through stage functions and execute_stage_list ===
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_passes_restart_to_stage_fn(mock_run_stage):
     """_execute_stage_list forwards stage_restarts to run_stage as restart_from_cpt."""
     mock_run_stage.return_value = MagicMock()
@@ -1260,7 +1259,7 @@ def test_execute_stage_list_passes_restart_to_stage_fn(mock_run_stage):
     assert call_kwargs.get("restart_from_cpt") == "/sim/nvt.cpt"
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_restart_only_for_matching_stage(mock_run_stage):
     """Only the stage with a cpt entry gets a non-empty restart_from_cpt."""
     nvt_fut = MagicMock()
@@ -1355,7 +1354,7 @@ def test_production_stage_skips_grompp_on_restart():
 # === Decision 6: Per-stage resource config wiring tests ===
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_passes_stage_config_when_slurm(mock_run_stage):
     """_execute_stage_list resolves per-stage config and forwards as stage_config to run_stage."""
     from mdfactory.orchestration.config import SlurmExecutorConfig
@@ -1378,7 +1377,7 @@ def test_execute_stage_list_passes_stage_config_when_slurm(mock_run_stage):
     assert em_cfg.cpus_per_node == 4
 
 
-@patch("mdfactory.orchestration.simulate.run_stage")
+@patch("mdfactory.orchestration.execution.run_stage")
 def test_execute_stage_list_no_stage_config_for_local(mock_run_stage):
     """_execute_stage_list does not inject stage_config for LocalProvider (no overrides)."""
     from mdfactory.orchestration.config import ExecutorConfig

--- a/mdfactory/tests/test_orchestration_simulate.py
+++ b/mdfactory/tests/test_orchestration_simulate.py
@@ -18,15 +18,15 @@ from mdfactory.orchestration.apps import (
     _resolve_thread_flags,
 )
 from mdfactory.orchestration.config import ExecutorConfig
+from mdfactory.orchestration.checkpoint import _detect_needed_stages
 from mdfactory.orchestration.simulate import (
-    _detect_needed_stages,
     _execute_stage_list,
     _log_dry_run_plan,
     _missing_build_files,
     _validate_stage_prerequisites,
-    _validate_trajectory_complete,
     run_simulations,
 )
+from mdfactory.orchestration.trajectory import _validate_trajectory_complete
 
 
 @pytest.fixture
@@ -153,7 +153,7 @@ def test_checkpoint_force_never_skips(mock_sim_dir):
     assert "EM" in needed
 
 
-@patch("mdfactory.orchestration.simulate._validate_trajectory_complete", return_value=True)
+@patch("mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True)
 def test_checkpoint_all_stages_complete(mock_validate, mock_sim_dir):
     """All stages skipped when outputs AND prerequisite checkpoints exist."""
     (mock_sim_dir / "min.gro").write_text("FAKE")
@@ -292,7 +292,7 @@ def test_multiple_simulations_mixed_states(tmp_path):
     (sim3 / "prod.xtc").write_text("FAKE")  # Trajectory present
 
     # Mock trajectory validation so fake XTC counts as complete
-    with patch("mdfactory.orchestration.simulate._validate_trajectory_complete", return_value=True):
+    with patch("mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True):
         results = run_simulations([sim1, sim2, sim3], ExecutorConfig(), dry_run=True)
 
     assert len(results) == 3
@@ -301,7 +301,7 @@ def test_multiple_simulations_mixed_states(tmp_path):
     assert results[2]["stages"] == []
 
 
-@patch("mdfactory.orchestration.simulate._validate_trajectory_complete", return_value=True)
+@patch("mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True)
 def test_checkpoint_production_output(mock_validate, mock_sim_dir):
     """Production stage skipped when prod.xtc is validated as complete."""
     (mock_sim_dir / "min.gro").write_text("FAKE")
@@ -403,7 +403,7 @@ def test_checkpoint_production_requires_npt_cpt(mock_sim_dir):
     assert "Production" in needed
 
 
-@patch("mdfactory.orchestration.simulate._validate_trajectory_complete", return_value=True)
+@patch("mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True)
 def test_checkpoint_production_skips_with_all_files(mock_validate, mock_sim_dir):
     """Production skipped when both prod.xtc AND npt.cpt exist (trajectory validated)."""
     (mock_sim_dir / "npt.cpt").write_text("FAKE CPT")
@@ -414,7 +414,7 @@ def test_checkpoint_production_skips_with_all_files(mock_validate, mock_sim_dir)
     assert "Production" not in needed
 
 
-@patch("mdfactory.orchestration.simulate._validate_trajectory_complete", return_value=True)
+@patch("mdfactory.orchestration.checkpoint._validate_trajectory_complete", return_value=True)
 def test_checkpoint_production_complete_with_trr_only(mock_validate, mock_sim_dir):
     """Production marked complete when only prod.trr exists (TRR-only MDP config)."""
     (mock_sim_dir / "npt.cpt").write_text("FAKE CPT")
@@ -989,7 +989,7 @@ def test_validate_trajectory_returns_false_for_non_parseable_file(mock_sim_dir):
     assert result is False
 
 
-@patch("mdfactory.orchestration.simulate.mda")
+@patch("mdfactory.orchestration.trajectory.mda")
 def test_validate_trajectory_with_mdanalysis_complete(mock_mda, mock_sim_dir):
     """Trajectory validation uses MDAnalysis to count frames (complete)."""
 
@@ -1009,7 +1009,7 @@ def test_validate_trajectory_with_mdanalysis_complete(mock_mda, mock_sim_dir):
     assert result is True
 
 
-@patch("mdfactory.orchestration.simulate.mda")
+@patch("mdfactory.orchestration.trajectory.mda")
 def test_validate_trajectory_with_mdanalysis_incomplete(mock_mda, mock_sim_dir):
     """Trajectory validation detects incomplete trajectories."""
 
@@ -1029,7 +1029,7 @@ def test_validate_trajectory_with_mdanalysis_incomplete(mock_mda, mock_sim_dir):
     assert result is False
 
 
-@patch("mdfactory.orchestration.simulate.mda")
+@patch("mdfactory.orchestration.trajectory.mda")
 def test_validate_trajectory_without_expected_frames(mock_mda, mock_sim_dir):
     """Trajectory validation without expected_frames checks readability only."""
 
@@ -1051,7 +1051,7 @@ def test_validate_trajectory_without_expected_frames(mock_mda, mock_sim_dir):
 
 def test_find_structure_file_priority_order(mock_sim_dir):
     """Find structure file uses correct priority order."""
-    from mdfactory.orchestration.simulate import find_structure_file
+    from mdfactory.orchestration.trajectory import find_structure_file
 
     # Create files in reverse priority order
     (mock_sim_dir / "system.pdb").write_text("FAKE")
@@ -1065,7 +1065,7 @@ def test_find_structure_file_priority_order(mock_sim_dir):
 
 def test_find_structure_file_returns_none_if_missing(tmp_path):
     """Find structure file returns None if no candidates exist."""
-    from mdfactory.orchestration.simulate import find_structure_file
+    from mdfactory.orchestration.trajectory import find_structure_file
 
     # Create empty directory with no structure files
     empty_dir = tmp_path / "empty"
@@ -1077,7 +1077,7 @@ def test_find_structure_file_returns_none_if_missing(tmp_path):
 
 def test_find_structure_file_candidates_derived_from_registry():
     """_STRUCTURE_CANDIDATES matches the current STAGE_REGISTRY gro_out fields."""
-    from mdfactory.orchestration.simulate import _STRUCTURE_CANDIDATES
+    from mdfactory.orchestration.trajectory import _STRUCTURE_CANDIDATES
     from mdfactory.orchestration.stages import STAGE_REGISTRY
 
     expected = [spec.gro_out for spec in reversed(STAGE_REGISTRY) if spec.gro_out] + ["system.pdb"]
@@ -1086,12 +1086,12 @@ def test_find_structure_file_candidates_derived_from_registry():
 
 def test_find_structure_file_picks_up_new_stage_gro(tmp_path, monkeypatch):
     """find_structure_file returns a new stage's .gro when _STRUCTURE_CANDIDATES is extended."""
-    import mdfactory.orchestration.simulate as sim_module
-    from mdfactory.orchestration.simulate import find_structure_file
+    import mdfactory.orchestration.trajectory as traj_module
+    from mdfactory.orchestration.trajectory import find_structure_file
 
     # Simulate a hypothetical future 'Heating' stage by patching the candidate list.
-    extended = ["heat.gro"] + sim_module._STRUCTURE_CANDIDATES
-    monkeypatch.setattr(sim_module, "_STRUCTURE_CANDIDATES", extended)
+    extended = ["heat.gro"] + traj_module._STRUCTURE_CANDIDATES
+    monkeypatch.setattr(traj_module, "_STRUCTURE_CANDIDATES", extended)
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -1103,7 +1103,7 @@ def test_find_structure_file_picks_up_new_stage_gro(tmp_path, monkeypatch):
 
 def test_extract_expected_frames_from_mdp(mock_sim_dir):
     """Extract expected frames from MDP file."""
-    from mdfactory.orchestration.simulate import _extract_expected_frames_from_mdp
+    from mdfactory.orchestration.trajectory import _extract_expected_frames_from_mdp
 
     # Create MDP with nsteps and nstxout-compressed
     mdp_content = """
@@ -1122,7 +1122,7 @@ def test_extract_expected_frames_from_mdp(mock_sim_dir):
 
 def test_extract_expected_frames_handles_comments(mock_sim_dir):
     """MDP parser ignores comments correctly."""
-    from mdfactory.orchestration.simulate import _extract_expected_frames_from_mdp
+    from mdfactory.orchestration.trajectory import _extract_expected_frames_from_mdp
 
     mdp_content = """
     ; nsteps = 999999  ; This is a comment
@@ -1140,7 +1140,7 @@ def test_extract_expected_frames_handles_comments(mock_sim_dir):
 
 def test_extract_expected_frames_returns_none_for_missing_file(mock_sim_dir):
     """MDP parser returns None if file doesn't exist."""
-    from mdfactory.orchestration.simulate import _extract_expected_frames_from_mdp
+    from mdfactory.orchestration.trajectory import _extract_expected_frames_from_mdp
 
     result = _extract_expected_frames_from_mdp(mock_sim_dir, "Production")
     assert result is None
@@ -1148,7 +1148,7 @@ def test_extract_expected_frames_returns_none_for_missing_file(mock_sim_dir):
 
 def test_extract_expected_frames_returns_none_for_incomplete_mdp(mock_sim_dir):
     """MDP parser returns None if required parameters missing."""
-    from mdfactory.orchestration.simulate import _extract_expected_frames_from_mdp
+    from mdfactory.orchestration.trajectory import _extract_expected_frames_from_mdp
 
     # Only nsteps, no nstxout-compressed
     (mock_sim_dir / "md.mdp").write_text("nsteps = 100000\n")
@@ -1503,7 +1503,7 @@ def test_mdrun_app_cpt_log_message_mentions_file():
 
 def test_detect_stage_state_partial_restart_nvt(tmp_path):
     """Partial NVT: .cpt + .tpr present, .gro absent → status=partial, restart=True."""
-    from mdfactory.orchestration.simulate import _detect_stage_state
+    from mdfactory.orchestration.checkpoint import _detect_stage_state
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -1520,7 +1520,7 @@ def test_detect_stage_state_partial_restart_nvt(tmp_path):
 
 def test_detect_stage_state_partial_restart_em(tmp_path):
     """Partial EM: min.cpt + min.tpr present, min.gro absent → status=partial."""
-    from mdfactory.orchestration.simulate import _detect_stage_state
+    from mdfactory.orchestration.checkpoint import _detect_stage_state
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -1536,7 +1536,7 @@ def test_detect_stage_state_partial_restart_em(tmp_path):
 
 def test_detect_stage_state_not_started_when_no_files(tmp_path):
     """Empty directory → status=not_started, restart=False."""
-    from mdfactory.orchestration.simulate import _detect_stage_state
+    from mdfactory.orchestration.checkpoint import _detect_stage_state
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -1550,7 +1550,7 @@ def test_detect_stage_state_not_started_when_no_files(tmp_path):
 
 def test_detect_needed_stages_with_restart_info_partial(tmp_path):
     """Restart info propagated into the work-plan when partial progress exists."""
-    from mdfactory.orchestration.simulate import _detect_needed_stages_with_restart_info
+    from mdfactory.orchestration.checkpoint import _detect_needed_stages_with_restart_info
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -2018,7 +2018,7 @@ def test_clean_simulation_outputs_dry_run(tmp_path):
 
 def test_detect_stage_state_trajectory_stale_cpt(tmp_path):
     """Production with cpt+tpr but no trajectory → not_started (stale-cpt fix)."""
-    from mdfactory.orchestration.simulate import _detect_stage_state
+    from mdfactory.orchestration.checkpoint import _detect_stage_state
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()
@@ -2035,7 +2035,7 @@ def test_detect_stage_state_trajectory_stale_cpt(tmp_path):
 
 def test_detect_stage_state_structure_partial_cpt_unchanged(tmp_path):
     """EM with cpt+tpr but no gro → still partial (structure stages unchanged)."""
-    from mdfactory.orchestration.simulate import _detect_stage_state
+    from mdfactory.orchestration.checkpoint import _detect_stage_state
 
     sim_dir = tmp_path / "sim"
     sim_dir.mkdir()


### PR DESCRIPTION
Closes #48

Split `simulate.py` (871 lines, 6 concerns) into focused modules following SRP: extract checkpoint detection into `checkpoint.py` and trajectory validation + structure file discovery into `trajectory.py`.

Implementation plan posted as a comment below.
