### PR TITLE
refactor: remove unused wait=False path from build_systems

### DIFF
--- a/mdfactory/orchestration/build.py
+++ b/mdfactory/orchestration/build.py
@@ -37,7 +37,6 @@ def build_systems(
     config: "ExecutorConfig",
     *,
     output_dir: Path | None = None,
-    wait: bool = True,
     dry_run: bool = False,
 ) -> list:
     """Submit parallel builds via Parsl (or preview with dry_run).
@@ -50,10 +49,6 @@ def build_systems(
         Executor configuration for Parsl.
     output_dir : Path, optional
         Base output directory for builds. Defaults to current directory.
-    wait : bool, optional
-        Whether to wait for all futures to complete. Default True.
-        If False, returns raw AppFutures and the caller is responsible
-        for calling ``parsl.clear()`` after all futures complete.
     dry_run : bool, optional
         If True, log what would be built and return descriptions without
         loading Parsl or submitting any work. Default False.
@@ -62,8 +57,7 @@ def build_systems(
     -------
     list
         If dry_run=True, list of description dicts.
-        If wait=True, list of result dicts.
-        If wait=False, list of AppFutures.
+        Otherwise, list of result dicts.
 
     """
     output_dir = Path(output_dir) if output_dir else Path.cwd()
@@ -104,7 +98,7 @@ def build_systems(
 
     # parsl_session owns the full DFK lifecycle: guard, load, and shutdown
     # (including scancel of lingering SLURM jobs) on exit.
-    with parsl_session(config) as session:
+    with parsl_session(config):
         build_app = get_build_app()
 
         # Submit all builds
@@ -115,11 +109,6 @@ def build_systems(
             futures.append(build_app(input_dict))
 
         logger.info(f"Submitted {len(futures)} build(s) to Parsl")
-
-        if not wait:
-            logger.warning("Returning raw futures — caller must call parsl.clear() when done.")
-            session.detach()
-            return futures
 
         # Poll futures with live status reporting
         return _wait_with_progress(futures, hashes=input_hashes, label="Parsl Builds")

--- a/mdfactory/orchestration/session.py
+++ b/mdfactory/orchestration/session.py
@@ -34,23 +34,10 @@ class ParslSession:
     ----------
     parsl : module
         The imported ``parsl`` module, for submitting apps or inspecting the DFK.
-    detached : bool
-        When ``True``, the context manager will **not** shut down the DFK on
-        exit; the caller takes ownership of cleanup. Set via :meth:`detach`.
 
     """
 
     parsl: object
-    detached: bool = False
-
-    def detach(self) -> None:
-        """Transfer DFK ownership to the caller (skip shutdown on exit).
-
-        Used when returning raw futures (e.g. ``wait=False``): the caller is
-        then responsible for calling ``parsl.clear()`` once all futures
-        complete.
-        """
-        self.detached = True
 
 
 @contextmanager
@@ -58,8 +45,7 @@ def parsl_session(config: "ExecutorConfig") -> Iterator[ParslSession]:
     """Manage a Parsl ``DataFlowKernel`` lifecycle for an orchestration run.
 
     Guards against an already-active DFK, loads ``config``'s Parsl config,
-    yields a :class:`ParslSession`, and guarantees shutdown on exit unless the
-    session was detached via :meth:`ParslSession.detach`.
+    yields a :class:`ParslSession`, and guarantees shutdown on exit.
 
     Sessions must be **sequential, never nested**.  :func:`_guard_no_active_dfk`
     raises :class:`RuntimeError` if a DFK is already loaded when this context
@@ -81,8 +67,7 @@ def parsl_session(config: "ExecutorConfig") -> Iterator[ParslSession]:
     Yields
     ------
     ParslSession
-        Session handle exposing the ``parsl`` module and a ``detach()`` escape
-        hatch.
+        Session handle exposing the ``parsl`` module.
 
     Raises
     ------
@@ -103,8 +88,7 @@ def parsl_session(config: "ExecutorConfig") -> Iterator[ParslSession]:
     try:
         yield session
     finally:
-        if not session.detached:
-            _shutdown_parsl()
+        _shutdown_parsl()
 
 
 def _guard_no_active_dfk(parsl) -> None:

--- a/mdfactory/tests/test_orchestration_build.py
+++ b/mdfactory/tests/test_orchestration_build.py
@@ -131,29 +131,6 @@ def test_build_systems_handles_failed_future(monkeypatch, tmp_path):
     assert results[0]["error_detail"] == "CUDA OOM"
 
 
-def test_build_systems_no_wait(monkeypatch, tmp_path):
-    """build_systems with wait=False returns futures directly."""
-    import parsl
-
-    mock_app_fn = MagicMock()
-    mock_future = MagicMock()
-    mock_app_fn.return_value = mock_future
-
-    import mdfactory.orchestration.build as build_mod
-
-    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
-    monkeypatch.setattr(parsl, "load", MagicMock())
-
-    mock_model = FakeBuildInput(hash="NW1")
-    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
-    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
-
-    cfg = ExecutorConfig()
-    futures = build_mod.build_systems([mock_model], cfg, output_dir=tmp_path, wait=False)
-
-    assert futures == [mock_future]
-
-
 def test_build_systems_dry_run_invalid_input_type(tmp_path):
     """build_systems with dry_run=True raises TypeError for invalid input."""
     from mdfactory.orchestration.build import build_systems
@@ -394,35 +371,6 @@ def test_wait_with_progress_multi_iteration(monkeypatch):
     assert results[0]["status"] == "success"
     # done() should have been called at least twice (False then True)
     assert mock_future.done.call_count >= 2
-
-
-# --- Finding 10: Assert non-cleanup in no_wait ---
-
-
-def test_build_systems_no_wait_does_not_clear(monkeypatch, tmp_path):
-    """build_systems with wait=False does NOT call parsl.clear()."""
-    import parsl
-
-    mock_app_fn = MagicMock()
-    mock_future = MagicMock()
-    mock_app_fn.return_value = mock_future
-
-    import mdfactory.orchestration.build as build_mod
-
-    monkeypatch.setattr(build_mod, "get_build_app", lambda: mock_app_fn)
-    monkeypatch.setattr(parsl, "load", MagicMock())
-    mock_clear = MagicMock()
-    monkeypatch.setattr(parsl, "clear", mock_clear)
-
-    mock_model = FakeBuildInput(hash="NW2")
-    monkeypatch.setattr(build_mod, "BuildInput", FakeBuildInput)
-    monkeypatch.setattr(ExecutorConfig, "to_parsl_config", lambda self: MagicMock())
-
-    cfg = ExecutorConfig()
-    futures = build_mod.build_systems([mock_model], cfg, output_dir=tmp_path, wait=False)
-
-    assert futures == [mock_future]
-    mock_clear.assert_not_called()
 
 
 # --- Finding 10: failure description helper ---

--- a/mdfactory/tests/test_orchestration_session.py
+++ b/mdfactory/tests/test_orchestration_session.py
@@ -1,5 +1,5 @@
 # ABOUTME: Tests for the reusable Parsl session context manager
-# ABOUTME: Validates DFK guard, load, shutdown, and detach semantics
+# ABOUTME: Validates DFK guard, load, and shutdown semantics
 """Tests for orchestration Parsl session management."""
 
 from unittest.mock import MagicMock
@@ -32,21 +32,9 @@ def test_parsl_session_loads_and_shuts_down(monkeypatch):
 
     with parsl_session(ExecutorConfig()) as session:
         assert isinstance(session, ParslSession)
-        assert session.detached is False
 
     parsl.load.assert_called_once()
     parsl.clear.assert_called_once()
-
-
-def test_parsl_session_detach_skips_shutdown(monkeypatch):
-    """A detached session does not shut down the DFK on exit."""
-    _patch_parsl(monkeypatch)
-
-    with parsl_session(ExecutorConfig()) as session:
-        session.detach()
-
-    parsl.load.assert_called_once()
-    parsl.clear.assert_not_called()
 
 
 def test_parsl_session_guards_active_dfk(monkeypatch):


### PR DESCRIPTION
Closes #52

Remove unused `wait=False` path from `build_systems`, matching the cleanup done in PR 50 for `simulate.py`. Also removes `session.detach()` from `ParslSession` since no caller uses it after this change.

Implementation plan posted as a comment below.
